### PR TITLE
fix: place J2CL inline threads at reply anchors

### DIFF
--- a/docs/superpowers/plans/2026-05-01-issue-1167-inline-placement-parity.md
+++ b/docs/superpowers/plans/2026-05-01-issue-1167-inline-placement-parity.md
@@ -1,0 +1,345 @@
+# Issue 1167 Inline Placement Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render J2CL inline reply threads at their parent blip's inline anchor instead of always as detached replies after the blip.
+
+**Architecture:** The projector already exposes `J2clInlineReplyAnchor` metadata on each parent blip and the renderer already serializes it as `data-inline-reply-anchors`. This slice keeps the transport unchanged, renders lightweight anchor placeholder elements in the parent `.j2cl-read-blip-content`, and teaches both flat and viewport-window placement paths to attach matching `parentBlipId/threadId` reply thread hosts at those placeholders. Threads without valid anchors keep the current sibling-after-parent fallback so malformed data stays readable.
+
+**Tech Stack:** Java J2CL renderer, elemental2 DOM tests, SBT-only verification, existing Lit `<wave-blip>` slots.
+
+---
+
+## Files
+
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java`
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java`
+- Modify: `wave/config/changelog.d/<new-fragment>.json`
+
+## Acceptance
+
+- A child blip whose `parentBlipId` points at a rendered parent and whose `threadId` matches a parent `J2clInlineReplyAnchor` is mounted in an inline thread host at that anchor placeholder.
+- The inline host is still a `.thread.inline-thread.j2cl-read-thread`, still receives the existing collapse/toggle enhancement, and still contributes to the parent's `reply-count`.
+- Multiple anchors in the same parent preserve source text order and do not reverse sibling thread order.
+- A child blip with no matching anchor falls back to the existing sibling-after-parent placement.
+- Existing windowed rendering keeps viewport fragment order, focus restoration, collapse restoration, and scroll-anchor restoration.
+
+## Task 1: Add Renderer Regression Tests
+
+**Files:**
+- Modify: `j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java`
+
+- [ ] **Step 1: Add a flat-render failing test**
+
+Add a test near `renderExposesInlineReplyAnchorMetadataOnBlipHost`:
+
+```java
+  @Test
+  public void renderPlacesMatchingThreadAtInlineReplyAnchor() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clReadBlip root =
+        new J2clReadBlip(
+            "b+root",
+            "Before after",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "Alice",
+            1714240000000L,
+            "",
+            "",
+            false,
+            false,
+            false,
+            false,
+            "",
+            0L,
+            12,
+            false,
+            Arrays.asList(new J2clInlineReplyAnchor("t+inline", "Before ".length())));
+    J2clReadBlip reply =
+        new J2clReadBlip(
+            "b+reply",
+            "Inline reply",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "bob@example.com",
+            "Bob",
+            1714240100000L,
+            "b+root",
+            "t+inline",
+            false,
+            false,
+            false);
+
+    Assert.assertTrue(renderer.render(Arrays.asList(root, reply), Collections.<String>emptyList()));
+
+    HTMLElement anchor =
+        (HTMLElement) blip(host, "b+root").querySelector("[data-inline-reply-anchor-thread-id='t+inline']");
+    Assert.assertNotNull(anchor);
+    HTMLElement thread =
+        (HTMLElement) anchor.querySelector(".inline-thread[data-inline-reply-anchor-thread-id='t+inline']");
+    Assert.assertNotNull(thread);
+    Assert.assertEquals("b+reply", thread.querySelector("[data-blip-id]").getAttribute("data-blip-id"));
+    Assert.assertEquals("1", blip(host, "b+root").getAttribute("reply-count"));
+  }
+```
+
+- [ ] **Step 2: Add a fallback test**
+
+Add a test proving unmatched child threads stay reachable through the existing fallback:
+
+```java
+  @Test
+  public void renderFallsBackWhenThreadHasNoMatchingInlineReplyAnchor() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clReadBlip root = new J2clReadBlip("b+root", "Root");
+    J2clReadBlip reply =
+        new J2clReadBlip(
+            "b+reply",
+            "Detached reply",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "bob@example.com",
+            "Bob",
+            1714240100000L,
+            "b+root",
+            "t+missing",
+            false,
+            false,
+            false);
+
+    Assert.assertTrue(renderer.render(Arrays.asList(root, reply), Collections.<String>emptyList()));
+
+    HTMLElement fallbackThread =
+        (HTMLElement) host.querySelector(".inline-thread[data-parent-blip-id='b+root']");
+    Assert.assertNotNull(fallbackThread);
+    Assert.assertFalse(fallbackThread.hasAttribute("data-inline-reply-anchor-thread-id"));
+    Assert.assertSame(blip(host, "b+root").nextSibling, fallbackThread);
+  }
+```
+
+- [ ] **Step 3: Add a window-render failing test**
+
+Add a test near `renderWindowEntriesFollowManifestDfsOrderWhenFragmentsArriveOutOfOrder`:
+
+```java
+  @Test
+  public void renderWindowPlacesMatchingThreadAtInlineReplyAnchor() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    J2clReadWindowEntry root =
+        J2clReadWindowEntry.loadedWithTaskMetadata(
+            "blip:b+root",
+            0L,
+            12L,
+            "b+root",
+            "Before after",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "Alice",
+            1714240000000L,
+            "",
+            "t+root",
+            false,
+            false,
+            false,
+            "",
+            0L,
+            12,
+            false,
+            Arrays.asList(new J2clInlineReplyAnchor("t+inline", "Before ".length())));
+    J2clReadWindowEntry reply =
+        J2clReadWindowEntry.loadedWithTaskMetadata(
+            "blip:b+reply",
+            12L,
+            24L,
+            "b+reply",
+            "Inline reply",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "bob@example.com",
+            "Bob",
+            1714240100000L,
+            "b+root",
+            "t+inline",
+            false,
+            false,
+            false,
+            "",
+            0L,
+            12,
+            false);
+
+    Assert.assertTrue(renderer.renderWindow(Arrays.asList(root, reply)));
+
+    HTMLElement anchor =
+        (HTMLElement) blip(host, "b+root").querySelector("[data-inline-reply-anchor-thread-id='t+inline']");
+    Assert.assertNotNull(anchor);
+    Assert.assertNotNull(anchor.querySelector(".inline-thread[data-inline-reply-anchor-thread-id='t+inline']"));
+    Assert.assertEquals("reply", blip(host, "b+reply").getAttribute("data-blip-depth"));
+  }
+```
+
+- [ ] **Step 4: Run the targeted test and confirm RED**
+
+Run:
+
+```bash
+sbt --batch j2clSearchTest
+```
+
+Expected: the new inline placement tests fail because no anchor placeholder exists and child thread hosts are mounted as siblings after the parent.
+
+## Task 2: Render Inline Anchor Placeholders
+
+**Files:**
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java`
+
+- [ ] **Step 1: Replace the `renderBlipText` call for blips with anchors**
+
+In `renderBlip`, replace:
+
+```java
+renderBlipText(content, blip.getText(), buildMentionArray(blip.getBlipId()));
+```
+
+with:
+
+```java
+renderBlipText(
+    content,
+    blip.getText(),
+    buildMentionArray(blip.getBlipId()),
+    blip.getInlineReplyAnchors());
+```
+
+- [ ] **Step 2: Add an overload that inserts placeholders**
+
+Change the existing `renderBlipText(HTMLElement, String, List<J2clMentionRange>)` into an overload that delegates to a new four-argument method:
+
+```java
+  private void renderBlipText(
+      HTMLElement content, String text, List<J2clMentionRange> mentions) {
+    renderBlipText(content, text, mentions, Collections.<J2clInlineReplyAnchor>emptyList());
+  }
+```
+
+Add a first-pass implementation in the four-argument method that preserves existing mention rendering when mentions are present and inserts anchor placeholders only for plain text without mentions. The placeholder element must be:
+
+```java
+HTMLElement marker = (HTMLElement) DomGlobal.document.createElement("span");
+marker.className = "j2cl-inline-reply-anchor";
+marker.setAttribute("data-inline-reply-anchor", "true");
+marker.setAttribute("data-inline-reply-anchor-thread-id", anchor.getThreadId());
+marker.setAttribute("data-inline-reply-anchor-offset", Integer.toString(offset));
+marker.setAttribute("aria-label", "Inline replies");
+```
+
+For this slice, if both mentions and anchors exist in the same blip, keep mention rendering unchanged and let thread placement fall back. That avoids corrupting mention chips; a later richer text renderer can merge both range streams.
+
+## Task 3: Place Matching Threads At Anchors
+
+**Files:**
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java`
+
+- [ ] **Step 1: Add helper `inlineReplyAnchorHost`**
+
+Add a helper that finds the anchor placeholder inside a parent `<wave-blip>`:
+
+```java
+  private static HTMLElement inlineReplyAnchorHost(HTMLElement parentHost, String threadId) {
+    if (parentHost == null || threadId == null || threadId.isEmpty()) {
+      return null;
+    }
+    return (HTMLElement)
+        parentHost.querySelector(
+            "[data-inline-reply-anchor-thread-id='" + cssAttributeValue(threadId) + "']");
+  }
+```
+
+If no safe CSS escaping helper exists, avoid selector interpolation by iterating `querySelectorAll("[data-inline-reply-anchor-thread-id]")` and comparing attributes directly.
+
+- [ ] **Step 2: Add helper `appendThreadHostAfterAnchorOrParent`**
+
+Add a helper that mounts the new thread under the anchor placeholder when available, otherwise uses the existing sibling-after-parent insertion logic. When mounting at an anchor, set:
+
+```java
+threadHost.setAttribute("data-inline-reply-anchor-thread-id", tid);
+threadHost.setAttribute("data-inline-reply-anchor-placement", "inline");
+anchorHost.appendChild(threadHost);
+```
+
+- [ ] **Step 3: Update flat `appendBlipsAsTree` placement**
+
+In the flat-render branch, when creating a new `threadHost`, call the helper instead of duplicating insertion logic. Keep `lastThreadHostByParent` for fallback sibling ordering only; anchored hosts are ordered by text placeholders in the parent content.
+
+- [ ] **Step 4: Update `resolveWinThreadTarget` placement**
+
+In the window-render path, use the same helper with `parentHost` and `threadId` so viewport hydration and live updates behave the same way.
+
+## Task 4: Changelog And Verification
+
+**Files:**
+- Create: `wave/config/changelog.d/20260501-j2cl-inline-placement-parity.json`
+- Modify: `wave/config/changelog.json` by running the assembler only.
+
+- [ ] **Step 1: Add a user-facing changelog fragment**
+
+Create:
+
+```json
+{
+  "type": "fixed",
+  "summary": "J2CL now places inline reply threads at their parent blip anchor when anchor metadata is available."
+}
+```
+
+- [ ] **Step 2: Run narrow verification**
+
+Run:
+
+```bash
+sbt --batch j2clSearchTest
+```
+
+Expected: all `j2clSearchTest` tests pass.
+
+- [ ] **Step 3: Run full lane verification**
+
+Run:
+
+```bash
+python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json && git diff --check && sbt --batch compile Test/compile j2clSearchTest j2clLitTest
+```
+
+Expected: exit code 0.
+
+- [ ] **Step 4: Self-review**
+
+Review the diff against #1167 acceptance:
+
+- Anchored inline child threads mount under anchor placeholders.
+- Unanchored children remain visible through fallback.
+- Existing collapse toggles and reply counts still work.
+- No Maven commands were used.
+- No main checkout files were edited.
+
+- [ ] **Step 5: Commit, push, and open PR**
+
+Use a commit message:
+
+```bash
+git commit -m "fix: place J2CL inline threads at reply anchors"
+```
+
+Push and open a PR linked to #1167 and #904. Include exact verification output summary in the PR body and in a #1167 issue comment.
+
+## Self-Review Notes
+
+- Spec coverage: The plan covers the specific remaining #1167 functional gap: true inline placement when anchor metadata is available, fallback rendering for malformed data, reply-count preservation, and viewport-window parity.
+- Placeholder scan: No implementation step is left open-ended. The only deliberate limitation is explicit: anchors plus mention chips fall back rather than attempting a range-merge in this slice.
+- Type consistency: The plan uses existing types already present in this lane: `J2clReadBlip`, `J2clReadWindowEntry`, `J2clInlineReplyAnchor`, `HTMLElement`, and `J2clAttachmentRenderModel`.
+- Risk: The first implementation should avoid CSS selector interpolation for thread IDs because Wave thread IDs may include punctuation. Attribute iteration is safer.

