### PR TITLE
fix(ci): surface deploy notification failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,7 @@ jobs:
           bash scripts/ci-validate-deploy-healthcheck.sh
           python3 -m unittest scripts.tests.test_doc_guardrails -v
           python3 -m unittest scripts.tests.test_deploy_sanity_gate -v
+          python3 -m unittest scripts.tests.test_send_resend_email -v
           python3 -m unittest scripts.tests.test_deploy_overlap_safety -v
           python3 -m unittest scripts.tests.test_repair_corrupted_waves -v
           WAVE_IMAGE_BLUE=ghcr.io/example/wave:test \

--- a/.github/workflows/deploy-contabo.yml
+++ b/.github/workflows/deploy-contabo.yml
@@ -456,84 +456,131 @@ jobs:
           echo "$CHANGELOG_HTML" > /tmp/changelog_html.txt
 
       - name: Notify deploy success
+        id: notify_success
         if: always() && steps.deploy.outcome == 'success' && (github.event_name == 'push' || github.event.inputs.action == 'deploy')
         env:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           WAVE_EMAIL_FROM: ${{ secrets.WAVE_EMAIL_FROM }}
           NOTIFICATION_RECIPIENTS: ${{ vars.NOTIFICATION_RECIPIENTS || secrets.ON_CALL_EMAILS || 'vega113@gmail.com' }}
         run: |
+          set -euo pipefail
           CHANGELOG_HTML=$(cat /tmp/changelog_html.txt 2>/dev/null || true)
           EMAIL_SUBJECT="SupaWave deployed: ${RELEASE_ID:0:8}"
           EMAIL_HTML="<h2>Deploy succeeded</h2><table><tr><td>Commit</td><td><code>${RELEASE_ID:0:8}</code></td></tr><tr><td>Branch</td><td><code>${GITHUB_REF_NAME}</code></td></tr><tr><td>Image</td><td><code>$IMAGE_REF</code></td></tr><tr><td>Host</td><td>$CANONICAL_HOST</td></tr><tr><td>Run</td><td><a href='https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID'>View run</a></td></tr></table>${CHANGELOG_HTML}"
-          recipients_json=$(python3 - <<'PY'
-          import json
-          import os
-          import sys
-
-          raw = os.getenv("NOTIFICATION_RECIPIENTS", "").strip()
-          if not raw:
-              print("")
-              sys.exit(0)
-
-          if raw.startswith("["):
-              try:
-                  recipients = [item.strip() for item in json.loads(raw) if isinstance(item, str) and item.strip()]
-                  print(json.dumps(recipients))
-                  sys.exit(0)
-              except Exception:
-                  pass
-
-          recipients = [item.strip() for item in raw.split(",") if item.strip()]
-          print(json.dumps(recipients))
-          PY
-          )
-          if [ -z "$recipients_json" ] || [ "$recipients_json" = "[]" ]; then
-            echo "No deploy notification recipients configured; skipping email notification."
-            exit 0
-          fi
-          PAYLOAD=$(WAVE_EMAIL_FROM_VALUE="${WAVE_EMAIL_FROM:-noreply@supawave.ai}" RECIPIENTS_JSON="$recipients_json" EMAIL_SUBJECT="$EMAIL_SUBJECT" EMAIL_HTML="$EMAIL_HTML" python3 -c 'import json, os; print(json.dumps({"from": os.environ["WAVE_EMAIL_FROM_VALUE"], "to": json.loads(os.environ["RECIPIENTS_JSON"]), "subject": os.environ["EMAIL_SUBJECT"], "html": os.environ["EMAIL_HTML"]}))')
-          RESPONSE=$(curl -s --fail-with-body -X POST https://api.resend.com/emails \
-            -H "Authorization: Bearer $RESEND_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD") || echo "Email notification failed (non-blocking): $RESPONSE"
+          python3 scripts/deployment/send_resend_email.py \
+            --label "Deploy success" \
+            --subject "$EMAIL_SUBJECT" \
+            --html "$EMAIL_HTML"
 
       - name: Notify deploy failure
-        if: always() && failure() && !cancelled() && (github.event_name == 'push' || github.event.inputs.action == 'deploy')
+        id: notify_failure
+        if: always() && failure() && steps.deploy.outcome != 'success' && !cancelled() && (github.event_name == 'push' || github.event.inputs.action == 'deploy')
         env:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           WAVE_EMAIL_FROM: ${{ secrets.WAVE_EMAIL_FROM }}
           NOTIFICATION_RECIPIENTS: ${{ vars.NOTIFICATION_RECIPIENTS || secrets.ON_CALL_EMAILS || 'vega113@gmail.com' }}
         run: |
