### PR TITLE
test(j2cl): stabilize inline reply parity selector

### DIFF
--- a/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
+++ b/j2cl/lit/test/wavy-composer-toolbar-actions.test.js
@@ -1,5 +1,6 @@
 import { fixture, expect, html, oneEvent } from "@open-wc/testing";
 import "../src/elements/wavy-composer.js";
+import "../src/elements/wavy-format-toolbar.js";
 import "../src/elements/wavy-link-modal.js";
 
 // J-UI-5 (#1083) — selection-driven toolbar action handlers.
@@ -592,6 +593,48 @@ describe("wavy-composer toolbar action handlers", () => {
 });
 
 describe("wavy-composer reply-submit components payload", () => {
+  it("preserves a real slotted Bold toolbar click in the submit payload", async () => {
+    const el = await fixture(html`
+      <wavy-composer available>
+        <wavy-format-toolbar slot="toolbar"></wavy-format-toolbar>
+      </wavy-composer>
+    `);
+    const body = bodyOf(el);
+    body.textContent = "hello world";
+    selectTextRange(el, body.firstChild, "hello ".length, "hello world".length);
+
+    const toolbar = el.querySelector("wavy-format-toolbar");
+    toolbar.selectionDescriptor = {
+      collapsed: false,
+      activeAnnotations: [],
+      boundingRect: { left: 0, top: 24, width: 60, height: 18 }
+    };
+    await toolbar.updateComplete;
+    toolbar.renderRoot
+      .querySelector('toolbar-button[data-toolbar-action="bold"]')
+      .renderRoot.querySelector("button")
+      .click();
+
+    expect(body.querySelector("strong"), "Bold click must wrap the selected word").to.exist;
+    expect(body.querySelector("strong").textContent).to.equal("world");
+
+    const submitPromise = oneEvent(el, "reply-submit");
+    el._submit();
+    const evt = await submitPromise;
+
+    expect(evt.detail.value).to.equal("hello world");
+    expect(evt.detail.components).to.deep.equal([
+      { type: "text", text: "hello " },
+      {
+        type: "annotated",
+        text: "world",
+        annotationKey: "fontWeight",
+        annotationValue: "bold",
+        annotations: [{ key: "fontWeight", value: "bold" }]
+      }
+    ]);
+  });
+
   it("emits components array with annotated bold run", async () => {
     const el = await fixture(html`<wavy-composer available></wavy-composer>`);
     const body = bodyOf(el);

--- a/wave/config/changelog.d/2026-05-02-j2cl-inline-reply-parity-gate.json
+++ b/wave/config/changelog.d/2026-05-02-j2cl-inline-reply-parity-gate.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-02-j2cl-inline-reply-parity-gate",
+  "version": "PR #1182",
+  "date": "2026-05-02",
+  "title": "J2CL inline reply parity gate stabilization",
+  "summary": "Stabilizes the J2CL inline reply parity coverage so nested reply toolbars no longer mask the compose behavior under test.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Scopes the J2CL inline reply parity test to the outer blip toolbar and adds coverage for slotted Bold toolbar submits."
+      ]
+    }
+  ]
+}

--- a/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
@@ -56,9 +56,15 @@ async function clickReplyOnFirstBlipJ2cl(page: Page) {
   await firstBlip.scrollIntoViewIfNeeded();
   await firstBlip.hover();
   // The Reply button lives inside <wave-blip-toolbar>'s shadow root;
-  // Playwright pierces shadow DOM automatically.
+  // Playwright pierces shadow DOM automatically. Scope through the
+  // outer card first: a root blip can contain inline child wave-blip
+  // elements, and a broad descendant toolbar selector matches every
+  // nested reply button in strict mode before the compose path runs.
   await firstBlip
+    .locator("wavy-blip-card")
+    .first()
     .locator("wave-blip-toolbar")
+    .first()
     .locator("button[data-toolbar-action='reply']")
     .click({ timeout: 10_000 });
   const inlineComposer = firstBlip.locator(


### PR DESCRIPTION
## Summary
- Scope the J2CL inline reply parity helper to the outer blip card toolbar so nested inline reply toolbars do not trip Playwright strict mode.
- Add a Lit regression that verifies a real slotted Bold toolbar click is preserved in the reply-submit components payload.

Fixes part of #1161 under #904.

## Verification
- `sbt --batch j2clLitTest` -> 810 passed, 0 failed
- `WAVE_E2E_BASE_URL=http://127.0.0.1:9901 npx playwright test tests/inline-reply-parity.spec.ts --project=chromium --workers=1 --retries=0` -> 2 passed

## Self-review
- Test-only diff; no runtime behavior change and no changelog fragment required.
- Reproduced the failing J2CL gate locally before the selector fix: broad descendant toolbar selector matched six nested reply buttons in strict mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage validating Bold toolbar reply-submit behavior, confirming DOM wrapping and exact reply payload.
  * Improved Reply-button locators to target the correct inline composer toolbar when nested controls exist.
* **Documentation**
  * Added a changelog entry describing the inline-reply parity stabilization and test coverage updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->