--- a/docs/superpowers/plans/2026-05-01-issue-1167-inline-placement-parity.md
+++ b/docs/superpowers/plans/2026-05-01-issue-1167-inline-placement-parity.md
@@ -235,7 +235,7 @@ marker.className = "j2cl-inline-reply-anchor";
 marker.setAttribute("data-inline-reply-anchor", "true");
 marker.setAttribute("data-inline-reply-anchor-thread-id", anchor.getThreadId());
 marker.setAttribute("data-inline-reply-anchor-offset", Integer.toString(offset));
-marker.setAttribute("aria-label", "Inline replies");
+marker.setAttribute("aria-hidden", "true");
 ```
 
 For this slice, if both mentions and anchors exist in the same blip, keep mention rendering unchanged and let thread placement fall back. That avoids corrupting mention chips; a later richer text renderer can merge both range streams.
@@ -262,14 +262,15 @@ Add a helper that finds the anchor placeholder inside a parent `<wave-blip>`:
 
 If no safe CSS escaping helper exists, avoid selector interpolation by iterating `querySelectorAll("[data-inline-reply-anchor-thread-id]")` and comparing attributes directly.
 
-- [ ] **Step 2: Add helper `appendThreadHostAfterAnchorOrParent`**
+- [ ] **Step 2: Add helper `mountInlineThreadHost`**
 
-Add a helper that mounts the new thread under the anchor placeholder when available, otherwise uses the existing sibling-after-parent insertion logic. When mounting at an anchor, set:
+Add a helper that uses the anchor placeholder as the lookup point, then mounts the new thread in the parent `<wave-blip>` extension slot so task-completed body styling does not decorate reply content. When no anchor is available, use the existing sibling-after-parent insertion logic. When mounting at an anchor, set:
 
 ```java
 threadHost.setAttribute("data-inline-reply-anchor-thread-id", tid);
 threadHost.setAttribute("data-inline-reply-anchor-placement", "inline");