+          set -euo pipefail
           EMAIL_SUBJECT="SupaWave deploy FAILED: ${RELEASE_ID:0:8}"
           EMAIL_HTML="<h2>Deploy failed</h2><p>The production deploy failed and the previous version is still running.</p><table><tr><td>Commit</td><td><code>${RELEASE_ID:0:8}</code></td></tr><tr><td>Branch</td><td><code>${GITHUB_REF_NAME}</code></td></tr><tr><td>Image</td><td><code>$IMAGE_REF</code></td></tr><tr><td>Host</td><td>$CANONICAL_HOST</td></tr><tr><td>Logs</td><td><a href='https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID'>View full logs</a></td></tr></table><p><strong>Next steps:</strong> Check the deploy logs linked above. Previous version is auto-preserved.</p>"
-          recipients_json=$(python3 - <<'PY'
-          import json
-          import os
-          import sys
+          python3 scripts/deployment/send_resend_email.py \
+            --label "Deploy failure" \
+            --subject "$EMAIL_SUBJECT" \
+            --html "$EMAIL_HTML"
 
-          raw = os.getenv("NOTIFICATION_RECIPIENTS", "").strip()
-          if not raw:
-              print("")
-              sys.exit(0)
+      - name: Close deploy-notification-failure issues on notification success
+        if: >-
+          always() &&
+          (steps.notify_success.outcome == 'success' || steps.notify_failure.outcome == 'success') &&
+          (github.event_name == 'push' || github.event.inputs.action == 'deploy')
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'deploy-notification-failure',
+              state: 'open'
+            });
+            for (const issue of issues.filter(i => !i.pull_request)) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Resolved by successful deploy notification delivery for ${context.sha.substring(0, 8)} in [run ${context.runId}](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed'
+              });
+            }
 
-          if raw.startswith("["):
-              try:
-                  recipients = [item.strip() for item in json.loads(raw) if isinstance(item, str) and item.strip()]
-                  print(json.dumps(recipients))
-                  sys.exit(0)
-              except Exception:
-                  pass
+      - name: Create GitHub issue on deploy notification failure
+        continue-on-error: true
+        if: >-
+          always() &&
+          (steps.notify_success.outcome == 'failure' || steps.notify_failure.outcome == 'failure') &&
+          (github.event_name == 'push' || github.event.inputs.action == 'deploy')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = 'deploy-notification-failure';
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label
+              });
+            } catch (e) {
+              if (e.status !== 404) {
+                throw e;
+              }
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+                color: 'f97316',
+                description: 'Automated: deploy notification email failed'
+              });
+            }
 
