### PR TITLE
fix(j2cl): restore keyboard and mention parity

### DIFF
--- a/j2cl/lit/src/shortcuts/blip-focus.js
+++ b/j2cl/lit/src/shortcuts/blip-focus.js
@@ -179,12 +179,14 @@ export function setFocusedBlip(target, root = document) {
   if (typeof target.scrollIntoView === "function") {
     target.scrollIntoView({ block: "nearest", inline: "nearest" });
   }
-  // Move browser active element so renderer keydown handlers that
-  // reseed focus from event.currentTarget start from the right blip.
-  if (typeof target.focus === "function") {
-    if (!target.hasAttribute("tabindex")) target.setAttribute("tabindex", "-1");
-    target.focus({ preventScroll: true });
-  }
+  // Keep DOM focus where the shell-level keyboard handler received it.
+  // Moving browser focus onto the <wave-blip> host makes the next
+  // repeated j/k keydown target the custom element itself; in the
+  // viewport-windowed read surface that event can be consumed at the
+  // current blip boundary before the renderer has grown the next window.
+  // GWT's focus frame is visual state rather than native DOM focus, so
+  // the parity behavior is to reflect focus via attributes/classes and
+  // leave keyboard ownership with the shell.
   target.dispatchEvent(
     new CustomEvent(FOCUS_CHANGED_EVENT, {
       bubbles: true,

--- a/wave/config/changelog.d/2026-05-02-j2cl-keyboard-mention-parity.json
+++ b/wave/config/changelog.d/2026-05-02-j2cl-keyboard-mention-parity.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-02-j2cl-keyboard-mention-parity",
+  "version": "Issue #1161",
+  "date": "2026-05-02",
+  "title": "J2CL keyboard and mention parity",
+  "summary": "Fixes repeated J2CL blip keyboard navigation and keeps the mention parity harness on the root blip toolbar.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Keeps repeated j/k shortcut ownership at the shell level so focus advances across viewport-windowed blips like GWT.",
+        "Scopes mention-reply parity clicks to the root blip toolbar so nested inline reply buttons no longer mask production @mention chooser checks."
+      ]
+    }
+  ]
+}

--- a/wave/src/e2e/j2cl-gwt-parity/tests/helpers/mention.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/helpers/mention.ts
@@ -217,8 +217,16 @@ export async function openInlineComposerJ2cl(page: Page): Promise<Locator> {
     try {
       await firstBlip.scrollIntoViewIfNeeded({ timeout: 5_000 });
       await firstBlip.hover({ timeout: 5_000 });
+      // Scope through the outer card before piercing into the toolbar.
+      // The seeded welcome wave contains nested inline reply blips inside
+      // the first root blip; a broad descendant toolbar selector matches
+      // every nested reply action and fails Playwright strict mode before
+      // the mention flow can exercise the UI.
       await firstBlip
+        .locator("wavy-blip-card")
+        .first()
         .locator("wave-blip-toolbar")
+        .first()
         .locator("button[data-toolbar-action='reply']")
         .click({ timeout: 10_000 });
       break;


### PR DESCRIPTION
Fixes part of #1161.\n\n## Summary\n- Keep J2CL blip focus as shell-owned visual/ARIA state instead of moving native DOM focus onto the focused <wave-blip>, which lets repeated j/k continue advancing across the viewport-windowed read surface like GWT.\n- Scope the shared mention parity helper to the root blip toolbar so nested inline reply buttons no longer mask @mention chooser checks.\n- Add a changelog fragment for the user-facing keyboard parity fix.\n\n## Verification\n- npm test -- --files test/shortcuts/blip-focus.test.js test/shortcuts/keybindings.test.js -> 44 passed.\n- sbt --batch j2clLitTest -> 810 passed, 0 failed.\n- python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json -> passed.\n- WAVE_E2E_BASE_URL=http://127.0.0.1:9902 npx playwright test tests/keyboard-shortcuts-parity.spec.ts:96 tests/keyboard-shortcuts-parity.spec.ts:286 --project=chromium --workers=1 --retries=0 -> passed.\n- WAVE_E2E_BASE_URL=http://127.0.0.1:9902 npx playwright test tests/mention-autocomplete-parity.spec.ts:188 --project=chromium --workers=1 --retries=0 -> passed.\n\nNote: a combined multi-spec run can still expose pre-existing local file-store/test-state flakiness around reload/persistence; the fixed parity slices pass as focused checks against the rebuilt staged server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard focus handling for blips to maintain proper focus state
  * Enhanced mention and reply interactions for better keyboard navigation consistency
  * Refined toolbar interaction targeting to prevent unintended action triggers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->