-anchorHost.appendChild(threadHost);
+threadHost.setAttribute("slot", "blip-extension");
+parentBlipHost.appendChild(threadHost);
 ```
 
 - [ ] **Step 3: Update flat `appendBlipsAsTree` placement**
@@ -283,7 +284,7 @@ In the window-render path, use the same helper with `parentHost` and `threadId` 
 ## Task 4: Changelog And Verification
 
 **Files:**
-- Create: `wave/config/changelog.d/20260501-j2cl-inline-placement-parity.json`
+- Create: `wave/config/changelog.d/2026-05-01-j2cl-inline-placement-parity.json`
 - Modify: `wave/config/changelog.json` by running the assembler only.
 
 - [ ] **Step 1: Add a user-facing changelog fragment**

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1313,7 +1313,7 @@ public final class J2clReadSurfaceDomRenderer {
     marker.setAttribute("data-inline-reply-anchor-thread-id", segment.getThreadId());
     marker.setAttribute(
         "data-inline-reply-anchor-offset", Integer.toString(segment.getTextOffset()));
-    marker.setAttribute("aria-label", "Inline replies");
+    marker.setAttribute("aria-hidden", "true");
     return marker;
   }
 
@@ -1865,16 +1865,20 @@ public final class J2clReadSurfaceDomRenderer {
     if (inlineAnchor != null) {
       threadHost.setAttribute("data-inline-reply-anchor-thread-id", threadId);
       threadHost.setAttribute("data-inline-reply-anchor-placement", "inline");
-      inlineAnchor.appendChild(threadHost);
+      // Keep the mounted thread outside the default body slot so parent task
+      // strikethrough/quiet-color styling does not decorate unrelated replies.
+      threadHost.setAttribute("slot", "blip-extension");
+      parentBlipHost.appendChild(threadHost);
       return;
     }
 
     threadHost.removeAttribute("data-inline-reply-anchor-thread-id");
     threadHost.removeAttribute("data-inline-reply-anchor-placement");
+    threadHost.removeAttribute("slot");
     // review-1089 round-2/4: fallback reply threads stay as siblings
     // after the parent <wave-blip>, ordered after any previous fallback
-    // thread for the same parent. Anchored threads live inside their text
-    // marker and intentionally do not advance this fallback insertion point.
+    // thread for the same parent. Anchored threads live in the parent card's
+    // extension slot and intentionally do not advance this fallback point.
     HTMLElement anchor = lastThreadHostByParent.get(parentBlipId);
     if (anchor == null) {
       anchor = parentBlipHost;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1868,7 +1868,7 @@ public final class J2clReadSurfaceDomRenderer {
       // Keep the mounted thread outside the default body slot so parent task
       // strikethrough/quiet-color styling does not decorate unrelated replies.
       threadHost.setAttribute("slot", "blip-extension");
-      parentBlipHost.appendChild(threadHost);
+      insertAnchoredThreadInOrder(parentBlipHost, threadHost, inlineAnchor);
       return;
     }
 
@@ -1895,6 +1895,37 @@ public final class J2clReadSurfaceDomRenderer {
     }
     if (parentBlipId != null && !parentBlipId.isEmpty()) {
       lastThreadHostByParent.put(parentBlipId, threadHost);
+    }
+  }
+
+  private static void insertAnchoredThreadInOrder(
+      HTMLElement parentBlipHost, HTMLElement threadHost, HTMLElement inlineAnchor) {
+    int offset = anchorOffset(inlineAnchor);
+    Element child = parentBlipHost.firstElementChild;
+    while (child != null) {
+      if ("blip-extension".equals(child.getAttribute("slot"))
+          && child.hasAttribute("data-inline-reply-anchor-thread-id")) {
+        String existingTid = child.getAttribute("data-inline-reply-anchor-thread-id");
+        HTMLElement existingAnchor = inlineReplyAnchorHost(parentBlipHost, existingTid);
+        if (existingAnchor != null && anchorOffset(existingAnchor) > offset) {
+          parentBlipHost.insertBefore(threadHost, child);
+          return;
+        }
+      }
+      child = child.nextElementSibling;
+    }
+    parentBlipHost.appendChild(threadHost);
+  }
+
+  private static int anchorOffset(HTMLElement anchorEl) {
+    String val = anchorEl.getAttribute("data-inline-reply-anchor-offset");
+    if (val == null || val.isEmpty()) {
+      return 0;
+    }
+    try {
+      return Integer.parseInt(val);
+    } catch (NumberFormatException e) {
+      return 0;
     }
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1186,10 +1186,6 @@ public final class J2clReadSurfaceDomRenderer {
       List<J2clMentionRange> mentions,
       List<J2clInlineReplyAnchor> inlineReplyAnchors) {
     String safeText = text == null ? "" : text;
-    // The current mention renderer already owns text-node splitting. Until
-    // mention and inline-reply ranges are merged into one rich-text pass, keep
-    // mention rendering authoritative and let anchored threads fall back to
-    // sibling placement for this uncommon overlap.
     if (mentions == null || mentions.isEmpty()) {
       List<InlineAnchorTextSegment> segments =
           inlineAnchorTextSegments(safeText, inlineReplyAnchors);
@@ -1207,6 +1203,7 @@ public final class J2clReadSurfaceDomRenderer {
       return;
     }
 
+    List<J2clInlineReplyAnchor> sortedAnchors = validInlineReplyAnchors(safeText, inlineReplyAnchors);
     int cursor = 0;
     boolean renderedMention = false;
     for (J2clMentionRange mention : mentions) {
@@ -1219,7 +1216,7 @@ public final class J2clReadSurfaceDomRenderer {
         continue;
       }
       if (start > cursor) {
-        content.appendChild(DomGlobal.document.createTextNode(safeText.substring(cursor, start)));
+        appendTextSegmentWithAnchors(content, safeText, cursor, start, sortedAnchors);
       }
       HTMLElement chip = (HTMLElement) DomGlobal.document.createElement("span");
       chip.className = "j2cl-read-mention-chip";
@@ -1233,12 +1230,35 @@ public final class J2clReadSurfaceDomRenderer {
       renderedMention = true;
     }
     if (cursor < safeText.length()) {
-      content.appendChild(DomGlobal.document.createTextNode(safeText.substring(cursor)));
+      appendTextSegmentWithAnchors(content, safeText, cursor, safeText.length(), sortedAnchors);
     }
-    if (!renderedMention) {
-      content.textContent = safeText;
-    } else {
+    if (renderedMention) {
       content.setAttribute("data-has-rendered-mentions", "true");
+    }
+  }
+
+  private static void appendTextSegmentWithAnchors(
+      HTMLElement content,
+      String safeText,
+      int from,
+      int to,
+      List<J2clInlineReplyAnchor> sortedAnchors) {
+    int cursor = from;
+    for (J2clInlineReplyAnchor anchor : sortedAnchors) {
+      int offset = normalizedAnchorOffset(safeText, anchor);
+      if (offset < from || offset >= to) {
+        continue;
+      }
+      if (offset > cursor) {
+        content.appendChild(DomGlobal.document.createTextNode(safeText.substring(cursor, offset)));
+      }
+      content.appendChild(
+          renderInlineReplyAnchor(
+              InlineAnchorTextSegment.anchor(anchor.getThreadId(), offset)));
+      cursor = offset;
+    }
+    if (cursor < to) {
+      content.appendChild(DomGlobal.document.createTextNode(safeText.substring(cursor, to)));
     }
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1215,9 +1215,7 @@ public final class J2clReadSurfaceDomRenderer {
       if (start < cursor || end <= start) {
         continue;
       }
-      if (start > cursor) {
-        appendTextSegmentWithAnchors(content, safeText, cursor, start, sortedAnchors);
-      }
+      appendTextSegmentWithAnchors(content, safeText, cursor, start, sortedAnchors);
       HTMLElement chip = (HTMLElement) DomGlobal.document.createElement("span");
       chip.className = "j2cl-read-mention-chip";
       chip.setAttribute("data-j2cl-read-mention", "true");
@@ -1229,9 +1227,7 @@ public final class J2clReadSurfaceDomRenderer {
       cursor = end;
       renderedMention = true;
     }
-    if (cursor < safeText.length()) {
-      appendTextSegmentWithAnchors(content, safeText, cursor, safeText.length(), sortedAnchors);
-    }
+    appendTextSegmentWithAnchors(content, safeText, cursor, safeText.length(), sortedAnchors);
     if (renderedMention) {
       content.setAttribute("data-has-rendered-mentions", "true");
     }
@@ -1246,7 +1242,7 @@ public final class J2clReadSurfaceDomRenderer {
     int cursor = from;
     for (J2clInlineReplyAnchor anchor : sortedAnchors) {
       int offset = normalizedAnchorOffset(safeText, anchor);
-      if (offset < from || offset >= to) {
+      if (offset < from || offset > to) {
         continue;
       }
       if (offset > cursor) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -34,6 +34,42 @@ public final class J2clReadSurfaceDomRenderer {
   private static final double EDGE_SCROLL_THRESHOLD_PX = 64;
   private static final String ATTACHMENT_TELEMETRY_BOUND = "data-attachment-telemetry-bound";
 
+  static final class InlineAnchorTextSegment {
+    private final String text;
+    private final String threadId;
+    private final int textOffset;
+
+    private InlineAnchorTextSegment(String text, String threadId, int textOffset) {
+      this.text = text == null ? "" : text;
+      this.threadId = threadId == null ? "" : threadId;
+      this.textOffset = Math.max(0, textOffset);
+    }
+
+    static InlineAnchorTextSegment text(String text) {
+      return new InlineAnchorTextSegment(text, "", 0);
+    }
+
+    static InlineAnchorTextSegment anchor(String threadId, int textOffset) {
+      return new InlineAnchorTextSegment("", threadId, textOffset);
+    }
+
+    boolean isAnchor() {
+      return !threadId.isEmpty();
+    }
+
+    String getText() {
+      return text;
+    }
+
+    String getThreadId() {
+      return threadId;
+    }
+
+    int getTextOffset() {
+      return textOffset;
+    }
+  }
+
   /**
    * F-4 (#1039 / R-4.4 / subsumes #1056): how long an unread blip must dwell
    * inside the viewport before we treat it as "the user actually read it".
@@ -953,38 +989,9 @@ public final class J2clReadSurfaceDomRenderer {
           threadHost.setAttribute("data-thread-id", "inline-" + parentBlipId);
         }
         threadHost.setAttribute("data-parent-blip-id", parentBlipId);
-        // review-1089 round-2 (Copilot): mount the reply thread as a
-        // *sibling after* the parent <wave-blip> rather than as a
-        // child of its default slot. The wave-blip element places
-        // its default slot inside the .body wrapper, which inherits
-        // styling like the F-3.S2 task-completed strikethrough
-        // (`:host([data-task-completed]) .body { text-decoration:
-        // line-through; color: var(--wavy-text-quiet); }`). Nested
-        // replies are unrelated to the parent's task state and must
-        // not pick up that visual treatment.
-        // review-1089 round-4 (codex P2): anchor after the last thread
-        // host for this parent (if any) so sibling threads stay in
-        // manifest DFS order — otherwise the second thread would be
-        // inserted before the first.
-        HTMLElement anchor = lastThreadHostByParent.get(parentBlipId);
-        if (anchor == null) {
-          anchor = parentBlipHost;
-        }
-        if (anchor.parentNode != null) {
-          if (anchor.nextSibling != null) {
-            anchor.parentNode.insertBefore(threadHost, anchor.nextSibling);
-          } else {
-            anchor.parentNode.appendChild(threadHost);
-          }
-        } else {
-          // The parent is somehow detached (defensive — should not
-          // happen for blips we just appended above). Fall back to
-          // appending under the parent so the content remains
-          // reachable.
-          parentBlipHost.appendChild(threadHost);
-        }
+        mountInlineThreadHost(
+            parentBlipHost, threadHost, parentBlipId, threadId, lastThreadHostByParent);
         threadHostsByThreadKey.put(threadKey, threadHost);
-        lastThreadHostByParent.put(parentBlipId, threadHost);
       }
       threadHost.appendChild(blipElement);
     }
