### PR TITLE
fix(ci): restore deploy email sender default

### DIFF
--- a/scripts/deployment/send_resend_email.py
+++ b/scripts/deployment/send_resend_email.py
@@ -11,7 +11,7 @@ import sys
 from urllib.parse import urlparse
 
 
-DEFAULT_FROM = "SupaWave Deploy <noreply@supawave.ai>"
+DEFAULT_FROM = "noreply@supawave.ai"
 DEFAULT_API_URL = "https://api.resend.com/emails"
 
 

--- a/scripts/tests/test_send_resend_email.py
+++ b/scripts/tests/test_send_resend_email.py
@@ -21,17 +21,17 @@ class SendResendEmailTest(unittest.TestCase):
         send_resend_email.parse_recipients("ops@example.com, dev@example.com,"),
     )
 
-  def test_build_payload_uses_branded_sender_and_html(self):
+  def test_build_payload_uses_sender_and_html(self):
     payload = json.loads(
         send_resend_email.build_payload(
-            "SupaWave Deploy <noreply@supawave.ai>",
+            "noreply@supawave.ai",
             ["ops@example.com"],
             "SupaWave deployed: abc123",
             "<h2>Deploy succeeded</h2>",
         )
     )
 
-    self.assertEqual("SupaWave Deploy <noreply@supawave.ai>", payload["from"])
+    self.assertEqual("noreply@supawave.ai", payload["from"])
     self.assertEqual(["ops@example.com"], payload["to"])
     self.assertEqual("SupaWave deployed: abc123", payload["subject"])
     self.assertEqual("<h2>Deploy succeeded</h2>", payload["html"])
@@ -43,7 +43,7 @@ class SendResendEmailTest(unittest.TestCase):
       result = send_resend_email.send_resend_email(
           api_key="test-key",
           api_url="https://api.resend.com/emails",
-          sender="SupaWave Deploy <noreply@supawave.ai>",
+          sender="noreply@supawave.ai",
           recipients=["ops@example.com"],
           subject="subject",
           html="<p>body</p>",
@@ -64,7 +64,7 @@ class SendResendEmailTest(unittest.TestCase):
         send_resend_email.send_resend_email(
             api_key="test-key",
             api_url="https://example.com/emails",
-            sender="SupaWave Deploy <noreply@supawave.ai>",
+            sender="noreply@supawave.ai",
             recipients=["ops@example.com"],
             subject="subject",
             html="<p>body</p>",


### PR DESCRIPTION
## Summary
- restore the deploy notification fallback sender to bare noreply@supawave.ai
- keep the Resend curl transport, failure visibility, and GitHub fallback issue handling from #1178/#1180
- update notifier tests for the restored sender format

Fixes #1177

## Evidence
- Today's successful Resend send used `SupaWave Deploy <noreply@supawave.ai>` and landed in Gmail Spam.
- Older deploy emails from bare `noreply@supawave.ai` are still visible in Gmail Inbox.
- Resend accepted the message, so this PR targets the repo-side sender-format regression rather than the already-fixed transport failure.

## Verification
- `python3 -m unittest scripts.tests.test_send_resend_email scripts.tests.test_deploy_sanity_gate` => OK, 18 tests
- `git diff --check` => clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the sender email address format in deployment notifications from "SupaWave Deploy <noreply@supawave.ai>" to "noreply@supawave.ai".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->