### PR TITLE
fix(j2cl): stretch selected wave panel

### DIFF
--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -170,15 +170,19 @@ body.j2cl-root-shell-page:not(.j2cl-debug-overlay-on) [data-j2cl-debug-only] {
 }
 
 .sidecar-selected-host {
+  box-sizing: border-box;
   min-width: 0;
+  width: 100%;
 }
 
 .sidecar-selected-card {
   background: rgba(255, 255, 255, 0.97);
   border: 1px solid #e2e8f0;
   border-radius: 4px;
+  box-sizing: border-box;
   box-shadow: none;
   padding: 12px;
+  width: 100%;
 }
 
 shell-root[data-wave-controls-compact="true"] wavy-wave-header-actions,

--- a/wave/config/changelog.d/2026-05-02-j2cl-wave-panel-width.json
+++ b/wave/config/changelog.d/2026-05-02-j2cl-wave-panel-width.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-02-j2cl-wave-panel-width",
+  "version": "Issue #1161",
+  "date": "2026-05-02",
+  "title": "J2CL wave panel width parity",
+  "summary": "Makes the J2CL selected-wave panel fill the available shell width like the GWT wave panel.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Stretches the selected-wave host and card to the full main column so wide screens no longer show a narrow J2CL wave panel with unused whitespace."
+      ]
+    }
+  ]
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -680,6 +680,12 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
             .matcher(css)
             .find());
     assertTrue(
+        "The selected-wave host must include padding in its full-width box calculation",
+        java.util.regex.Pattern.compile(
+                "\\.sidecar-selected-host\\s*\\{[^}]*\\bbox-sizing\\s*:\\s*border-box\\s*;")
+            .matcher(css)
+            .find());
+    assertTrue(
         "The selected-wave card must not shrink-wrap the read surface on wide screens",
         java.util.regex.Pattern.compile(
                 "\\.sidecar-selected-card\\s*\\{[^}]*\\bwidth\\s*:\\s*100%\\s*;")

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -671,6 +671,28 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
             && css.contains("display: none"));
   }
 
+  public void testServerFirstSelectedWaveWrappersFillMainColumn() {
+    String css = readSourceFile("j2cl/src/main/webapp/assets/sidecar.css");
+    assertTrue(
+        "The server-first selected-wave host must stretch to the full shell main column",
+        java.util.regex.Pattern.compile(
+                "\\.sidecar-selected-host\\s*\\{[^}]*\\bwidth\\s*:\\s*100%\\s*;")
+            .matcher(css)
+            .find());
+    assertTrue(
+        "The selected-wave card must not shrink-wrap the read surface on wide screens",
+        java.util.regex.Pattern.compile(
+                "\\.sidecar-selected-card\\s*\\{[^}]*\\bwidth\\s*:\\s*100%\\s*;")
+            .matcher(css)
+            .find());
+    assertTrue(
+        "The selected-wave card must include padding in its full-width box calculation",
+        java.util.regex.Pattern.compile(
+                "\\.sidecar-selected-card\\s*\\{[^}]*\\bbox-sizing\\s*:\\s*border-box\\s*;")
+            .matcher(css)
+            .find());
+  }
+
   public void testJ2clComposeSurfaceViewListensForBlipReplyEvents() {
     // F-3.S1 (#1038, R-5.1 step 1): the Java compose view must subscribe
     // to F-2's <wave-blip> Reply / Edit CustomEvents and mount an inline


### PR DESCRIPTION
## Summary
- Fixes #1161 follow-up parity gap where the J2CL selected-wave panel could render as a narrow column on wide screens while GWT uses the available panel width.
- Makes the selected-wave host/card full-width with border-box sizing so the read surface fills the shell main column.
- Adds a focused regression assertion against the shipped `sidecar.css` rule shape and a changelog fragment.

## Self-review
- Scope is limited to selected-wave wrapper sizing; rail width, split layout columns, blip rendering, and scrolling behavior are unchanged.
- Regression test failed before the CSS change because `.sidecar-selected-host` did not carry `width: 100%`, then passed after the patch.

## Verification
- RED: `python3 scripts/assemble-changelog.py && sbt --batch 'Test/testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellIntegrationTest'` failed at `testServerFirstSelectedWaveWrappersFillMainColumn` before the CSS fix.
- GREEN: `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json` passed.
- GREEN: `sbt --batch 'Test/testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellIntegrationTest'` passed: 34 tests, 0 failed.

Issue: #1161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed selected-wave panel layout so the side panel stretches to fill available shell width, removing narrow whitespace on wide screens and matching standard panel behavior.

* **Tests**
  * Added an integration test to verify the updated layout and sizing behavior.

* **Documentation**
  * Added a changelog entry describing the release and layout fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->