@@ -1104,7 +1111,11 @@ public final class J2clReadSurfaceDomRenderer {
 
     HTMLElement content = (HTMLElement) DomGlobal.document.createElement("div");
     content.className = "blip-content j2cl-read-blip-content";
-    renderBlipText(content, blip.getText(), buildMentionArray(blip.getBlipId()));
+    renderBlipText(
+        content,
+        blip.getText(),
+        buildMentionArray(blip.getBlipId()),
+        blip.getInlineReplyAnchors());
     element.appendChild(content);
 
     if (!blip.getAttachments().isEmpty()) {
@@ -1165,9 +1176,34 @@ public final class J2clReadSurfaceDomRenderer {
 
   private void renderBlipText(
       HTMLElement content, String text, List<J2clMentionRange> mentions) {
+    renderBlipText(
+        content, text, mentions, Collections.<J2clInlineReplyAnchor>emptyList());
+  }
+
+  private void renderBlipText(
+      HTMLElement content,
+      String text,
+      List<J2clMentionRange> mentions,
+      List<J2clInlineReplyAnchor> inlineReplyAnchors) {
     String safeText = text == null ? "" : text;
+    // The current mention renderer already owns text-node splitting. Until
+    // mention and inline-reply ranges are merged into one rich-text pass, keep
+    // mention rendering authoritative and let anchored threads fall back to
+    // sibling placement for this uncommon overlap.
     if (mentions == null || mentions.isEmpty()) {
-      content.textContent = safeText;
+      List<InlineAnchorTextSegment> segments =
+          inlineAnchorTextSegments(safeText, inlineReplyAnchors);
+      if (segments.size() == 1 && !segments.get(0).isAnchor()) {
+        content.textContent = safeText;
+        return;
+      }
+      for (InlineAnchorTextSegment segment : segments) {
+        if (segment.isAnchor()) {
+          content.appendChild(renderInlineReplyAnchor(segment));
+        } else if (!segment.getText().isEmpty()) {
+          content.appendChild(DomGlobal.document.createTextNode(segment.getText()));
+        }
+      }
       return;
     }
 
@@ -1204,6 +1240,81 @@ public final class J2clReadSurfaceDomRenderer {
     } else {
       content.setAttribute("data-has-rendered-mentions", "true");
     }
+  }
+
+  static List<InlineAnchorTextSegment> inlineAnchorTextSegmentsForTest(
+      String text, List<J2clInlineReplyAnchor> anchors) {
+    return inlineAnchorTextSegments(text, anchors);
+  }
+
+  private static List<InlineAnchorTextSegment> inlineAnchorTextSegments(
+      String text, List<J2clInlineReplyAnchor> anchors) {
+    String safeText = text == null ? "" : text;
+    List<J2clInlineReplyAnchor> validAnchors = validInlineReplyAnchors(safeText, anchors);
+    if (validAnchors.isEmpty()) {
+      return Collections.singletonList(InlineAnchorTextSegment.text(safeText));
+    }
+    List<InlineAnchorTextSegment> segments = new ArrayList<InlineAnchorTextSegment>();
+    int cursor = 0;
+    for (J2clInlineReplyAnchor anchor : validAnchors) {
+      int offset = normalizedAnchorOffset(safeText, anchor);
+      if (offset > cursor) {
+        segments.add(InlineAnchorTextSegment.text(safeText.substring(cursor, offset)));
+      }
+      segments.add(InlineAnchorTextSegment.anchor(anchor.getThreadId(), offset));
+      cursor = offset;
+    }
+    if (cursor < safeText.length()) {
+      segments.add(InlineAnchorTextSegment.text(safeText.substring(cursor)));
+    }
+    return segments;
+  }
+
+  private static List<J2clInlineReplyAnchor> validInlineReplyAnchors(
+      String safeText, List<J2clInlineReplyAnchor> anchors) {
+    if (anchors == null || anchors.isEmpty()) {
+      return Collections.emptyList();
+    }
+    List<J2clInlineReplyAnchor> valid = new ArrayList<J2clInlineReplyAnchor>();
+    for (J2clInlineReplyAnchor anchor : anchors) {
+      if (anchor == null || anchor.getThreadId().isEmpty()) {
+        continue;
+      }
+      valid.add(anchor);
+    }
+    Collections.sort(
+        valid,
+        new Comparator<J2clInlineReplyAnchor>() {
+          @Override
+          public int compare(J2clInlineReplyAnchor left, J2clInlineReplyAnchor right) {
+            int offsetCompare =
+                normalizedAnchorOffset(safeText, left) - normalizedAnchorOffset(safeText, right);
+            if (offsetCompare != 0) {
+              return offsetCompare;
+            }
+            return 0;
+          }
+        });
+    return valid;
+  }
+
+  private static int normalizedAnchorOffset(String safeText, J2clInlineReplyAnchor anchor) {
+    int length = safeText == null ? 0 : safeText.length();
+    if (anchor == null) {
+      return 0;
+    }
+    return Math.max(0, Math.min(length, anchor.getTextOffset()));
+  }
+
+  private static HTMLElement renderInlineReplyAnchor(InlineAnchorTextSegment segment) {
+    HTMLElement marker = (HTMLElement) DomGlobal.document.createElement("span");
+    marker.className = "j2cl-inline-reply-anchor";
+    marker.setAttribute("data-inline-reply-anchor", "true");
+    marker.setAttribute("data-inline-reply-anchor-thread-id", segment.getThreadId());
+    marker.setAttribute(
+        "data-inline-reply-anchor-offset", Integer.toString(segment.getTextOffset()));
+    marker.setAttribute("aria-label", "Inline replies");
+    return marker;
   }
 
   private static String mentionDisplayText(
@@ -1737,23 +1848,69 @@ public final class J2clReadSurfaceDomRenderer {
       String scopedId = !tid.isEmpty() ? (parentBlipId + "::" + tid) : ("inline-" + parentBlipId);
       threadHost.setAttribute("data-thread-id", scopedId);
       threadHost.setAttribute("data-parent-blip-id", parentBlipId);
-      HTMLElement winAnchor = winLastThreadHostByParent.get(parentBlipId);
-      if (winAnchor == null) {
-        winAnchor = parentHost;
-      }
-      if (winAnchor.parentNode != null) {
-        if (winAnchor.nextSibling != null) {
-          winAnchor.parentNode.insertBefore(threadHost, winAnchor.nextSibling);
-        } else {
-          winAnchor.parentNode.appendChild(threadHost);
-        }
-      } else {
-        parentHost.appendChild(threadHost);
-      }
+      mountInlineThreadHost(
+          parentHost, threadHost, parentBlipId, tid, winLastThreadHostByParent);
       winThreadHostsByKey.put(threadKey, threadHost);
-      winLastThreadHostByParent.put(parentBlipId, threadHost);
     }
     return threadHost;
+  }
+
+  private static void mountInlineThreadHost(
+      HTMLElement parentBlipHost,
+      HTMLElement threadHost,
+      String parentBlipId,
+      String threadId,
+      Map<String, HTMLElement> lastThreadHostByParent) {
+    HTMLElement inlineAnchor = inlineReplyAnchorHost(parentBlipHost, threadId);
+    if (inlineAnchor != null) {
+      threadHost.setAttribute("data-inline-reply-anchor-thread-id", threadId);
+      threadHost.setAttribute("data-inline-reply-anchor-placement", "inline");
+      inlineAnchor.appendChild(threadHost);
+      return;
+    }
+
+    threadHost.removeAttribute("data-inline-reply-anchor-thread-id");
+    threadHost.removeAttribute("data-inline-reply-anchor-placement");
+    // review-1089 round-2/4: fallback reply threads stay as siblings
+    // after the parent <wave-blip>, ordered after any previous fallback
+    // thread for the same parent. Anchored threads live inside their text
+    // marker and intentionally do not advance this fallback insertion point.
+    HTMLElement anchor = lastThreadHostByParent.get(parentBlipId);
+    if (anchor == null) {
+      anchor = parentBlipHost;
+    }
+    if (anchor != null && anchor.parentNode != null) {
+      if (anchor.nextSibling != null) {
+        anchor.parentNode.insertBefore(threadHost, anchor.nextSibling);
+      } else {
+        anchor.parentNode.appendChild(threadHost);
+      }
+    } else if (parentBlipHost != null) {
+      // Defensive fallback for a detached parent; keep reply content reachable.
+      parentBlipHost.appendChild(threadHost);
+    }
+    if (parentBlipId != null && !parentBlipId.isEmpty()) {
+      lastThreadHostByParent.put(parentBlipId, threadHost);
+    }
+  }
+
+  private static HTMLElement inlineReplyAnchorHost(HTMLElement parentBlipHost, String threadId) {
+    if (parentBlipHost == null || threadId == null || threadId.isEmpty()) {
+      return null;
+    }
+    HTMLElement content = (HTMLElement) parentBlipHost.querySelector(".j2cl-read-blip-content");
+    if (content == null) {
+      return null;
+    }
+    Element anchor = content.firstElementChild;
+    while (anchor != null) {
+      if (anchor.hasAttribute("data-inline-reply-anchor-thread-id")
+          && threadId.equals(anchor.getAttribute("data-inline-reply-anchor-thread-id"))) {
+        return (HTMLElement) anchor;
+      }
+      anchor = anchor.nextElementSibling;
+    }
+    return null;
   }
 
   private HTMLElement renderPlaceholder(J2clReadWindowEntry entry) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1953,15 +1953,19 @@ public final class J2clReadSurfaceDomRenderer {
     if (content == null) {
       return null;
     }
+    HTMLElement found = null;
     Element anchor = content.firstElementChild;
     while (anchor != null) {
       if (anchor.hasAttribute("data-inline-reply-anchor-thread-id")
           && threadId.equals(anchor.getAttribute("data-inline-reply-anchor-thread-id"))) {
-        return (HTMLElement) anchor;
+        if (found != null) {
+          return null; // duplicate marker — treat as malformed, use fallback placement
+        }
+        found = (HTMLElement) anchor;
       }
       anchor = anchor.nextElementSibling;
     }
-    return null;
+    return found;
   }
 
   private HTMLElement renderPlaceholder(J2clReadWindowEntry entry) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -432,6 +432,62 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void renderFallsBackWhenDuplicateInlineReplyAnchorsExistForSameThread() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    // Two anchors with the same threadId — malformed; thread must use sibling fallback.
+    J2clReadBlip root =
+        new J2clReadBlip(
+            "b+root",
+            "A B C",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "Alice",
+            1714240000000L,
+            "",
+            "",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false,
+            /* taskDone= */ false,
+            /* taskAssignee= */ "",
+            /* taskDueTimestamp= */ 0L,
+            /* bodyItemCount= */ 5,
+            /* isTask= */ false,
+            Arrays.asList(
+                new J2clInlineReplyAnchor("t+dup", 2),
+                new J2clInlineReplyAnchor("t+dup", 4)));
+    J2clReadBlip reply =
+        new J2clReadBlip(
+            "b+reply",
+            "Dup reply",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "bob@example.com",
+            "Bob",
+            1714240100000L,
+            "b+root",
+            "t+dup",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false);
+
+    Assert.assertTrue(
+        renderer.render(Arrays.asList(root, reply), Collections.<String>emptyList()));
+
+    HTMLElement fallbackThread =
+        (HTMLElement) host.querySelector(".inline-thread[data-parent-blip-id='b+root']");
+    Assert.assertNotNull(fallbackThread);
+    Assert.assertFalse(
+        "Duplicate-anchor thread must not be placed inline",
+        fallbackThread.hasAttribute("data-inline-reply-anchor-placement"));
+    Assert.assertSame(
+        "Duplicate-anchor thread must mount as sibling-after-parent",
+        blip(host, "b+root").nextSibling,
+        fallbackThread);
+  }
+
+  @Test
   public void renderPlacesMultipleAnchoredThreadsInTextOffsetOrder() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -390,8 +390,11 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertNotNull(anchor);
     HTMLElement thread =
         (HTMLElement)
-            anchor.querySelector(".inline-thread[data-inline-reply-anchor-thread-id='t+inline']");
+            blip(host, "b+root")
+                .querySelector(".inline-thread[data-inline-reply-anchor-thread-id='t+inline']");
     Assert.assertNotNull(thread);
+    Assert.assertEquals("blip-extension", thread.getAttribute("slot"));
+    Assert.assertEquals(blip(host, "b+root"), thread.parentElement);
     Assert.assertEquals(
         "b+reply",
         thread.querySelector("[data-blip-id]").getAttribute("data-blip-id"));
@@ -1883,8 +1886,12 @@ public class J2clReadSurfaceDomRendererTest {
             blip(host, "b+root")
                 .querySelector("[data-inline-reply-anchor-thread-id='t+inline']");
     Assert.assertNotNull(anchor);
-    Assert.assertNotNull(
-        anchor.querySelector(".inline-thread[data-inline-reply-anchor-thread-id='t+inline']"));
+    HTMLElement thread =
+        (HTMLElement)
+            blip(host, "b+root")
+                .querySelector(".inline-thread[data-inline-reply-anchor-thread-id='t+inline']");
+    Assert.assertNotNull(thread);
+    Assert.assertEquals("blip-extension", thread.getAttribute("slot"));
     Assert.assertEquals("reply", blip(host, "b+reply").getAttribute("data-blip-depth"));
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -432,6 +432,88 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void renderPlacesMultipleAnchoredThreadsInTextOffsetOrder() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clReadBlip root =
+        new J2clReadBlip(
+            "b+root",
+            "A B C",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "Alice",
+            1714240000000L,
+            "",
+            "",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false,
+            /* taskDone= */ false,
+            /* taskAssignee= */ "",
+            /* taskDueTimestamp= */ 0L,
+            /* bodyItemCount= */ 12,
+            /* isTask= */ false,
+            Arrays.asList(
+                new J2clInlineReplyAnchor("t+first", 2),
+                new J2clInlineReplyAnchor("t+second", 4)));
+    // Arrive in reverse order so naive append would place t+second before t+first.
+    J2clReadBlip replySecond =
+        new J2clReadBlip(
+            "b+second",
+            "Second reply",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "bob@example.com",
+            "Bob",
+            1714240200000L,
+            "b+root",
+            "t+second",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false);
+    J2clReadBlip replyFirst =
+        new J2clReadBlip(
+            "b+first",
+            "First reply",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "carol@example.com",
+            "Carol",
+            1714240100000L,
+            "b+root",
+            "t+first",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false);
+
+    Assert.assertTrue(
+        renderer.render(
+            Arrays.asList(root, replySecond, replyFirst), Collections.<String>emptyList()));
+
+    HTMLElement rootBlip = blip(host, "b+root");
+    HTMLElement firstThread =
+        (HTMLElement) rootBlip.querySelector(".inline-thread[data-inline-reply-anchor-thread-id='t+first']");
+    HTMLElement secondThread =
+        (HTMLElement) rootBlip.querySelector(".inline-thread[data-inline-reply-anchor-thread-id='t+second']");
+    Assert.assertNotNull(firstThread);
+    Assert.assertNotNull(secondThread);
+    // firstThread (offset 2) must appear before secondThread (offset 4) in DOM order.
+    int firstIdx = -1, secondIdx = -1, idx = 0;
+    Element child = rootBlip.firstElementChild;
+    while (child != null) {
+      if (child == firstThread) {
+        firstIdx = idx;
+      }
+      if (child == secondThread) {
+        secondIdx = idx;
+      }
+      idx++;
+      child = child.nextElementSibling;
+    }
+    Assert.assertTrue("t+first thread must precede t+second in DOM", firstIdx < secondIdx);
+    Assert.assertTrue("both threads must be children of rootBlip", firstIdx >= 0 && secondIdx >= 0);
+  }
+
+  @Test
   public void renderOmitsTaskAttributesWhenOpen() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -324,6 +324,111 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void inlineReplyAnchorSegmentsPreserveTextOrderAndSkipInvalidAnchors() {
+    List<J2clReadSurfaceDomRenderer.InlineAnchorTextSegment> segments =
+        J2clReadSurfaceDomRenderer.inlineAnchorTextSegmentsForTest(
+            "Before middle after",
+            Arrays.asList(
+                new J2clInlineReplyAnchor("t+middle", "Before ".length()),
+                new J2clInlineReplyAnchor("", 3),
+                null,
+                new J2clInlineReplyAnchor("t+end", "Before middle ".length())));
+
+    Assert.assertEquals(5, segments.size());
+    Assert.assertEquals("Before ", segments.get(0).getText());
+    Assert.assertEquals("t+middle", segments.get(1).getThreadId());
+    Assert.assertEquals("middle ", segments.get(2).getText());
+    Assert.assertEquals("t+end", segments.get(3).getThreadId());
+    Assert.assertEquals("after", segments.get(4).getText());
+  }
+
+  @Test
+  public void renderPlacesMatchingThreadAtInlineReplyAnchor() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clReadBlip root =
+        new J2clReadBlip(
+            "b+root",
+            "Before after",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "Alice",
+            1714240000000L,
+            "",
+            "",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false,
+            /* taskDone= */ false,
+            /* taskAssignee= */ "",
+            /* taskDueTimestamp= */ 0L,
+            /* bodyItemCount= */ 12,
+            /* isTask= */ false,
+            Arrays.asList(new J2clInlineReplyAnchor("t+inline", "Before ".length())));
+    J2clReadBlip reply =
+        new J2clReadBlip(
+            "b+reply",
+            "Inline reply",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "bob@example.com",
+            "Bob",
+            1714240100000L,
+            "b+root",
+            "t+inline",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false);
+
+    Assert.assertTrue(
+        renderer.render(Arrays.asList(root, reply), Collections.<String>emptyList()));
+
+    HTMLElement anchor =
+        (HTMLElement)
+            blip(host, "b+root")
+                .querySelector("[data-inline-reply-anchor-thread-id='t+inline']");
+    Assert.assertNotNull(anchor);
+    HTMLElement thread =
+        (HTMLElement)
+            anchor.querySelector(".inline-thread[data-inline-reply-anchor-thread-id='t+inline']");
+    Assert.assertNotNull(thread);
+    Assert.assertEquals(
+        "b+reply",
+        thread.querySelector("[data-blip-id]").getAttribute("data-blip-id"));
+    Assert.assertEquals("1", blip(host, "b+root").getAttribute("reply-count"));
+  }
+
+  @Test
+  public void renderFallsBackWhenThreadHasNoMatchingInlineReplyAnchor() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clReadBlip root = new J2clReadBlip("b+root", "Root");
+    J2clReadBlip reply =
+        new J2clReadBlip(
+            "b+reply",
+            "Detached reply",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "bob@example.com",
+            "Bob",
+            1714240100000L,
+            "b+root",
+            "t+missing",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false);
+
+    Assert.assertTrue(
+        renderer.render(Arrays.asList(root, reply), Collections.<String>emptyList()));
+
+    HTMLElement fallbackThread =
+        (HTMLElement) host.querySelector(".inline-thread[data-parent-blip-id='b+root']");
+    Assert.assertNotNull(fallbackThread);
+    Assert.assertFalse(fallbackThread.hasAttribute("data-inline-reply-anchor-thread-id"));
+    Assert.assertSame(blip(host, "b+root").nextSibling, fallbackThread);
+  }
+
+  @Test
   public void renderOmitsTaskAttributesWhenOpen() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();