-          recipients = [item.strip() for item in raw.split(",") if item.strip()]
-          print(json.dumps(recipients))
-          PY
-          )
-          if [ -z "$recipients_json" ] || [ "$recipients_json" = "[]" ]; then
-            echo "No deploy notification recipients configured; skipping email notification."
-            exit 0
-          fi
-          PAYLOAD=$(WAVE_EMAIL_FROM_VALUE="${WAVE_EMAIL_FROM:-noreply@supawave.ai}" RECIPIENTS_JSON="$recipients_json" EMAIL_SUBJECT="$EMAIL_SUBJECT" EMAIL_HTML="$EMAIL_HTML" python3 -c 'import json, os; print(json.dumps({"from": os.environ["WAVE_EMAIL_FROM_VALUE"], "to": json.loads(os.environ["RECIPIENTS_JSON"]), "subject": os.environ["EMAIL_SUBJECT"], "html": os.environ["EMAIL_HTML"]}))')
-          RESPONSE=$(curl -s --fail-with-body -X POST https://api.resend.com/emails \
-            -H "Authorization: Bearer $RESEND_API_KEY" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD") || echo "Email notification failed (non-blocking): $RESPONSE"
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              `Deploy notification email failed for commit \`${context.sha.substring(0, 8)}\`.`,
+              ``,
+              `**Run:** [${context.runId}](${runUrl})`,
+              `**Branch:** \`${context.ref}\``,
+              `**Success notification outcome:** \`${{ steps.notify_success.outcome }}\``,
+              `**Failure notification outcome:** \`${{ steps.notify_failure.outcome }}\``,
+              ``,
+              `Check the notification step log for the Resend HTTP error or delivery response.`
+            ].join('\n');
+
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: label,
+              state: 'open'
+            });
+            const existingIssue = existing.find(issue => !issue.pull_request);
+            if (existingIssue) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existingIssue.number,
+                body
+              });
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Deploy notification email failed: ${context.sha.substring(0, 8)}`,
+              body,
+              labels: [label, 'agent-task']
+            });

--- a/scripts/deployment/send_resend_email.py
+++ b/scripts/deployment/send_resend_email.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Send a deploy notification email through Resend."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from urllib.parse import urlparse
+
+
+DEFAULT_FROM = "SupaWave Deploy <noreply@supawave.ai>"
+DEFAULT_API_URL = "https://api.resend.com/emails"
+
+
+def parse_recipients(raw: str) -> list[str]:
+  raw = raw.strip()
+  if not raw:
+    return []
+  if raw.startswith("["):
+    try:
+      parsed = json.loads(raw)
+    except json.JSONDecodeError:
+      parsed = None
+    if isinstance(parsed, list):
+      return [item.strip() for item in parsed if isinstance(item, str) and item.strip()]
+  return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def build_payload(sender: str, recipients: list[str], subject: str, html: str) -> bytes:
+  return json.dumps(
+      {
+          "from": sender,
+          "to": recipients,
+          "subject": subject,
+          "html": html,
+      }
+  ).encode("utf-8")
+
+
+def send_resend_email(
+    *,
+    api_key: str,
+    api_url: str,
+    sender: str,
+    recipients: list[str],
+    subject: str,
+    html: str,
+) -> dict[str, object]:
+  parsed = urlparse(api_url)
+  if parsed.scheme != "https" or parsed.netloc != "api.resend.com":
+    raise RuntimeError(f"Unsupported Resend API URL: {api_url}")
+  request = urllib.request.Request(
+      api_url,
+      data=build_payload(sender, recipients, subject, html),
+      headers={
+          "Authorization": f"Bearer {api_key}",
+          "Content-Type": "application/json",
+      },
+      method="POST",
+  )
+  try:
+    with urllib.request.urlopen(request, timeout=20) as response:
+      body = response.read().decode("utf-8", errors="replace")
+  except urllib.error.HTTPError as exc:
+    body = exc.read().decode("utf-8", errors="replace")
+    raise RuntimeError(f"Resend API returned HTTP {exc.code}: {body}") from exc
+  except urllib.error.URLError as exc:
+    raise RuntimeError(f"Resend API request failed: {exc.reason}") from exc
+
+  try:
+    parsed = json.loads(body)
+  except json.JSONDecodeError as exc:
+    raise RuntimeError(f"Resend API returned non-JSON response: {body}") from exc
+  if not isinstance(parsed, dict):
+    raise RuntimeError(f"Resend API returned unexpected response: {body}")
+  return parsed
+
+
+def read_html(args: argparse.Namespace) -> str:
+  if args.html_file:
+    with open(args.html_file, encoding="utf-8") as handle:
+      return handle.read()
+  return args.html
+
+
+def main() -> int:
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--subject", required=True)
+  parser.add_argument("--html", default="")
+  parser.add_argument("--html-file")
+  parser.add_argument("--label", default="deploy")
+  args = parser.parse_args()
+
+  api_key = os.getenv("RESEND_API_KEY", "").strip()
+  if not api_key:
+    print("RESEND_API_KEY is not configured; cannot send deploy notification.", file=sys.stderr)
+    return 1
+
+  recipients = parse_recipients(os.getenv("NOTIFICATION_RECIPIENTS", ""))
+  if not recipients:
+    print("No deploy notification recipients configured; skipping email notification.")
+    return 0
+
+  sender = os.getenv("WAVE_EMAIL_FROM", "").strip() or DEFAULT_FROM
+  api_url = os.getenv("RESEND_API_URL", DEFAULT_API_URL).strip() or DEFAULT_API_URL
+  try:
+    response = send_resend_email(
+        api_key=api_key,
+        api_url=api_url,
+        sender=sender,
+        recipients=recipients,
+        subject=args.subject,
+        html=read_html(args),
+    )
+  except RuntimeError as exc:
+    print(f"Email notification failed: {exc}", file=sys.stderr)
+    return 1
+
+  message_id = response.get("id")
+  if message_id:
+    print(
+        f"{args.label} notification sent via Resend: id={message_id} "
+        f"recipients={len(recipients)}"
+    )
+  else:
+    print(
+        f"{args.label} notification accepted by Resend without an id: "
+        f"recipients={len(recipients)} response={json.dumps(response, sort_keys=True)}"
+    )
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/scripts/tests/test_deploy_sanity_gate.py
+++ b/scripts/tests/test_deploy_sanity_gate.py
@@ -103,5 +103,24 @@ esac
     remote_idx = workflow.index("name: Upload bundle")
     self.assertLess(validate_idx, remote_idx)
 
+  def test_deploy_workflow_records_notification_failures(self):
+    workflow = DEPLOY_WORKFLOW.read_text(encoding="utf-8")
+
+    self.assertIn("id: notify_success", workflow)
+    self.assertIn("id: notify_failure", workflow)
+    self.assertIn("failure() && steps.deploy.outcome != 'success'", workflow)
+    self.assertIn("name: Close deploy-notification-failure issues on notification success", workflow)
+    self.assertIn("name: Create GitHub issue on deploy notification failure", workflow)
+    self.assertIn("continue-on-error: true", workflow)
+    self.assertIn("deploy-notification-failure", workflow)
+    self.assertIn("Check the notification step log for the Resend HTTP error", workflow)
+
+  def test_build_workflow_runs_deploy_notification_tests(self):
+    workflow = (REPO_ROOT / ".github" / "workflows" / "build.yml").read_text(
+        encoding="utf-8"
+    )
+
+    self.assertIn("python3 -m unittest scripts.tests.test_send_resend_email -v", workflow)
+
 if __name__ == "__main__":
   unittest.main()

--- a/scripts/tests/test_send_resend_email.py
+++ b/scripts/tests/test_send_resend_email.py
@@ -1,0 +1,144 @@
+import contextlib
+import io
+import json
+import os
+import unittest
+from unittest import mock
+from urllib.error import HTTPError, URLError
+
+from scripts.deployment import send_resend_email
+
+
+class SendResendEmailTest(unittest.TestCase):
+  def test_parse_recipients_accepts_json_array(self):
+    self.assertEqual(
+        ["ops@example.com", "dev@example.com"],
+        send_resend_email.parse_recipients('["ops@example.com", " dev@example.com ", ""]'),
+    )
+
+  def test_parse_recipients_accepts_comma_list(self):
+    self.assertEqual(
+        ["ops@example.com", "dev@example.com"],
+        send_resend_email.parse_recipients("ops@example.com, dev@example.com,"),
+    )
+
+  def test_build_payload_uses_branded_sender_and_html(self):
+    payload = json.loads(
+        send_resend_email.build_payload(
+            "SupaWave Deploy <noreply@supawave.ai>",
+            ["ops@example.com"],
+            "SupaWave deployed: abc123",
+            "<h2>Deploy succeeded</h2>",
+        )
+    )
+
+    self.assertEqual("SupaWave Deploy <noreply@supawave.ai>", payload["from"])
+    self.assertEqual(["ops@example.com"], payload["to"])
+    self.assertEqual("SupaWave deployed: abc123", payload["subject"])
+    self.assertEqual("<h2>Deploy succeeded</h2>", payload["html"])
+
+  def test_send_resend_email_returns_message_id_response(self):
+    response = mock.MagicMock()
+    response.__enter__.return_value.read.return_value = b'{"id":"email_123"}'
+
+    with mock.patch("urllib.request.urlopen", return_value=response) as urlopen:
+      result = send_resend_email.send_resend_email(
+          api_key="test-key",
+          api_url="https://api.resend.com/emails",
+          sender="SupaWave Deploy <noreply@supawave.ai>",
+          recipients=["ops@example.com"],
+          subject="subject",
+          html="<p>body</p>",
+      )
+
+    self.assertEqual({"id": "email_123"}, result)
+    request = urlopen.call_args.args[0]
+    self.assertEqual("Bearer test-key", request.headers["Authorization"])
+
+  def test_send_resend_email_rejects_non_resend_url_before_request(self):
+    with mock.patch("urllib.request.urlopen") as urlopen:
+      with self.assertRaisesRegex(RuntimeError, "Unsupported Resend API URL"):
+        send_resend_email.send_resend_email(
+            api_key="test-key",
+            api_url="https://example.com/emails",
+            sender="SupaWave Deploy <noreply@supawave.ai>",
+            recipients=["ops@example.com"],
+            subject="subject",
+            html="<p>body</p>",
+        )
+
+    urlopen.assert_not_called()
+
+  def test_send_resend_email_reports_http_body_on_failure(self):
+    error = HTTPError(
+        "https://api.resend.com/emails",
+        403,
+        "Forbidden",
+        hdrs=None,
+        fp=mock.MagicMock(read=mock.MagicMock(return_value=b'{"message":"domain not verified"}')),
+    )
+
+    with mock.patch("urllib.request.urlopen", side_effect=error):
+      with self.assertRaisesRegex(RuntimeError, "domain not verified"):
+        send_resend_email.send_resend_email(
+            api_key="test-key",
+            api_url="https://api.resend.com/emails",
+            sender="noreply@supawave.ai",
+            recipients=["ops@example.com"],
+            subject="subject",
+            html="<p>body</p>",
+        )
+
+  def test_send_resend_email_reports_network_failure(self):
+    with mock.patch("urllib.request.urlopen", side_effect=URLError("timeout")):
+      with self.assertRaisesRegex(RuntimeError, "timeout"):
+        send_resend_email.send_resend_email(
+            api_key="test-key",
+            api_url="https://api.resend.com/emails",
+            sender="noreply@supawave.ai",
+            recipients=["ops@example.com"],
+            subject="subject",
+            html="<p>body</p>",
+        )
+
+  def test_main_fails_when_api_key_missing(self):
+    with mock.patch.dict(os.environ, {"NOTIFICATION_RECIPIENTS": "ops@example.com"}, clear=True):
+      with mock.patch("sys.argv", ["send_resend_email.py", "--subject", "subject", "--html", "<p>body</p>"]):
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+          result = send_resend_email.main()
+
+    self.assertEqual(1, result)
+    self.assertIn("RESEND_API_KEY is not configured", stderr.getvalue())
+
+  def test_main_skips_empty_recipients(self):
+    with mock.patch.dict(os.environ, {"RESEND_API_KEY": "test-key"}, clear=True):
+      with mock.patch("sys.argv", ["send_resend_email.py", "--subject", "subject", "--html", "<p>body</p>"]):
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+          result = send_resend_email.main()
+
+    self.assertEqual(0, result)
+    self.assertIn("No deploy notification recipients configured", stdout.getvalue())
+
+  def test_main_logs_accepted_response_without_id(self):
+    response = mock.MagicMock()
+    response.__enter__.return_value.read.return_value = b'{"status":"queued"}'
+    env = {
+        "RESEND_API_KEY": "test-key",
+        "NOTIFICATION_RECIPIENTS": "ops@example.com",
+    }
+
+    with mock.patch.dict(os.environ, env, clear=True):
+      with mock.patch("urllib.request.urlopen", return_value=response):
+        with mock.patch("sys.argv", ["send_resend_email.py", "--subject", "subject", "--html", "<p>body</p>"]):
+          stdout = io.StringIO()
+          with contextlib.redirect_stdout(stdout):
+            result = send_resend_email.main()
+
+    self.assertEqual(0, result)
+    self.assertIn("accepted by Resend without an id", stdout.getvalue())
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
## Summary\n- Replace inline deploy Resend shell snippets with a tested Python notification helper.\n- Log Resend message ids on accepted sends and fail with the non-secret HTTP/body error when Resend rejects a notification.\n- Create/append a `deploy-notification-failure` issue if a notification step fails, so a successful deploy with broken email is no longer invisible.\n\nFixes #1177\n\n## Verification\n- `python3 -m unittest scripts.tests.test_send_resend_email scripts.tests.test_deploy_sanity_gate`\n- workflow YAML parse with Python `yaml.safe_load`\n- `git diff --check`\n- `python3 -m py_compile scripts/deployment/send_resend_email.py scripts/tests/test_send_resend_email.py scripts/tests/test_deploy_sanity_gate.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment notifications now use a dedicated delivery tool and respect configured recipients for clearer, reliable alerts.
  * Workflow now automatically opens a labeled issue when notification delivery fails and closes related issues when delivery succeeds.

* **Tests**
  * Added unit tests covering recipient parsing, payload building, delivery success/failure behaviors, and CI validation of notification handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->