### PR TITLE
fix(ci): use curl for Resend notifications

### DIFF
--- a/scripts/deployment/send_resend_email.py
+++ b/scripts/deployment/send_resend_email.py
@@ -59,6 +59,7 @@ def send_resend_email(
     result = subprocess.run(
         [
             "curl",
+            "-q",
             "-sS",
             "--fail-with-body",
             "--max-time",

--- a/scripts/deployment/send_resend_email.py
+++ b/scripts/deployment/send_resend_email.py
@@ -52,30 +52,38 @@ def send_resend_email(
   parsed = urlparse(api_url)
   if parsed.scheme != "https" or parsed.netloc != "api.resend.com":
     raise RuntimeError(f"Unsupported Resend API URL: {api_url}")
-  result = subprocess.run(
-      [
-          "curl",
-          "-sS",
-          "--fail-with-body",
-          "--max-time",
-          "20",
-          "-X",
-          "POST",
-          api_url,
-          "-H",
-          f"Authorization: Bearer {api_key}",
-          "-H",
-          "Content-Type: application/json",
-          "-d",
-          build_payload(sender, recipients, subject, html).decode("utf-8"),
-      ],
-      capture_output=True,
-      text=True,
-      check=False,
-  )
+  # Pass the Authorization header via stdin config to keep the API key out of
+  # the process argv (visible via ps/proc on shared runners).
+  curl_config = f'header = "Authorization: Bearer {api_key}"\n'
+  try:
+    result = subprocess.run(
+        [
+            "curl",
+            "-sS",
+            "--fail-with-body",
+            "--max-time",
+            "20",
+            "--config",
+            "-",
+            "-X",
+            "POST",
+            api_url,
+            "-H",
+            "Content-Type: application/json",
+            "-d",
+            build_payload(sender, recipients, subject, html).decode("utf-8"),
+        ],
+        input=curl_config,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+  except (FileNotFoundError, OSError) as exc:
+    raise RuntimeError(f"curl is not available: {exc}") from exc
   body = result.stdout
   if result.returncode != 0:
-    error_detail = body.strip() or result.stderr.strip() or f"curl exited {result.returncode}"
+    parts = [p for p in (body.strip(), result.stderr.strip()) if p]
+    error_detail = " | ".join(parts) if parts else f"curl exited {result.returncode}"
     raise RuntimeError(f"Resend API request failed: {error_detail}")
 
   try:

--- a/scripts/deployment/send_resend_email.py
+++ b/scripts/deployment/send_resend_email.py
@@ -6,9 +6,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
 import sys
-import urllib.error
-import urllib.request
 from urllib.parse import urlparse
 
 
@@ -53,23 +52,31 @@ def send_resend_email(
   parsed = urlparse(api_url)
   if parsed.scheme != "https" or parsed.netloc != "api.resend.com":
     raise RuntimeError(f"Unsupported Resend API URL: {api_url}")
-  request = urllib.request.Request(
-      api_url,
-      data=build_payload(sender, recipients, subject, html),
-      headers={
-          "Authorization": f"Bearer {api_key}",
-          "Content-Type": "application/json",
-      },
-      method="POST",
+  result = subprocess.run(
+      [
+          "curl",
+          "-sS",
+          "--fail-with-body",
+          "--max-time",
+          "20",
+          "-X",
+          "POST",
+          api_url,
+          "-H",
+          f"Authorization: Bearer {api_key}",
+          "-H",
+          "Content-Type: application/json",
+          "-d",
+          build_payload(sender, recipients, subject, html).decode("utf-8"),
+      ],
+      capture_output=True,
+      text=True,
+      check=False,
   )
-  try:
-    with urllib.request.urlopen(request, timeout=20) as response:
-      body = response.read().decode("utf-8", errors="replace")
-  except urllib.error.HTTPError as exc:
-    body = exc.read().decode("utf-8", errors="replace")
-    raise RuntimeError(f"Resend API returned HTTP {exc.code}: {body}") from exc
-  except urllib.error.URLError as exc:
-    raise RuntimeError(f"Resend API request failed: {exc.reason}") from exc
+  body = result.stdout
+  if result.returncode != 0:
+    error_detail = body.strip() or result.stderr.strip() or f"curl exited {result.returncode}"
+    raise RuntimeError(f"Resend API request failed: {error_detail}")
 
   try:
     parsed = json.loads(body)

--- a/scripts/tests/test_send_resend_email.py
+++ b/scripts/tests/test_send_resend_email.py
@@ -4,7 +4,6 @@ import json
 import os
 import unittest
 from unittest import mock
-from urllib.error import HTTPError, URLError
 
 from scripts.deployment import send_resend_email
 
@@ -38,10 +37,9 @@ class SendResendEmailTest(unittest.TestCase):
     self.assertEqual("<h2>Deploy succeeded</h2>", payload["html"])
 
   def test_send_resend_email_returns_message_id_response(self):
-    response = mock.MagicMock()
-    response.__enter__.return_value.read.return_value = b'{"id":"email_123"}'
+    response = mock.MagicMock(returncode=0, stdout='{"id":"email_123"}', stderr="")
 
-    with mock.patch("urllib.request.urlopen", return_value=response) as urlopen:
+    with mock.patch("subprocess.run", return_value=response) as run:
       result = send_resend_email.send_resend_email(
           api_key="test-key",
           api_url="https://api.resend.com/emails",
@@ -52,11 +50,12 @@ class SendResendEmailTest(unittest.TestCase):
       )
 
     self.assertEqual({"id": "email_123"}, result)
-    request = urlopen.call_args.args[0]
-    self.assertEqual("Bearer test-key", request.headers["Authorization"])
+    command = run.call_args.args[0]
+    self.assertEqual("curl", command[0])
+    self.assertIn("Authorization: Bearer test-key", command)
 
   def test_send_resend_email_rejects_non_resend_url_before_request(self):
-    with mock.patch("urllib.request.urlopen") as urlopen:
+    with mock.patch("subprocess.run") as run:
       with self.assertRaisesRegex(RuntimeError, "Unsupported Resend API URL"):
         send_resend_email.send_resend_email(
             api_key="test-key",
@@ -67,18 +66,16 @@ class SendResendEmailTest(unittest.TestCase):
             html="<p>body</p>",
         )
 
-    urlopen.assert_not_called()
+    run.assert_not_called()
 
   def test_send_resend_email_reports_http_body_on_failure(self):
-    error = HTTPError(
-        "https://api.resend.com/emails",
-        403,
-        "Forbidden",
-        hdrs=None,
-        fp=mock.MagicMock(read=mock.MagicMock(return_value=b'{"message":"domain not verified"}')),
+    response = mock.MagicMock(
+        returncode=22,
+        stdout='{"message":"domain not verified"}',
+        stderr="curl: (22) The requested URL returned error: 403",
     )
 
-    with mock.patch("urllib.request.urlopen", side_effect=error):
+    with mock.patch("subprocess.run", return_value=response):
       with self.assertRaisesRegex(RuntimeError, "domain not verified"):
         send_resend_email.send_resend_email(
             api_key="test-key",
@@ -90,7 +87,8 @@ class SendResendEmailTest(unittest.TestCase):
         )
 
   def test_send_resend_email_reports_network_failure(self):
-    with mock.patch("urllib.request.urlopen", side_effect=URLError("timeout")):
+    response = mock.MagicMock(returncode=28, stdout="", stderr="curl: (28) timeout")
+    with mock.patch("subprocess.run", return_value=response):
       with self.assertRaisesRegex(RuntimeError, "timeout"):
         send_resend_email.send_resend_email(
             api_key="test-key",
@@ -122,15 +120,14 @@ class SendResendEmailTest(unittest.TestCase):
     self.assertIn("No deploy notification recipients configured", stdout.getvalue())
 
   def test_main_logs_accepted_response_without_id(self):
-    response = mock.MagicMock()
-    response.__enter__.return_value.read.return_value = b'{"status":"queued"}'
+    response = mock.MagicMock(returncode=0, stdout='{"status":"queued"}', stderr="")
     env = {
         "RESEND_API_KEY": "test-key",
         "NOTIFICATION_RECIPIENTS": "ops@example.com",
     }
 
     with mock.patch.dict(os.environ, env, clear=True):
-      with mock.patch("urllib.request.urlopen", return_value=response):
+      with mock.patch("subprocess.run", return_value=response):
         with mock.patch("sys.argv", ["send_resend_email.py", "--subject", "subject", "--html", "<p>body</p>"]):
           stdout = io.StringIO()
           with contextlib.redirect_stdout(stdout):

--- a/scripts/tests/test_send_resend_email.py
+++ b/scripts/tests/test_send_resend_email.py
@@ -52,7 +52,11 @@ class SendResendEmailTest(unittest.TestCase):
     self.assertEqual({"id": "email_123"}, result)
     command = run.call_args.args[0]
     self.assertEqual("curl", command[0])
-    self.assertIn("Authorization: Bearer test-key", command)
+    # API key must not appear in argv — it is passed via stdin config instead.
+    self.assertNotIn("test-key", " ".join(command))
+    stdin_input = run.call_args.kwargs.get("input", "")
+    self.assertIn("Authorization: Bearer", stdin_input)
+    self.assertIn("test-key", stdin_input)
 
   def test_send_resend_email_rejects_non_resend_url_before_request(self):
     with mock.patch("subprocess.run") as run:
@@ -77,6 +81,36 @@ class SendResendEmailTest(unittest.TestCase):
 
     with mock.patch("subprocess.run", return_value=response):
       with self.assertRaisesRegex(RuntimeError, "domain not verified"):
+        send_resend_email.send_resend_email(
+            api_key="test-key",
+            api_url="https://api.resend.com/emails",
+            sender="noreply@supawave.ai",
+            recipients=["ops@example.com"],
+            subject="subject",
+            html="<p>body</p>",
+        )
+
+  def test_send_resend_email_includes_stderr_in_http_failure(self):
+    response = mock.MagicMock(
+        returncode=22,
+        stdout='{"message":"domain not verified"}',
+        stderr="curl: (22) The requested URL returned error: 403",
+    )
+
+    with mock.patch("subprocess.run", return_value=response):
+      with self.assertRaisesRegex(RuntimeError, r"domain not verified.*curl: \(22\)"):
+        send_resend_email.send_resend_email(
+            api_key="test-key",
+            api_url="https://api.resend.com/emails",
+            sender="noreply@supawave.ai",
+            recipients=["ops@example.com"],
+            subject="subject",
+            html="<p>body</p>",
+        )
+
+  def test_send_resend_email_raises_when_curl_missing(self):
+    with mock.patch("subprocess.run", side_effect=FileNotFoundError("No such file: curl")):
+      with self.assertRaisesRegex(RuntimeError, "curl is not available"):
         send_resend_email.send_resend_email(
             api_key="test-key",
             api_url="https://api.resend.com/emails",


### PR DESCRIPTION
## Summary\n- Switch the deploy notification helper back to curl for the actual Resend POST while keeping the URL allowlist, recipient parsing, response logging, and tests from #1178.\n- This addresses the merge deploy failure where Resend/Cloudflare returned `HTTP 403: error code: 1010` to Python urllib.\n\nFollow-up for #1177 and #1179.\n\n## Verification\n- `python3 -m unittest scripts.tests.test_send_resend_email scripts.tests.test_deploy_sanity_gate`\n- workflow YAML parse for `.github/workflows/deploy-contabo.yml` and `.github/workflows/build.yml`\n- `git diff --check`\n- `python3 -m py_compile scripts/deployment/send_resend_email.py scripts/tests/test_send_resend_email.py`