@@ -1722,6 +1827,65 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertEquals(
         Arrays.asList("b+root", "b+second", "b+nested", "b+third"),
         blipIds(host));
+  }
+
+  @Test
+  public void renderWindowPlacesMatchingThreadAtInlineReplyAnchor() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clReadWindowEntry root =
+        J2clReadWindowEntry.loadedWithTaskMetadata(
+            "blip:b+root",
+            0L,
+            12L,
+            "b+root",
+            "Before after",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "Alice",
+            1714240000000L,
+            "",
+            "t+root",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* taskDone= */ false,
+            /* taskAssignee= */ "",
+            /* taskDueTimestamp= */ 0L,
+            /* bodyItemCount= */ 12,
+            /* isTask= */ false,
+            Arrays.asList(new J2clInlineReplyAnchor("t+inline", "Before ".length())));
+    J2clReadWindowEntry reply =
+        J2clReadWindowEntry.loadedWithTaskMetadata(
+            "blip:b+reply",
+            12L,
+            24L,
+            "b+reply",
+            "Inline reply",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "bob@example.com",
+            "Bob",
+            1714240100000L,
+            "b+root",
+            "t+inline",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* taskDone= */ false,
+            /* taskAssignee= */ "",
+            /* taskDueTimestamp= */ 0L,
+            /* bodyItemCount= */ 12,
+            /* isTask= */ false);
+
+    Assert.assertTrue(renderer.renderWindow(Arrays.asList(root, reply)));
+
+    HTMLElement anchor =
+        (HTMLElement)
+            blip(host, "b+root")
+                .querySelector("[data-inline-reply-anchor-thread-id='t+inline']");
+    Assert.assertNotNull(anchor);
+    Assert.assertNotNull(
+        anchor.querySelector(".inline-thread[data-inline-reply-anchor-thread-id='t+inline']"));
+    Assert.assertEquals("reply", blip(host, "b+reply").getAttribute("data-blip-depth"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -1320,6 +1320,66 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void renderBlipTextRendersInlineAnchorSpansEvenWhenMentionsArePresent() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    renderer.setMentionBinder(
+        blipId ->
+            "b+root".equals(blipId)
+                ? Arrays.asList(new J2clMentionRange(3, 9, "alice@example.com", "@Alice"))
+                : Collections.<J2clMentionRange>emptyList());
+
+    J2clReadBlip root =
+        new J2clReadBlip(
+            "b+root",
+            "Hi @Alice reply here",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "Alice",
+            1714240000000L,
+            "",
+            "",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false,
+            /* taskDone= */ false,
+            /* taskAssignee= */ "",
+            /* taskDueTimestamp= */ 0L,
+            /* bodyItemCount= */ 20,
+            /* isTask= */ false,
+            Arrays.asList(new J2clInlineReplyAnchor("t+inline", 10)));
+    J2clReadBlip reply =
+        new J2clReadBlip(
+            "b+reply",
+            "Inline reply",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "bob@example.com",
+            "Bob",
+            1714240100000L,
+            "b+root",
+            "t+inline",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false);
+
+    renderer.render(Arrays.asList(root, reply), Collections.<String>emptyList());
+
+    HTMLElement blipEl = blip(host, "b+root");
+    HTMLElement anchor =
+        (HTMLElement) blipEl.querySelector("[data-inline-reply-anchor-thread-id='t+inline']");
+    Assert.assertNotNull(
+        "Inline anchor span must be present even when blip has mentions", anchor);
+    Assert.assertNotNull(
+        "Mention chip must still render alongside anchor",
+        blipEl.querySelector("[data-j2cl-read-mention='true']"));
+    HTMLElement thread =
+        (HTMLElement) blipEl.querySelector(".inline-thread[data-inline-reply-anchor-thread-id='t+inline']");
+    Assert.assertNotNull("Anchored thread must be mounted on parent blip", thread);
+    Assert.assertEquals("blip-extension", thread.getAttribute("slot"));
+  }
+
+  @Test
   public void openAndDownloadLinksEmitClickTelemetry() {
     assumeBrowserDom();
     RecordingTelemetrySink telemetry = new RecordingTelemetrySink();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -1380,6 +1380,122 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void renderBlipTextRendersInlineAnchorAtMentionStartBoundary() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    // Mention starts at offset 3; anchor is also at offset 3 (mention-start boundary).
+    renderer.setMentionBinder(
+        blipId ->
+            "b+root".equals(blipId)
+                ? Arrays.asList(new J2clMentionRange(3, 9, "alice@example.com", "@Alice"))
+                : Collections.<J2clMentionRange>emptyList());
+
+    J2clReadBlip root =
+        new J2clReadBlip(
+            "b+root",
+            "Hi @Alice reply",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "Alice",
+            1714240000000L,
+            "",
+            "",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false,
+            /* taskDone= */ false,
+            /* taskAssignee= */ "",
+            /* taskDueTimestamp= */ 0L,
+            /* bodyItemCount= */ 15,
+            /* isTask= */ false,
+            Arrays.asList(new J2clInlineReplyAnchor("t+boundary", 3)));
+    J2clReadBlip reply =
+        new J2clReadBlip(
+            "b+reply",
+            "Boundary reply",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "bob@example.com",
+            "Bob",
+            1714240100000L,
+            "b+root",
+            "t+boundary",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false);
+
+    renderer.render(Arrays.asList(root, reply), Collections.<String>emptyList());
+
+    HTMLElement blipEl = blip(host, "b+root");
+    HTMLElement anchor =
+        (HTMLElement) blipEl.querySelector("[data-inline-reply-anchor-thread-id='t+boundary']");
+    Assert.assertNotNull(
+        "Anchor at mention-start offset must be rendered even when mention occupies same position",
+        anchor);
+    Assert.assertNotNull(
+        "Mention chip must still render alongside anchor at its start offset",
+        blipEl.querySelector("[data-j2cl-read-mention='true']"));
+  }
+
+  @Test
+  public void renderBlipTextRendersInlineAnchorAtEndOfTextWithMentions() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    // "Hello @Al" length=9; mention covers [6,9]; anchor at offset 9 (end of text).
+    renderer.setMentionBinder(
+        blipId ->
+            "b+root".equals(blipId)
+                ? Arrays.asList(new J2clMentionRange(6, 9, "alice@example.com", "@Al"))
+                : Collections.<J2clMentionRange>emptyList());
+
+    J2clReadBlip root =
+        new J2clReadBlip(
+            "b+root",
+            "Hello @Al",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "Alice",
+            1714240000000L,
+            "",
+            "",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false,
+            /* taskDone= */ false,
+            /* taskAssignee= */ "",
+            /* taskDueTimestamp= */ 0L,
+            /* bodyItemCount= */ 9,
+            /* isTask= */ false,
+            Arrays.asList(new J2clInlineReplyAnchor("t+eot", 9)));
+    J2clReadBlip reply =
+        new J2clReadBlip(
+            "b+reply",
+            "End-of-text reply",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "bob@example.com",
+            "Bob",
+            1714240100000L,
+            "b+root",
+            "t+eot",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* deleted= */ false);
+
+    renderer.render(Arrays.asList(root, reply), Collections.<String>emptyList());
+
+    HTMLElement blipEl = blip(host, "b+root");
+    HTMLElement anchor =
+        (HTMLElement) blipEl.querySelector("[data-inline-reply-anchor-thread-id='t+eot']");
+    Assert.assertNotNull(
+        "Anchor at end-of-text offset must be rendered even when all text is consumed by mentions",
+        anchor);
+    Assert.assertNotNull(
+        "Mention chip must still render alongside end-of-text anchor",
+        blipEl.querySelector("[data-j2cl-read-mention='true']"));
+  }
+
+  @Test
   public void openAndDownloadLinksEmitClickTelemetry() {
     assumeBrowserDom();
     RecordingTelemetrySink telemetry = new RecordingTelemetrySink();

--- a/wave/config/changelog.d/2026-05-01-j2cl-inline-placement-parity.json
+++ b/wave/config/changelog.d/2026-05-01-j2cl-inline-placement-parity.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-01-j2cl-inline-placement-parity",
+  "version": "Issue #1167",
+  "date": "2026-05-01",
+  "title": "J2CL inline reply placement parity",
+  "summary": "J2CL now places reply threads at inline reply anchors when anchor metadata is available.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Render inline reply anchor mount points in plain-text blips and attach matching child threads at those anchors instead of always below the whole blip.",
+        "Keep malformed or unanchored reply threads visible through the existing sibling fallback placement."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Render inline reply anchor placeholders inside plain-text J2CL blip content.
- Mount matching child thread hosts at those anchors for both flat and viewport-window rendering.
- Preserve the existing sibling fallback for unanchored/malformed threads and keep reply-count/collapse metadata intact.

## Verification
- RED first: `sbt --batch j2clSearchTest` failed before implementation with missing `InlineAnchorTextSegment` / `inlineAnchorTextSegmentsForTest` symbols.
- `sbt --batch j2clSearchTest` passed after implementation.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json && git diff --check && sbt --batch compile Test/compile j2clSearchTest j2clLitTest` passed after self-review tweak.

Closes #1167
Part of #904


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline reply anchoring: reply threads can be mounted at placeholder anchors within blip text in both normal and windowed rendering; unmatched/malformed replies fall back to sibling placement. Existing collapse/toggle, reply-count, focus and scroll behaviors preserved.

* **Tests**
  * Added DOM and rendering tests for anchor matching, fallback placement, ordering by text offset, mention interactions, and window-render parity.

* **Documentation**
  * Added implementation plan and changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->