### PR TITLE
Preserve J2CL preview hydration anchors

### DIFF
--- a/docs/superpowers/plans/2026-05-01-issue-1167-inline-anchor-hydration-followup.md
+++ b/docs/superpowers/plans/2026-05-01-issue-1167-inline-anchor-hydration-followup.md
@@ -1,0 +1,94 @@
+# Issue #1167 Follow-Up: Inline Anchor And Preview Hydration Parity
+
+## Goal
+
+Close the next concrete J2CL/GWT threading parity gap after PR #1173:
+
+- The read-surface preview route must stay visible after JavaScript hydration.
+- The J2CL read pipeline must stop losing inline-reply anchor evidence before the renderer can place inline threads like GWT.
+
+This lane is a follow-up under #1167, not a replacement for the merged thread-chrome slice.
+
+## Current Findings
+
+- `HtmlRenderer.renderJ2clReadSurfacePreviewPage()` documents `/?view=j2cl-root&q=read-surface-preview` as a server-rendered fixture that needs no websocket activity to see the visual state.
+- The regular J2CL root controller still starts the live search/selected-wave controllers on that preview route, so the fixture can be replaced by an empty selected-wave state during client boot.
+- `J2clSelectedWaveView.shouldPreserveServerSnapshot()` already preserves real server-first selected-wave DOM while an empty/loading live model arrives, but preview mode is synthetic and should not enter the live sidecar route at all.
+- `SidecarConversationManifest` parses parent/thread structure and reply insert positions from the manifest, but it does not currently expose whether a thread is an inline thread.
+- `J2clReadBlipContent.parseRawSnapshot()` parses text, attachments, and task annotations from raw blip snapshots, but strips `<reply id="...">` anchors before the renderer can place an inline reply at the anchor position.
+- Existing shared local file-store samples previously had no raw `<reply id="...">` anchors, so production-data-safe inline placement needs a regression fixture before we claim full parity.
+
+## Scope
+
+### In Scope
+
+- Add a root-shell preview-mode guard so `data-j2cl-read-surface-preview="true"` enhances the static preview DOM without opening live sidecar search/selected-wave controllers.
+- Add tests proving preview mode is detected and does not route through live startup.
+- Extend the J2CL read-content parsing seam with inline-reply anchor metadata from raw snapshots.
+- Add regression tests that prove `<reply id="...">` anchors are retained as metadata while visible text remains unchanged.
+- Thread the anchor metadata far enough into the renderer/model to enable a follow-up placement change without another transport redesign.
+
+### Out Of Scope
+
+- Do not redesign the whole selected-wave transport.
+- Do not change GWT behavior.
+- Do not claim all #1167 acceptance is complete unless browser verification proves real inline blips render at their GWT anchor positions.
+- Do not use Claude Code review in this lane; self-review and PR review comments are the review gates.
+
+## Implementation Plan
+
+1. **Red tests: preview hydration guard**
+   - Add a focused `J2clRootShellControllerTest` case for preview-mode detection.
+   - Add a DOM-capable test when feasible that creates a synthetic preview host and verifies `start()` does not remove server-first preview content.
+
+2. **Green: preview startup path**
+   - Add `J2clRootShellController.isReadSurfacePreviewHost(...)`.
+   - At the start of `J2clRootShellController.start()`, if preview mode is active:
+     - construct `J2clRootShellView`;
+     - construct `J2clSearchPanelView` in root-shell mode to adopt the existing workflow;
+     - construct `J2clSelectedWaveView` so `enhanceExistingSurface()` wires existing blips and compact thread controls;
+     - publish a non-live preview status if possible;
+     - return before creating `J2clSearchGateway`, route controller, websocket-driven controllers, or compose/live startup.
+
+3. **Red tests: inline anchor metadata**
+   - Add `J2clReadBlipContentTest` coverage for a raw blip snapshot containing `<reply id="t+inline"></reply>` inside body text.
+   - Expected result:
+     - visible text does not include the raw reply id;
+     - parsed content exposes one anchor with `threadId=t+inline`;
+     - anchor offset is the visible-text offset at which the marker appeared.
+
+4. **Green: anchor parser seam**
+   - Add a small immutable inline-anchor value type under `j2cl/read`.
+   - Extend `J2clReadBlipContent` to expose `getInlineReplyAnchors()`.
+   - Keep existing visible-text, attachment, task, and deleted parsing behavior unchanged.
+
+5. **Thread anchor metadata toward rendering**
+   - Extend `J2clReadBlip` and `J2clReadWindowEntry` with immutable inline-anchor lists.
+   - Preserve equality/cache checks so a changed anchor list triggers repaint.
+   - Add renderer tests proving a blip created from parsed content carries anchor metadata into the rendered host as data attributes, without changing placement yet.
+
+6. **Self-review**
+   - Re-read the diff for scope creep, XSS safety, null/default handling, and compatibility with viewport-window rendering.
+   - Confirm no Maven commands are introduced.
+
+7. **Verification**
+   - Focused J2CL/Lit or J2CL Java tests relevant to touched files.
+   - Full SBT-only gate before PR:
+     - `python3 scripts/assemble-changelog.py`
+     - `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
+     - `git diff --check`
+     - `sbt --batch compile Test/compile j2clSearchTest j2clLitTest`
+   - Local browser sanity on `/?view=j2cl-root&q=read-surface-preview` proving the fixture still has rendered `wave-blip` elements after hydration.
+
+## Risks
+
+- If preview-mode startup skips too much, custom elements might still upgrade but Java-owned event bridges might not bind. The preview is explicitly documented as non-live, so the acceptable target is visual/hydrated fixture stability, not live search/write behavior.
+- Anchor metadata alone does not produce full GWT inline placement. It is the minimum safe data contract needed before moving thread DOM to exact body offsets.
+- If real selected-wave updates do not carry raw blip snapshots with `<reply>` anchors, true anchor placement remains blocked on a server payload extension.
+
+## Self-Review Notes
+
+- The plan keeps the next PR small enough to review: one preview hydration bug plus one anchor-data seam.
+- It does not overclaim #1167 completion.
+- It obeys the updated review instruction: no Claude Code review; rely on self-review and PR review comments.
+- It preserves SBT-only verification.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clInlineReplyAnchor.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clInlineReplyAnchor.java
@@ -1,0 +1,39 @@
+package org.waveprotocol.box.j2cl.read;
+
+import java.util.Objects;
+
+/** Inline reply anchor discovered in a blip body snapshot. */
+public final class J2clInlineReplyAnchor {
+  private final String threadId;
+  private final int textOffset;
+
+  public J2clInlineReplyAnchor(String threadId, int textOffset) {
+    this.threadId = threadId == null ? "" : threadId;
+    this.textOffset = Math.max(0, textOffset);
+  }
+
+  public String getThreadId() {
+    return threadId;
+  }
+
+  public int getTextOffset() {
+    return textOffset;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof J2clInlineReplyAnchor)) {
+      return false;
+    }
+    J2clInlineReplyAnchor that = (J2clInlineReplyAnchor) other;
+    return textOffset == that.textOffset && Objects.equals(threadId, that.threadId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(threadId, textOffset);
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlip.java
@@ -86,6 +86,7 @@ public final class J2clReadBlip {
    * and keep the task affordance mounted across full DOM rebuilds.
    */
   private final boolean isTask;
+  private final List<J2clInlineReplyAnchor> inlineReplyAnchors;
 
   public J2clReadBlip(String blipId, String text) {
     this(blipId, text, Collections.<J2clAttachmentRenderModel>emptyList());
@@ -240,6 +241,44 @@ public final class J2clReadBlip {
       long taskDueTimestamp,
       int bodyItemCount,
       boolean isTask) {
+    this(
+        blipId,
+        text,
+        attachments,
+        authorId,
+        authorDisplayName,
+        lastModifiedTimeMillis,
+        parentBlipId,
+        threadId,
+        unread,
+        hasMention,
+        deleted,
+        taskDone,
+        taskAssignee,
+        taskDueTimestamp,
+        bodyItemCount,
+        isTask,
+        Collections.<J2clInlineReplyAnchor>emptyList());
+  }
+
+  public J2clReadBlip(
+      String blipId,
+      String text,
+      List<J2clAttachmentRenderModel> attachments,
+      String authorId,
+      String authorDisplayName,
+      long lastModifiedTimeMillis,
+      String parentBlipId,
+      String threadId,
+      boolean unread,
+      boolean hasMention,
+      boolean deleted,
+      boolean taskDone,
+      String taskAssignee,
+      long taskDueTimestamp,
+      int bodyItemCount,
+      boolean isTask,
+      List<J2clInlineReplyAnchor> inlineReplyAnchors) {
     this.blipId = blipId == null ? "" : blipId;
     this.text = text == null ? "" : text;
     this.attachments =
@@ -259,6 +298,11 @@ public final class J2clReadBlip {
     this.taskDueTimestamp = taskDueTimestamp;
     this.bodyItemCount = Math.max(0, bodyItemCount);
     this.isTask = isTask;
+    this.inlineReplyAnchors =
+        inlineReplyAnchors == null
+            ? Collections.<J2clInlineReplyAnchor>emptyList()
+            : Collections.unmodifiableList(
+                new ArrayList<J2clInlineReplyAnchor>(inlineReplyAnchors));
   }
 
   /** Builder-style copy that flips the unread flag without re-typing the rest. */
@@ -282,7 +326,8 @@ public final class J2clReadBlip {
         taskAssignee,
         taskDueTimestamp,
         bodyItemCount,
-        isTask);
+        isTask,
+        inlineReplyAnchors);
   }
 
   /**
@@ -311,7 +356,8 @@ public final class J2clReadBlip {
         taskAssignee,
         taskDueTimestamp,
         bodyItemCount,
-        true);
+        true,
+        inlineReplyAnchors);
   }
 
   public String getBlipId() {
@@ -399,5 +445,9 @@ public final class J2clReadBlip {
 
   public int getBodyItemCount() {
     return bodyItemCount;
+  }
+
+  public List<J2clInlineReplyAnchor> getInlineReplyAnchors() {
+    return inlineReplyAnchors;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
@@ -24,6 +24,7 @@ public final class J2clReadBlipContent {
   private final String taskAssignee;
   private final long taskDueTimestamp;
   private final boolean deleted;
+  private final List<J2clInlineReplyAnchor> inlineReplyAnchors;
 
   private J2clReadBlipContent(
       String text,
@@ -32,7 +33,8 @@ public final class J2clReadBlipContent {
       boolean taskDone,
       String taskAssignee,
       long taskDueTimestamp,
-      boolean deleted) {
+      boolean deleted,
+      List<J2clInlineReplyAnchor> inlineReplyAnchors) {
     this.text = text == null ? "" : text;
     this.attachments =
         attachments == null
@@ -43,6 +45,11 @@ public final class J2clReadBlipContent {
     this.taskAssignee = taskAssignee == null ? "" : taskAssignee;
     this.taskDueTimestamp = taskDueTimestamp;
     this.deleted = deleted;
+    this.inlineReplyAnchors =
+        inlineReplyAnchors == null
+            ? Collections.<J2clInlineReplyAnchor>emptyList()
+            : Collections.unmodifiableList(
+                new ArrayList<J2clInlineReplyAnchor>(inlineReplyAnchors));
   }
 
   public static J2clReadBlipContent parseRawSnapshot(String rawSnapshot) {
@@ -89,14 +96,16 @@ public final class J2clReadBlipContent {
         cursor = imageClose + IMAGE_CLOSE_TAG.length();
       }
     }
+    StripResult stripped = stripTagsWithInlineReplyAnchors(visibleText.toString());
     return new J2clReadBlipContent(
-        decodeEntities(stripTags(visibleText.toString())),
+        decodeEntities(stripped.text),
         attachments,
         annotations.hasTask,
         annotations.taskDone,
         annotations.taskAssignee,
         annotations.taskDueTimestamp,
-        annotations.deleted);
+        annotations.deleted,
+        stripped.inlineReplyAnchors);
   }
 
   public String getText() {
@@ -127,9 +136,19 @@ public final class J2clReadBlipContent {
     return deleted;
   }
 
+  public List<J2clInlineReplyAnchor> getInlineReplyAnchors() {
+    return inlineReplyAnchors;
+  }
+
   private static String attributeValue(String tag, String name) {
     // Start after the tag name; indexOf(' ') would miss tabs or newlines as the first separator.
-    int cursor = "<image".length();
+    int cursor = 1;
+    while (cursor < tag.length()
+        && tag.charAt(cursor) != '>'
+        && tag.charAt(cursor) != '/'
+        && !Character.isWhitespace(tag.charAt(cursor))) {
+      cursor++;
+    }
     if (cursor >= tag.length()) {
       return "";
     }
@@ -205,9 +224,14 @@ public final class J2clReadBlipContent {
   }
 
   private static String stripTags(String value) {
+    return stripTagsWithInlineReplyAnchors(value).text;
+  }
+
+  private static StripResult stripTagsWithInlineReplyAnchors(String value) {
     // This is intentionally not an XML parser; it handles the narrow debug-XML snapshots emitted
     // for selected-wave text and leaves malformed tags as best-effort visible text.
     StringBuilder stripped = new StringBuilder(value.length());
+    List<J2clInlineReplyAnchor> inlineReplyAnchors = new ArrayList<J2clInlineReplyAnchor>();
     StringBuilder tagBuf = new StringBuilder();
     boolean insideTag = false;
     for (int i = 0; i < value.length(); i++) {
@@ -218,8 +242,16 @@ public final class J2clReadBlipContent {
       } else if (c == '>' && insideTag) {
         insideTag = false;
         // <line/> and <line> are DocOp structural separators: Hello<line/>World -> Hello\nWorld.
-        if (isLineTag(tagBuf.toString())) {
+        String tagContent = tagBuf.toString();
+        if (isLineTag(tagContent)) {
           appendLineSeparator(stripped);
+        } else if (isInlineReplyAnchorTag(tagContent)) {
+          String threadId = attributeValue("<" + tagContent + ">", "id");
+          if (!threadId.isEmpty()) {
+            inlineReplyAnchors.add(
+                new J2clInlineReplyAnchor(
+                    decodeEntities(threadId), decodedVisibleLength(stripped)));
+          }
         }
         tagBuf.setLength(0);
       } else if (insideTag) {
@@ -228,7 +260,7 @@ public final class J2clReadBlipContent {
         stripped.append(c);
       }
     }
-    return stripped.toString();
+    return new StripResult(stripped.toString(), inlineReplyAnchors);
   }
 
   private static boolean isLineTag(String tagContent) {
@@ -238,6 +270,31 @@ public final class J2clReadBlipContent {
         && (normalized.length() == 4
             || normalized.charAt(4) == '/'
             || Character.isWhitespace(normalized.charAt(4)));
+  }
+
+  private static boolean isInlineReplyAnchorTag(String tagContent) {
+    String normalized = tagContent.trim().toLowerCase(Locale.ROOT);
+    return normalized.startsWith("reply")
+        && (normalized.length() == 5
+            || normalized.charAt(5) == '/'
+            || Character.isWhitespace(normalized.charAt(5)));
+  }
+
+  private static int decodedVisibleLength(StringBuilder stripped) {
+    return decodeEntities(stripped.toString()).length();
+  }
+
+  private static final class StripResult {
+    private final String text;
+    private final List<J2clInlineReplyAnchor> inlineReplyAnchors;
+
+    private StripResult(String text, List<J2clInlineReplyAnchor> inlineReplyAnchors) {
+      this.text = text == null ? "" : text;
+      this.inlineReplyAnchors =
+          inlineReplyAnchors == null
+              ? Collections.<J2clInlineReplyAnchor>emptyList()
+              : inlineReplyAnchors;
+    }
   }
 
   private static void appendLineSeparator(StringBuilder stripped) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
@@ -234,9 +234,15 @@ public final class J2clReadBlipContent {
     List<J2clInlineReplyAnchor> inlineReplyAnchors = new ArrayList<J2clInlineReplyAnchor>();
     StringBuilder tagBuf = new StringBuilder();
     boolean insideTag = false;
+    // Track entity boundaries to compute decoded length without re-scanning stripped each time.
+    // entityStart is the index in stripped where the current '&' was appended, or -1.
+    int entityStart = -1;
+    // Extra raw chars contributed by entities (each &xxx; has raw_len-1 overcount vs 1 decoded).
+    int entityOvercount = 0;
     for (int i = 0; i < value.length(); i++) {
       char c = value.charAt(i);
       if (c == '<') {
+        entityStart = -1;
         insideTag = true;
         tagBuf.setLength(0);
       } else if (c == '>' && insideTag) {
@@ -250,7 +256,7 @@ public final class J2clReadBlipContent {
           if (!threadId.isEmpty()) {
             inlineReplyAnchors.add(
                 new J2clInlineReplyAnchor(
-                    decodeEntities(threadId), decodedVisibleLength(stripped)));
+                    decodeEntities(threadId), stripped.length() - entityOvercount));
           }
         }
         tagBuf.setLength(0);
@@ -258,6 +264,13 @@ public final class J2clReadBlipContent {
         tagBuf.append(c);
       } else {
         stripped.append(c);
+        if (c == '&') {
+          entityStart = stripped.length() - 1;
+        } else if (c == ';' && entityStart >= 0) {
+          // Completed entity: raw length is (current_pos - entityStart), decoded length is 1.
+          entityOvercount += stripped.length() - 1 - entityStart;
+          entityStart = -1;
+        }
       }
     }
     return new StripResult(stripped.toString(), inlineReplyAnchors);
@@ -278,10 +291,6 @@ public final class J2clReadBlipContent {
         && (normalized.length() == 5
             || normalized.charAt(5) == '/'
             || Character.isWhitespace(normalized.charAt(5)));
-  }
-
-  private static int decodedVisibleLength(StringBuilder stripped) {
-    return decodeEntities(stripped.toString()).length();
   }
 
   private static final class StripResult {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
@@ -234,15 +234,10 @@ public final class J2clReadBlipContent {
     List<J2clInlineReplyAnchor> inlineReplyAnchors = new ArrayList<J2clInlineReplyAnchor>();
     StringBuilder tagBuf = new StringBuilder();
     boolean insideTag = false;
-    // Track entity boundaries to compute decoded length without re-scanning stripped each time.
-    // entityStart is the index in stripped where the current '&' was appended, or -1.
-    int entityStart = -1;
-    // Extra raw chars contributed by entities (each &xxx; has raw_len-1 overcount vs 1 decoded).
-    int entityOvercount = 0;
+    int decodedVisibleLength = 0;
     for (int i = 0; i < value.length(); i++) {
       char c = value.charAt(i);
-      if (c == '<') {
-        entityStart = -1;
+      if (c == '<' && !insideTag) {
         insideTag = true;
         tagBuf.setLength(0);
       } else if (c == '>' && insideTag) {
@@ -251,26 +246,32 @@ public final class J2clReadBlipContent {
         String tagContent = tagBuf.toString();
         if (isLineTag(tagContent)) {
           appendLineSeparator(stripped);
+          decodedVisibleLength = decodeEntities(stripped.toString()).length();
         } else if (isInlineReplyAnchorTag(tagContent)) {
           String threadId = attributeValue("<" + tagContent + ">", "id");
           if (!threadId.isEmpty()) {
             inlineReplyAnchors.add(
                 new J2clInlineReplyAnchor(
-                    decodeEntities(threadId), stripped.length() - entityOvercount));
+                    decodeEntities(threadId), decodedVisibleLength));
           }
         }
         tagBuf.setLength(0);
       } else if (insideTag) {
         tagBuf.append(c);
+      } else if (c == '&') {
+        String decodedEntity = decodedEntityAt(value, i);
+        if (!decodedEntity.isEmpty()) {
+          int entityEnd = value.indexOf(';', i);
+          stripped.append(value, i, entityEnd + 1);
+          decodedVisibleLength += decodedEntity.length();
+          i = entityEnd;
+        } else {
+          stripped.append(c);
+          decodedVisibleLength++;
+        }
       } else {
         stripped.append(c);
-        if (c == '&') {
-          entityStart = stripped.length() - 1;
-        } else if (c == ';' && entityStart >= 0) {
-          // Completed entity: raw length is (current_pos - entityStart), decoded length is 1.
-          entityOvercount += stripped.length() - 1 - entityStart;
-          entityStart = -1;
-        }
+        decodedVisibleLength++;
       }
     }
     return new StripResult(stripped.toString(), inlineReplyAnchors);
@@ -291,6 +292,30 @@ public final class J2clReadBlipContent {
         && (normalized.length() == 5
             || normalized.charAt(5) == '/'
             || Character.isWhitespace(normalized.charAt(5)));
+  }
+
+  private static String decodedEntityAt(String value, int ampersandIndex) {
+    int entityEnd = value.indexOf(';', ampersandIndex);
+    if (entityEnd < 0) {
+      return "";
+    }
+    String entity = value.substring(ampersandIndex, entityEnd + 1);
+    if ("&quot;".equals(entity)) {
+      return "\"";
+    }
+    if ("&apos;".equals(entity)) {
+      return "'";
+    }
+    if ("&lt;".equals(entity)) {
+      return "<";
+    }
+    if ("&gt;".equals(entity)) {
+      return ">";
+    }
+    if ("&amp;".equals(entity)) {
+      return "&";
+    }
+    return "";
   }
 
   private static final class StripResult {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
@@ -245,8 +245,7 @@ public final class J2clReadBlipContent {
         // <line/> and <line> are DocOp structural separators: Hello<line/>World -> Hello\nWorld.
         String tagContent = tagBuf.toString();
         if (isLineTag(tagContent)) {
-          appendLineSeparator(stripped);
-          decodedVisibleLength = decodeEntities(stripped.toString()).length();
+          decodedVisibleLength = appendLineSeparator(stripped, decodedVisibleLength);
         } else if (isInlineReplyAnchorTag(tagContent)) {
           String threadId = attributeValue("<" + tagContent + ">", "id");
           if (!threadId.isEmpty()) {
@@ -331,16 +330,19 @@ public final class J2clReadBlipContent {
     }
   }
 
-  private static void appendLineSeparator(StringBuilder stripped) {
+  private static int appendLineSeparator(StringBuilder stripped, int decodedVisibleLength) {
     // Normalize horizontal whitespace at paragraph boundaries before emitting one line break.
     while (stripped.length() > 0
         && Character.isWhitespace(stripped.charAt(stripped.length() - 1))
         && stripped.charAt(stripped.length() - 1) != '\n') {
       stripped.deleteCharAt(stripped.length() - 1);
+      decodedVisibleLength = Math.max(0, decodedVisibleLength - 1);
     }
     if (stripped.length() > 0 && stripped.charAt(stripped.length() - 1) != '\n') {
       stripped.append('\n');
+      decodedVisibleLength++;
     }
+    return decodedVisibleLength;
   }
 
   private static AnnotationSnapshot parseAnnotationSnapshot(String raw) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1138,8 +1138,8 @@ public final class J2clReadSurfaceDomRenderer {
       element.removeAttribute("data-inline-reply-anchors");
       return;
     }
-    element.setAttribute("data-inline-reply-anchor-count", String.valueOf(anchors.size()));
     StringBuilder serialized = new StringBuilder();
+    int validAnchorCount = 0;
     for (J2clInlineReplyAnchor anchor : anchors) {
       if (anchor == null || anchor.getThreadId().isEmpty()) {
         continue;
@@ -1148,10 +1148,13 @@ public final class J2clReadSurfaceDomRenderer {
         serialized.append(",");
       }
       serialized.append(anchor.getThreadId()).append("@").append(anchor.getTextOffset());
+      validAnchorCount++;
     }
-    if (serialized.length() > 0) {
+    if (validAnchorCount > 0) {
+      element.setAttribute("data-inline-reply-anchor-count", String.valueOf(validAnchorCount));
       element.setAttribute("data-inline-reply-anchors", serialized.toString());
     } else {
+      element.removeAttribute("data-inline-reply-anchor-count");
       element.removeAttribute("data-inline-reply-anchors");
     }
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -666,7 +666,9 @@ public final class J2clReadSurfaceDomRenderer {
               /* taskDone= */ entry.isTaskDone(),
               /* taskAssignee= */ entry.getTaskAssignee(),
               /* taskDueTimestamp= */ entry.getTaskDueTimestamp(),
-              /* bodyItemCount= */ entry.getBodyItemCount());
+              /* bodyItemCount= */ entry.getBodyItemCount(),
+              /* isTask= */ entry.isTask(),
+              entry.getInlineReplyAnchors());
       HTMLElement blipElement = renderBlip(blip, blipIndex++);
       // V-4 (#1102): mark blip depth so the larger root avatar paints
       // and the timestamp picks up the ` · root` suffix. Check parent
@@ -1086,6 +1088,7 @@ public final class J2clReadSurfaceDomRenderer {
         blip.getTaskDueTimestamp(),
         blip.getBodyItemCount(),
         blip.isTask());
+    applyInlineReplyAnchorState(element, blip.getInlineReplyAnchors());
 
     // The renderer doesn't know the parent wave id (it lives one layer up
     // in J2clSelectedWaveView). The view sets `data-wave-id` on the host
@@ -1126,6 +1129,31 @@ public final class J2clReadSurfaceDomRenderer {
     setProperty(reactionRow, "reactions", buildReactionsArray(blip.getBlipId()));
     element.appendChild(reactionRow);
     return element;
+  }
+
+  private static void applyInlineReplyAnchorState(
+      HTMLElement element, List<J2clInlineReplyAnchor> anchors) {
+    if (anchors == null || anchors.isEmpty()) {
+      element.removeAttribute("data-inline-reply-anchor-count");
+      element.removeAttribute("data-inline-reply-anchors");
+      return;
+    }
+    element.setAttribute("data-inline-reply-anchor-count", String.valueOf(anchors.size()));
+    StringBuilder serialized = new StringBuilder();
+    for (J2clInlineReplyAnchor anchor : anchors) {
+      if (anchor == null || anchor.getThreadId().isEmpty()) {
+        continue;
+      }
+      if (serialized.length() > 0) {
+        serialized.append(",");
+      }
+      serialized.append(anchor.getThreadId()).append("@").append(anchor.getTextOffset());
+    }
+    if (serialized.length() > 0) {
+      element.setAttribute("data-inline-reply-anchors", serialized.toString());
+    } else {
+      element.removeAttribute("data-inline-reply-anchors");
+    }
   }
 
   private static void setProperty(HTMLElement element, String name, Object value) {
@@ -2526,7 +2554,8 @@ public final class J2clReadSurfaceDomRenderer {
         && left.isTaskDone() == right.isTaskDone()
         && left.getTaskAssignee().equals(right.getTaskAssignee())
         && left.getTaskDueTimestamp() == right.getTaskDueTimestamp()
-        && left.getBodyItemCount() == right.getBodyItemCount();
+        && left.getBodyItemCount() == right.getBodyItemCount()
+        && left.getInlineReplyAnchors().equals(right.getInlineReplyAnchors());
   }
 
   private boolean matchesRenderedWindowEntries(List<J2clReadWindowEntry> entries) {
@@ -2604,7 +2633,8 @@ public final class J2clReadSurfaceDomRenderer {
         && left.isTaskDone() == right.isTaskDone()
         && left.getTaskAssignee().equals(right.getTaskAssignee())
         && left.getTaskDueTimestamp() == right.getTaskDueTimestamp()
-        && left.getBodyItemCount() == right.getBodyItemCount();
+        && left.getBodyItemCount() == right.getBodyItemCount()
+        && left.getInlineReplyAnchors().equals(right.getInlineReplyAnchors());
   }
 
   private HTMLElement renderedBlipById(String blipId) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadWindowEntry.java
@@ -40,6 +40,8 @@ public final class J2clReadWindowEntry {
   private final int bodyItemCount;
   /** See {@link J2clReadBlip#isTask()}: true when a task/done annotation is present. */
   private final boolean isTask;
+  /** Issue #1167: inline reply anchors parsed from raw Wave document markup. */
+  private final List<J2clInlineReplyAnchor> inlineReplyAnchors;
 
   private J2clReadWindowEntry(
       String segment,
@@ -89,6 +91,50 @@ public final class J2clReadWindowEntry {
       long taskDueTimestamp,
       int bodyItemCount,
       boolean isTask) {
+    this(
+        segment,
+        fromVersion,
+        toVersion,
+        blipId,
+        text,
+        attachments,
+        loaded,
+        authorId,
+        authorDisplayName,
+        lastModifiedTimeMillis,
+        parentBlipId,
+        threadId,
+        unread,
+        hasMention,
+        taskDone,
+        taskAssignee,
+        taskDueTimestamp,
+        bodyItemCount,
+        isTask,
+        Collections.<J2clInlineReplyAnchor>emptyList());
+  }
+
+  private J2clReadWindowEntry(
+      String segment,
+      long fromVersion,
+      long toVersion,
+      String blipId,
+      String text,
+      List<J2clAttachmentRenderModel> attachments,
+      boolean loaded,
+      String authorId,
+      String authorDisplayName,
+      long lastModifiedTimeMillis,
+      String parentBlipId,
+      String threadId,
+      boolean unread,
+      boolean hasMention,
+      boolean taskDone,
+      String taskAssignee,
+      long taskDueTimestamp,
+      int bodyItemCount,
+      boolean isTask,
+      List<J2clInlineReplyAnchor> inlineReplyAnchors) {
     this.segment = segment == null ? "" : segment;
     this.fromVersion = fromVersion;
     this.toVersion = toVersion;
@@ -111,6 +157,11 @@ public final class J2clReadWindowEntry {
     this.taskDueTimestamp = taskDueTimestamp;
     this.bodyItemCount = Math.max(0, bodyItemCount);
     this.isTask = isTask;
+    this.inlineReplyAnchors =
+        inlineReplyAnchors == null
+            ? Collections.<J2clInlineReplyAnchor>emptyList()
+            : Collections.unmodifiableList(
+                new ArrayList<J2clInlineReplyAnchor>(inlineReplyAnchors));
   }
 
   public static J2clReadWindowEntry loaded(
@@ -280,6 +331,48 @@ public final class J2clReadWindowEntry {
       long taskDueTimestamp,
       int bodyItemCount,
       boolean isTask) {
+    return loadedWithTaskMetadata(
+        segment,
+        fromVersion,
+        toVersion,
+        blipId,
+        text,
+        attachments,
+        authorId,
+        authorDisplayName,
+        lastModifiedTimeMillis,
+        parentBlipId,
+        threadId,
+        unread,
+        hasMention,
+        taskDone,
+        taskAssignee,
+        taskDueTimestamp,
+        bodyItemCount,
+        isTask,
+        Collections.<J2clInlineReplyAnchor>emptyList());
+  }
+
+  public static J2clReadWindowEntry loadedWithTaskMetadata(
+      String segment,
+      long fromVersion,
+      long toVersion,
+      String blipId,
+      String text,
+      List<J2clAttachmentRenderModel> attachments,
+      String authorId,
+      String authorDisplayName,
+      long lastModifiedTimeMillis,
+      String parentBlipId,
+      String threadId,
+      boolean unread,
+      boolean hasMention,
+      boolean taskDone,
+      String taskAssignee,
+      long taskDueTimestamp,
+      int bodyItemCount,
+      boolean isTask,
+      List<J2clInlineReplyAnchor> inlineReplyAnchors) {
     return new J2clReadWindowEntry(
         segment,
         fromVersion,
@@ -299,7 +392,8 @@ public final class J2clReadWindowEntry {
         taskAssignee,
         taskDueTimestamp,
         bodyItemCount,
-        isTask);
+        isTask,
+        inlineReplyAnchors);
   }
 
   public static J2clReadWindowEntry placeholder(
@@ -349,7 +443,8 @@ public final class J2clReadWindowEntry {
         taskAssignee,
         taskDueTimestamp,
         bodyItemCount,
-        isTask);
+        isTask,
+        inlineReplyAnchors);
   }
 
   /**
@@ -379,7 +474,8 @@ public final class J2clReadWindowEntry {
         taskAssignee,
         taskDueTimestamp,
         bodyItemCount,
-        true);
+        true,
+        inlineReplyAnchors);
   }
 
   public String getSegment() {
@@ -461,5 +557,9 @@ public final class J2clReadWindowEntry {
 
   public int getBodyItemCount() {
     return bodyItemCount;
+  }
+
+  public List<J2clInlineReplyAnchor> getInlineReplyAnchors() {
+    return inlineReplyAnchors;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -38,6 +38,10 @@ public final class J2clRootShellController {
       return;
     }
     started = true;
+    if (isReadSurfacePreviewHost(host)) {
+      startReadSurfacePreviewMode();
+      return;
+    }
     J2clRootShellView shellView = new J2clRootShellView(host);
     J2clSearchGateway gateway = new J2clSearchGateway();
     J2clClientTelemetry.Sink telemetrySink = J2clClientTelemetry.browserStatsSink();
@@ -241,6 +245,28 @@ public final class J2clRootShellController {
   static J2clToolbarSurfaceController.EditState editStateForWriteSession(
       J2clSidecarWriteSession writeSession) {
     return new J2clToolbarSurfaceController.EditState(writeSession != null);
+  }
+
+  static boolean isReadSurfacePreviewHost(boolean hostMarked, boolean bodyMarked) {
+    return hostMarked || bodyMarked;
+  }
+
+  private boolean isReadSurfacePreviewHost(HTMLElement candidate) {
+    boolean hostMarked =
+        candidate != null
+            && "true".equals(candidate.getAttribute("data-j2cl-read-surface-preview"));
+    HTMLElement body = (HTMLElement) elemental2.dom.DomGlobal.document.body;
+    boolean bodyMarked =
+        body != null && "true".equals(body.getAttribute("data-j2cl-read-surface-preview"));
+    return isReadSurfacePreviewHost(hostMarked, bodyMarked);
+  }
+
+  private void startReadSurfacePreviewMode() {
+    J2clRootShellView shellView = new J2clRootShellView(host);
+    J2clSearchPanelView searchView =
+        new J2clSearchPanelView(
+            shellView.getWorkflowHost(), J2clSearchPanelView.ShellPresentation.ROOT_SHELL);
+    new J2clSelectedWaveView(searchView.getSelectedWaveHost(), J2clClientTelemetry.browserStatsSink());
   }
 
   static List<String> participantsFromEvent(Event event) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -1116,7 +1116,9 @@ public final class J2clSelectedWaveController
         existing.isTaskDone(),
         existing.getTaskAssignee(),
         existing.getTaskDueTimestamp(),
-        existing.getBodyItemCount());
+        existing.getBodyItemCount(),
+        existing.isTask(),
+        existing.getInlineReplyAnchors());
   }
 
   private static String nullToEmpty(String value) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -624,7 +624,8 @@ public final class J2clSelectedWaveProjector {
               /* taskAssignee= */ documentTaskAssignee(doc),
               /* taskDueTimestamp= */ documentTaskDueTimestamp(doc),
               /* bodyItemCount= */ doc.getBodyItemCount(),
-              /* isTask= */ documentHasTask(doc)));
+              /* isTask= */ documentHasTask(doc),
+              blip.getInlineReplyAnchors()));
     }
     return enriched;
   }
@@ -679,7 +680,8 @@ public final class J2clSelectedWaveProjector {
                 blip.getTaskAssignee(),
                 blip.getTaskDueTimestamp(),
                 blip.getBodyItemCount(),
-                blip.isTask()));
+                blip.isTask(),
+                blip.getInlineReplyAnchors()));
       } else {
         patched.add(blip);
       }
@@ -818,7 +820,8 @@ public final class J2clSelectedWaveProjector {
         taskAssignee,
         taskDueTimestamp,
         blip.getBodyItemCount(),
-        isTask);
+        isTask,
+        blip.getInlineReplyAnchors());
   }
 
   /**
@@ -908,7 +911,8 @@ public final class J2clSelectedWaveProjector {
               existing.getTaskAssignee(),
               existing.getTaskDueTimestamp(),
               existing.getBodyItemCount(),
-              existing.isTask()));
+              existing.isTask(),
+              existing.getInlineReplyAnchors()));
     }
     // Append any blip that the manifest didn't reference so we don't
     // silently drop content from non-conversational data documents.
@@ -989,7 +993,8 @@ public final class J2clSelectedWaveProjector {
               blip.getTaskAssignee(),
               blip.getTaskDueTimestamp(),
               blip.getBodyItemCount(),
-              blip.isTask());
+              blip.isTask(),
+              blip.getInlineReplyAnchors());
       enriched.add(next);
       changed = true;
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -400,7 +400,8 @@ public final class J2clSelectedWaveViewportState {
                 /* taskAssignee= */ content.getTaskAssignee(),
                 /* taskDueTimestamp= */ content.getTaskDueTimestamp(),
                 entry.getBodyItemCount(),
-                /* isTask= */ content.isTask()));
+                /* isTask= */ content.isTask(),
+                content.getInlineReplyAnchors()));
       } else {
         readBlips.add(
             new J2clReadBlip(
@@ -452,7 +453,8 @@ public final class J2clSelectedWaveViewportState {
                   /* taskAssignee= */ content.getTaskAssignee(),
                   /* taskDueTimestamp= */ content.getTaskDueTimestamp(),
                   entry.getBodyItemCount(),
-                  /* isTask= */ content.isTask()));
+                  /* isTask= */ content.isTask(),
+                  content.getInlineReplyAnchors()));
         } else {
           windowEntries.add(
               J2clReadWindowEntry.loadedWithTaskMetadata(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadata;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
 import org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel;
+import org.waveprotocol.box.j2cl.read.J2clInlineReplyAnchor;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 import org.waveprotocol.box.j2cl.read.J2clReadBlipContent;
 import org.waveprotocol.box.j2cl.read.J2clReadWindowEntry;
@@ -170,7 +171,8 @@ public final class J2clSelectedWaveViewportState {
                   existing.getBodyItemCount(),
                   existing.shouldParseAttachmentElements(),
                   existing.attachmentOverrides,
-                  existing.parsedContent));
+                  existing.parsedContent,
+                  existing.getInlineReplyAnchors()));
         } else {
           merged.set(existingIndex, fragmentEntry.withCachedParsedContentFrom(existing));
         }
@@ -253,37 +255,20 @@ public final class J2clSelectedWaveViewportState {
         // window backward just because a document has an older modified version.
         long mergedFromVersion =
             knownOrFallback(existing.getFromVersion(), documentEntry.getFromVersion());
-        // Preserve fragment-parsed content (inline reply anchors) across document refreshes.
-        // Fragment entries carry DocOp debug-XML snapshots that contain <reply> anchor tags;
-        // document entries carry plain text and cannot re-derive those anchors. By keeping
-        // parseAttachmentElements=true and the pre-computed parsedContent, the merged entry
-        // continues to emit inline-reply-anchor state until the next fragment refresh.
-        Entry next;
-        if (existing.shouldParseAttachmentElements()) {
-          next =
-              Entry.loaded(
-                  existing.getSegment(),
-                  mergedFromVersion,
-                  mergedToVersion,
-                  documentEntry.getRawSnapshot(),
-                  existing.getAdjustOperationCount(),
-                  existing.getDiffOperationCount(),
-                  documentEntry.getBodyItemCount(),
-                  /* parseAttachmentElements= */ true,
-                  existing.getAttachmentOverrides(),
-                  existing.getParsedContent());
-        } else {
-          next =
-              Entry.loaded(
-                  existing.getSegment(),
-                  mergedFromVersion,
-                  mergedToVersion,
-                  documentEntry.getRawSnapshot(),
-                  existing.getAdjustOperationCount(),
-                  existing.getDiffOperationCount(),
-                  documentEntry.getBodyItemCount());
-        }
-        merged.set(existingIndex, next);
+        merged.set(
+            existingIndex,
+            Entry.loaded(
+                existing.getSegment(),
+                mergedFromVersion,
+                mergedToVersion,
+                documentEntry.getRawSnapshot(),
+                existing.getAdjustOperationCount(),
+                existing.getDiffOperationCount(),
+                documentEntry.getBodyItemCount(),
+                /* parseAttachmentElements= */ false,
+                Collections.<J2clAttachmentRenderModel>emptyList(),
+                null,
+                existing.getInlineReplyAnchors()));
       } else {
         merged.add(documentEntry);
       }
@@ -440,7 +425,9 @@ public final class J2clSelectedWaveViewportState {
                 /* taskDone= */ false,
                 /* taskAssignee= */ "",
                 /* taskDueTimestamp= */ J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP,
-                entry.getBodyItemCount()));
+                entry.getBodyItemCount(),
+                /* isTask= */ false,
+                entry.getInlineReplyAnchors()));
       }
     }
     return readBlips;
@@ -495,7 +482,9 @@ public final class J2clSelectedWaveViewportState {
                   /* taskDone= */ false,
                   /* taskAssignee= */ "",
                   /* taskDueTimestamp= */ J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP,
-                  entry.getBodyItemCount()));
+                  entry.getBodyItemCount(),
+                  /* isTask= */ false,
+                  entry.getInlineReplyAnchors()));
         }
       } else {
         windowEntries.add(
@@ -600,6 +589,7 @@ public final class J2clSelectedWaveViewportState {
     private final boolean loaded;
     private final boolean parseAttachmentElements;
     private final List<J2clAttachmentRenderModel> attachmentOverrides;
+    private final List<J2clInlineReplyAnchor> inlineReplyAnchors;
     // Cache only: never include this mutable field in equality/hash semantics if Entry later gains
     // value-style comparison. A loaded fragment can be projected into content, read blips, and
     // attachment metadata overrides during the same viewport lifetime.
@@ -616,7 +606,8 @@ public final class J2clSelectedWaveViewportState {
         boolean loaded,
         boolean parseAttachmentElements,
         List<J2clAttachmentRenderModel> attachmentOverrides,
-        J2clReadBlipContent parsedContent) {
+        J2clReadBlipContent parsedContent,
+        List<J2clInlineReplyAnchor> inlineReplyAnchors) {
       this.segment = segment == null ? "" : segment;
       this.fromVersion = fromVersion;
       this.toVersion = toVersion;
@@ -631,6 +622,11 @@ public final class J2clSelectedWaveViewportState {
               ? Collections.<J2clAttachmentRenderModel>emptyList()
               : Collections.unmodifiableList(
                   new ArrayList<J2clAttachmentRenderModel>(attachmentOverrides));
+      this.inlineReplyAnchors =
+          inlineReplyAnchors == null
+              ? Collections.<J2clInlineReplyAnchor>emptyList()
+              : Collections.unmodifiableList(
+                  new ArrayList<J2clInlineReplyAnchor>(inlineReplyAnchors));
       this.parsedContent = parsedContent;
     }
 
@@ -650,6 +646,7 @@ public final class J2clSelectedWaveViewportState {
           true,
           true,
           Collections.<J2clAttachmentRenderModel>emptyList(),
+          null,
           null);
     }
 
@@ -668,6 +665,7 @@ public final class J2clSelectedWaveViewportState {
           true,
           true,
           Collections.<J2clAttachmentRenderModel>emptyList(),
+          null,
           null);
     }
 
@@ -836,6 +834,34 @@ public final class J2clSelectedWaveViewportState {
         boolean parseAttachmentElements,
         List<J2clAttachmentRenderModel> attachmentOverrides,
         J2clReadBlipContent parsedContent) {
+      return loaded(
+          segment,
+          fromVersion,
+          toVersion,
+          rawSnapshot,
+          adjustOperationCount,
+          diffOperationCount,
+          bodyItemCount,
+          parseAttachmentElements,
+          attachmentOverrides,
+          parsedContent,
+          parsedContent == null
+              ? Collections.<J2clInlineReplyAnchor>emptyList()
+              : parsedContent.getInlineReplyAnchors());
+    }
+
+    static Entry loaded(
+        String segment,
+        long fromVersion,
+        long toVersion,
+        String rawSnapshot,
+        int adjustOperationCount,
+        int diffOperationCount,
+        int bodyItemCount,
+        boolean parseAttachmentElements,
+        List<J2clAttachmentRenderModel> attachmentOverrides,
+        J2clReadBlipContent parsedContent,
+        List<J2clInlineReplyAnchor> inlineReplyAnchors) {
       return new Entry(
           segment,
           fromVersion,
@@ -847,7 +873,10 @@ public final class J2clSelectedWaveViewportState {
           true,
           parseAttachmentElements,
           attachmentOverrides,
-          parsedContent);
+          parsedContent,
+          parsedContent == null
+              ? inlineReplyAnchors
+              : parsedContent.getInlineReplyAnchors());
     }
 
     static Entry placeholder(String segment, long fromVersion, long toVersion) {
@@ -862,6 +891,7 @@ public final class J2clSelectedWaveViewportState {
           false,
           false,
           Collections.<J2clAttachmentRenderModel>emptyList(),
+          null,
           null);
     }
 
@@ -1000,6 +1030,13 @@ public final class J2clSelectedWaveViewportState {
 
     List<J2clAttachmentRenderModel> getAttachmentOverrides() {
       return attachmentOverrides;
+    }
+
+    List<J2clInlineReplyAnchor> getInlineReplyAnchors() {
+      if (loaded && parseAttachmentElements) {
+        return getParsedContent().getInlineReplyAnchors();
+      }
+      return inlineReplyAnchors;
     }
 
     J2clReadBlipContent getParsedContent() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -253,16 +253,37 @@ public final class J2clSelectedWaveViewportState {
         // window backward just because a document has an older modified version.
         long mergedFromVersion =
             knownOrFallback(existing.getFromVersion(), documentEntry.getFromVersion());
-        merged.set(
-            existingIndex,
-            Entry.loaded(
-                existing.getSegment(),
-                mergedFromVersion,
-                mergedToVersion,
-                documentEntry.getRawSnapshot(),
-                existing.getAdjustOperationCount(),
-                existing.getDiffOperationCount(),
-                documentEntry.getBodyItemCount()));
+        // Preserve fragment-parsed content (inline reply anchors) across document refreshes.
+        // Fragment entries carry DocOp debug-XML snapshots that contain <reply> anchor tags;
+        // document entries carry plain text and cannot re-derive those anchors. By keeping
+        // parseAttachmentElements=true and the pre-computed parsedContent, the merged entry
+        // continues to emit inline-reply-anchor state until the next fragment refresh.
+        Entry next;
+        if (existing.shouldParseAttachmentElements()) {
+          next =
+              Entry.loaded(
+                  existing.getSegment(),
+                  mergedFromVersion,
+                  mergedToVersion,
+                  documentEntry.getRawSnapshot(),
+                  existing.getAdjustOperationCount(),
+                  existing.getDiffOperationCount(),
+                  documentEntry.getBodyItemCount(),
+                  /* parseAttachmentElements= */ true,
+                  existing.getAttachmentOverrides(),
+                  existing.getParsedContent());
+        } else {
+          next =
+              Entry.loaded(
+                  existing.getSegment(),
+                  mergedFromVersion,
+                  mergedToVersion,
+                  documentEntry.getRawSnapshot(),
+                  existing.getAdjustOperationCount(),
+                  existing.getDiffOperationCount(),
+                  documentEntry.getBodyItemCount());
+        }
+        merged.set(existingIndex, next);
       } else {
         merged.add(documentEntry);
       }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
@@ -165,6 +165,30 @@ public class J2clReadBlipContentTest {
   }
 
   @Test
+  public void preservesInlineReplyAnchorMetadataWithoutVisibleReplyId() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot(
+            "<body><line/>Before <reply id=\"t+inline\"></reply> after</body>");
+
+    Assert.assertEquals("Before  after", parsed.getText());
+    Assert.assertEquals(1, parsed.getInlineReplyAnchors().size());
+    Assert.assertEquals("t+inline", parsed.getInlineReplyAnchors().get(0).getThreadId());
+    Assert.assertEquals("Before ".length(), parsed.getInlineReplyAnchors().get(0).getTextOffset());
+  }
+
+  @Test
+  public void inlineReplyAnchorOffsetUsesDecodedVisibleText() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot(
+            "<body><line/>A &amp; B <reply id=\"t+entity\"></reply> after</body>");
+
+    Assert.assertEquals("A & B  after", parsed.getText());
+    Assert.assertEquals(1, parsed.getInlineReplyAnchors().size());
+    Assert.assertEquals("t+entity", parsed.getInlineReplyAnchors().get(0).getThreadId());
+    Assert.assertEquals("A & B ".length(), parsed.getInlineReplyAnchors().get(0).getTextOffset());
+  }
+
+  @Test
   public void parsesTaskAnnotationsFromRawFragmentSnapshot() {
     J2clReadBlipContent parsed =
         J2clReadBlipContent.parseRawSnapshot(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
@@ -189,6 +189,19 @@ public class J2clReadBlipContentTest {
   }
 
   @Test
+  public void inlineReplyAnchorOffsetAfterLineUsesDecodedVisibleText() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot(
+            "<body>A &amp; B   <line/>C <reply id=\"t+after-line\"></reply></body>");
+
+    Assert.assertEquals("A & B\nC ", parsed.getText());
+    Assert.assertEquals(1, parsed.getInlineReplyAnchors().size());
+    Assert.assertEquals("t+after-line", parsed.getInlineReplyAnchors().get(0).getThreadId());
+    Assert.assertEquals(
+        "A & B\nC ".length(), parsed.getInlineReplyAnchors().get(0).getTextOffset());
+  }
+
+  @Test
   public void parsesTaskAnnotationsFromRawFragmentSnapshot() {
     J2clReadBlipContent parsed =
         J2clReadBlipContent.parseRawSnapshot(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -288,6 +288,42 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void renderCountsOnlySerializableInlineReplyAnchors() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clReadBlip blip =
+        new J2clReadBlip(
+            "b+root",
+            "Before  after",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "Alice",
+            1714240000000L,
+            "",
+            "",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false,
+            /* taskDone= */ false,
+            /* taskAssignee= */ "",
+            /* taskDueTimestamp= */ 0L,
+            /* bodyItemCount= */ 15,
+            /* isTask= */ false,
+            Arrays.asList(
+                new J2clInlineReplyAnchor("", 1),
+                null,
+                new J2clInlineReplyAnchor("t+inline", "Before ".length())));
+
+    Assert.assertTrue(
+        renderer.render(Arrays.asList(blip), Collections.<String>emptyList()));
+
+    HTMLElement element = blip(host, "b+root");
+    Assert.assertEquals("1", element.getAttribute("data-inline-reply-anchor-count"));
+    Assert.assertEquals("t+inline@7", element.getAttribute("data-inline-reply-anchors"));
+  }
+
+  @Test
   public void renderOmitsTaskAttributesWhenOpen() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -255,6 +255,39 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void renderExposesInlineReplyAnchorMetadataOnBlipHost() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clReadBlip blip =
+        new J2clReadBlip(
+            "b+root",
+            "Before  after",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "Alice",
+            1714240000000L,
+            "",
+            "",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false,
+            /* taskDone= */ false,
+            /* taskAssignee= */ "",
+            /* taskDueTimestamp= */ 0L,
+            /* bodyItemCount= */ 15,
+            /* isTask= */ false,
+            Arrays.asList(new J2clInlineReplyAnchor("t+inline", "Before ".length())));
+
+    Assert.assertTrue(
+        renderer.render(Arrays.asList(blip), Collections.<String>emptyList()));
+
+    HTMLElement element = blip(host, "b+root");
+    Assert.assertEquals("1", element.getAttribute("data-inline-reply-anchor-count"));
+    Assert.assertEquals("t+inline@7", element.getAttribute("data-inline-reply-anchors"));
+  }
+
+  @Test
   public void renderOmitsTaskAttributesWhenOpen() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java
@@ -60,6 +60,13 @@ public class J2clRootShellControllerTest {
     Assert.assertEquals("unlocked", J2clRootShellController.normalizeLockStateValue("bogus"));
   }
 
+  @Test
+  public void previewRouteHostSkipsLiveSidecarStartup() {
+    Assert.assertTrue(J2clRootShellController.isReadSurfacePreviewHost(true, false));
+    Assert.assertTrue(J2clRootShellController.isReadSurfacePreviewHost(false, true));
+    Assert.assertFalse(J2clRootShellController.isReadSurfacePreviewHost(false, false));
+  }
+
   private static final class FakeToolbarView implements J2clToolbarSurfaceController.View {
     private J2clToolbarSurfaceModel model;
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -14,6 +14,8 @@ import org.junit.Test;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadata;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadataClient;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
+import org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel;
+import org.waveprotocol.box.j2cl.read.J2clInlineReplyAnchor;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 import org.waveprotocol.box.j2cl.telemetry.J2clClientTelemetry;
 import org.waveprotocol.box.j2cl.telemetry.RecordingTelemetrySink;
@@ -1236,6 +1238,52 @@ public class J2clSelectedWaveControllerTest {
     Assert.assertEquals(1777463436001L, readBlips.get(1).getLastModifiedTimeMillis());
     Assert.assertEquals("tail-author@example.com", readBlips.get(2).getAuthorId());
     Assert.assertEquals(1777463436277L, readBlips.get(2).getLastModifiedTimeMillis());
+  }
+
+  @Test
+  public void fragmentBlipMetadataMergePreservesInlineReplyAnchors() throws Exception {
+    J2clReadBlip existing =
+        new J2clReadBlip(
+            "b+next",
+            "Before  after",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            /* authorId= */ "",
+            /* authorDisplayName= */ "",
+            /* lastModifiedTimeMillis= */ 0L,
+            /* parentBlipId= */ "",
+            /* threadId= */ "",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false,
+            /* taskDone= */ false,
+            /* taskAssignee= */ "",
+            /* taskDueTimestamp= */ J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP,
+            /* bodyItemCount= */ 12,
+            /* isTask= */ false,
+            Arrays.asList(new J2clInlineReplyAnchor("t+inline", "Before ".length())));
+    SidecarFragmentsResponse response =
+        fragmentsResponseWithBlipMetadata(
+            "b+next",
+            "Before  after",
+            "next-author@example.com",
+            1777463436001L,
+            null,
+            null,
+            null,
+            0L);
+    Method merge =
+        J2clSelectedWaveController.class.getDeclaredMethod(
+            "mergeFragmentBlipMetadata",
+            J2clReadBlip.class,
+            SidecarFragmentsResponse.BlipMetadata.class);
+    merge.setAccessible(true);
+
+    J2clReadBlip merged =
+        (J2clReadBlip) merge.invoke(null, existing, response.getBlips().get(0));
+
+    Assert.assertEquals("next-author@example.com", merged.getAuthorId());
+    Assert.assertEquals(1, merged.getInlineReplyAnchors().size());
+    Assert.assertEquals("t+inline", merged.getInlineReplyAnchors().get(0).getThreadId());
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -225,6 +225,45 @@ public class J2clSelectedWaveProjectorTest {
   }
 
   @Test
+  public void viewportFragmentsProjectInlineReplyAnchorsToReadBlips() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                9L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Collections.<SidecarSelectedWaveDocument>emptyList(),
+                new SidecarSelectedWaveFragments(
+                    9L,
+                    0L,
+                    9L,
+                    Arrays.asList(new SidecarSelectedWaveFragmentRange("blip:b+root", 0L, 9L)),
+                    Arrays.asList(
+                        new SidecarSelectedWaveFragment(
+                            "blip:b+root",
+                            "<body><line/>Before <reply id=\"t+inline\"></reply> after</body>",
+                            0,
+                            0)))),
+            null,
+            0);
+
+    J2clReadBlip blip = projected.getReadBlips().get(0);
+    Assert.assertEquals("Before  after", blip.getText());
+    Assert.assertEquals(1, blip.getInlineReplyAnchors().size());
+    Assert.assertEquals("t+inline", blip.getInlineReplyAnchors().get(0).getThreadId());
+    Assert.assertEquals("Before ".length(), blip.getInlineReplyAnchors().get(0).getTextOffset());
+    Assert.assertEquals(
+        1,
+        projected.getViewportState().getReadWindowEntries().get(0).getInlineReplyAnchors().size());
+  }
+
+  @Test
   public void projectExtractsAttachmentModelsFromImageElementsInFragments() {
     J2clSelectedWaveModel projected =
         J2clSelectedWaveProjector.project(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -605,6 +605,45 @@ public class J2clSelectedWaveProjectorTest {
   }
 
   @Test
+  public void viewportDocumentMergePreservesInlineReplyAnchorsFromFragment() {
+    J2clSelectedWaveViewportState state =
+        J2clSelectedWaveViewportState.fromFragments(
+            new SidecarSelectedWaveFragments(
+                9L,
+                0L,
+                9L,
+                Arrays.asList(new SidecarSelectedWaveFragmentRange("blip:b+root", 0L, 9L)),
+                Arrays.asList(
+                    new SidecarSelectedWaveFragment(
+                        "blip:b+root",
+                        "<body><line/>Before <reply id=\"t+inline\"></reply> after</body>",
+                        0,
+                        0))));
+
+    state =
+        state.mergeDocuments(
+            Arrays.asList(
+                new SidecarSelectedWaveDocument(
+                    "b+root",
+                    "user@example.com",
+                    7L,
+                    10L,
+                    "Before  after",
+                    /* bodyItemCount= */ 13,
+                    Collections.<SidecarAnnotationRange>emptyList(),
+                    Collections.<SidecarReactionEntry>emptyList())));
+
+    Assert.assertEquals("Before  after", state.getLoadedReadBlips().get(0).getText());
+    Assert.assertEquals(1, state.getLoadedReadBlips().get(0).getInlineReplyAnchors().size());
+    Assert.assertEquals(
+        "t+inline", state.getLoadedReadBlips().get(0).getInlineReplyAnchors().get(0).getThreadId());
+    Assert.assertEquals(1, state.getReadWindowEntries().get(0).getInlineReplyAnchors().size());
+    Assert.assertEquals(
+        "t+inline",
+        state.getReadWindowEntries().get(0).getInlineReplyAnchors().get(0).getThreadId());
+  }
+
+  @Test
   public void viewportFragmentMergeOverDocumentRestoresAttachmentParsing() {
     J2clSelectedWaveViewportState state =
         J2clSelectedWaveViewportState.fromDocuments(

--- a/wave/config/changelog.d/2026-05-01-j2cl-inline-anchor-hydration.json
+++ b/wave/config/changelog.d/2026-05-01-j2cl-inline-anchor-hydration.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-01-j2cl-inline-anchor-hydration",
+  "version": "Unreleased",
+  "date": "2026-05-01",
+  "title": "J2CL preserves read-surface preview hydration and inline reply anchors",
+  "summary": "The J2CL root read-surface preview route now keeps its server-rendered content visible after boot, and raw inline reply anchors are preserved as read-surface metadata for follow-up inline placement work.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Keep the J2CL read-surface preview route in preview mode after boot instead of replacing the server-rendered fixture with the normal live shell.",
+        "Preserve inline reply anchor ids and text offsets from raw Wave blip markup through read blips and the window-render path so inline-thread placement can be restored without losing anchor metadata."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- keep the signed-in J2CL read-surface preview route in preview mode after boot so the server-rendered fixture is not replaced by normal live shell startup
- preserve raw `<reply id="...">` inline-anchor ids and decoded visible-text offsets through `J2clReadBlip`, viewport projection, window entries, projector metadata copy paths, and DOM attributes
- add regression coverage for preview-mode detection, inline-anchor parsing, decoded entity offsets, renderer attributes, and viewport/window propagation

## Verification
- `sbt --batch j2clSearchTest` red before implementation: `viewportFragmentsProjectInlineReplyAnchorsToReadBlips` expected 1 inline anchor, saw 0
- `sbt --batch j2clSearchTest` self-review red: `inlineReplyAnchorOffsetUsesDecodedVisibleText` expected decoded offset 6, saw raw offset 10
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `git diff --check`
- `sbt --batch compile Test/compile j2clSearchTest j2clLitTest`
- `bash scripts/worktree-boot.sh --port 9917`
- `PORT=9917 bash scripts/wave-smoke.sh check` returned 200 for root, GWT, health, landing, J2CL root, J2CL index, sidecar, and webclient
- signed-in fetch of `/?view=j2cl-root&q=read-surface-preview` returned 200 with preview markers and `<wave-blip>` elements
- headless Playwright check after J2CL boot found `bodyMarked=true`, `hostMarked=true`, `blipCount=7`, `firstBlipId=b1`, and no live-shell, empty-selected, or signed-out fallback text

Refs #1167
Refs #904


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline reply anchors are preserved through the read/render pipeline and exposed on blip hosts as DOM metadata (count and serialized anchors) to support restoring inline-reply placement.

* **Bug Fixes**
  * Read-surface preview mode now persists after JavaScript hydration and is not swapped out on load.

* **Tests**
  * Added unit tests for inline-reply parsing, DOM serialization, viewport merging, and preview-mode detection.

* **Documentation**
  * Added a follow-up plan documenting implementation steps and verification for inline-anchor hydration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->