### PR TITLE
fix(j2cl): reveal new wave composer in root shell

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -51,6 +51,7 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
   // the create form. Single-line input with Enter-to-submit semantics so a
   // user who types just a title can ship the wave without reaching for the
   // mouse.
+  private final HTMLElement createHost;
   private final HTMLInputElement createTitleInput;
   private final HTMLTextAreaElement createInput;
   private final HTMLElement createSubmit;
@@ -84,7 +85,9 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
   static final String BLIP_DELETE_REQUEST_PREFIX = "wavy-blip-delete:";
 
   public J2clComposeSurfaceView(HTMLElement createHost, HTMLElement replyHost) {
+    this.createHost = createHost;
     createHost.innerHTML = "";
+    createHost.hidden = true;
     replyHost.innerHTML = "";
 
     HTMLElement shell = (HTMLElement) DomGlobal.document.createElement("composer-shell");
@@ -434,6 +437,7 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     // the title input; if the input is disabled (signed out / submitting)
     // skip silently rather than throwing.
     if (!createTitleInput.disabled) {
+      revealCreateSurface();
       createTitleInput.focus();
     }
   }
@@ -443,9 +447,14 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     // #1076: the keyboard shortcut drops the user straight into the body
     // composer and scrolls it into view without changing the button/title path.
     if (!createInput.disabled) {
+      revealCreateSurface();
       createInput.scrollIntoView();
       createInput.focus();
     }
+  }
+
+  private void revealCreateSurface() {
+    createHost.hidden = false;
   }
 
   /** F-3.S1 entrypoint: mount a `<wavy-composer>` inline at the originating blip. */

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -436,8 +436,8 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     // J-UI-3 (#1081, R-5.1): the rail's New Wave button drops the user into
     // the title input; if the input is disabled (signed out / submitting)
     // skip silently rather than throwing.
+    revealCreateSurface();
     if (!createTitleInput.disabled) {
-      revealCreateSurface();
       createTitleInput.focus();
     }
   }
@@ -446,8 +446,8 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
   public void focusCreateComposer() {
     // #1076: the keyboard shortcut drops the user straight into the body
     // composer and scrolls it into view without changing the button/title path.
+    revealCreateSurface();
     if (!createInput.disabled) {
-      revealCreateSurface();
       createInput.scrollIntoView();
       createInput.focus();
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -71,7 +71,7 @@ public final class J2clRootShellController {
     selectedWaveViewRef[0] = selectedWaveView;
     HTMLElement selectedWaveComposeHost = selectedWaveView.getComposeHost();
     HTMLElement selectedCreateHost =
-        createChildHost(selectedWaveComposeHost, "j2cl-root-create-host");
+        createSiblingHostBefore(selectedWaveComposeHost, "j2cl-root-create-host");
     HTMLElement selectedToolbarHost =
         createChildHost(selectedWaveComposeHost, "j2cl-root-toolbar-host");
     HTMLElement selectedReplyHost =
@@ -472,6 +472,16 @@ public final class J2clRootShellController {
     HTMLElement child = (HTMLElement) elemental2.dom.DomGlobal.document.createElement("div");
     child.className = className;
     parent.appendChild(child);
+    return child;
+  }
+
+  private static HTMLElement createSiblingHostBefore(HTMLElement reference, String className) {
+    HTMLElement child = (HTMLElement) elemental2.dom.DomGlobal.document.createElement("div");
+    child.className = className;
+    if (reference.parentNode == null) {
+      throw new IllegalStateException("Reference host must be attached before creating sibling host.");
+    }
+    reference.parentNode.insertBefore(child, reference);
     return child;
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -70,6 +70,8 @@ public final class J2clRootShellController {
         new J2clSelectedWaveView(searchView.getSelectedWaveHost(), telemetrySink);
     selectedWaveViewRef[0] = selectedWaveView;
     HTMLElement selectedWaveComposeHost = selectedWaveView.getComposeHost();
+    HTMLElement selectedCreateHost =
+        createChildHost(selectedWaveComposeHost, "j2cl-root-create-host");
     HTMLElement selectedToolbarHost =
         createChildHost(selectedWaveComposeHost, "j2cl-root-toolbar-host");
     HTMLElement selectedReplyHost =
@@ -99,7 +101,7 @@ public final class J2clRootShellController {
     J2clComposeSurfaceController composeController =
         new J2clComposeSurfaceController(
             gateway,
-            new J2clComposeSurfaceView(searchView.getComposeHost(), selectedReplyHost),
+            new J2clComposeSurfaceView(selectedCreateHost, selectedReplyHost),
             J2clComposeSurfaceController.richContentDeltaFactory(rootShellSessionSeed),
             J2clComposeSurfaceController.attachmentControllerFactory(rootShellSessionSeed, telemetrySink),
             createSuccessHandler,

--- a/wave/config/changelog.d/2026-05-02-j2cl-new-wave-visible-composer.json
+++ b/wave/config/changelog.d/2026-05-02-j2cl-new-wave-visible-composer.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-02-j2cl-new-wave-visible-composer",
+  "version": "Issue #1161",
+  "date": "2026-05-02",
+  "title": "J2CL New Wave composer parity",
+  "summary": "Mounts the J2CL root New Wave composer in the visible wave panel instead of the hidden legacy search card.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "The root-shell New Wave button and shortcut now focus a visible create composer under the selected-wave panel."
+      ]
+    }
+  ]
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -248,6 +248,28 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
             "<div class=\"sidecar-selected-compose\" data-j2cl-compose-host=\"true\"></div>"));
   }
 
+  public void testRootShellCreateSurfaceMountsInVisibleSelectedWaveHost() {
+    String source =
+        readSourceFile(
+            "j2cl/src/main/java/org/waveprotocol/box/j2cl/root/"
+                + "J2clRootShellController.java");
+    assertTrue(
+        "Root-shell New Wave must mount the create surface in the visible "
+            + "selected-wave compose host, not the hidden legacy search card.",
+        source.contains(
+            "new J2clComposeSurfaceView(selectedCreateHost, selectedReplyHost)"));
+    assertTrue(
+        "Root-shell New Wave must use a dedicated visible create child host so "
+            + "J2clComposeSurfaceView does not clear the reply/toolbar hosts.",
+        source.contains(
+            "createChildHost(selectedWaveComposeHost, \"j2cl-root-create-host\")"));
+    assertFalse(
+        "Root-shell New Wave must not bind createHost to searchView.getComposeHost(), "
+            + "because the root shell hides the legacy search card.",
+        source.contains(
+            "new J2clComposeSurfaceView(searchView.getComposeHost(), selectedReplyHost)"));
+  }
+
   // ---------------------------------------------------------------------
   // F-2 slice 6 (#1058, Part A) — visible-rail regression lock.
   //
@@ -728,5 +750,19 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         "J2clComposeSurfaceView must mount the new <wavy-composer> "
             + "element for inline composer surfaces (R-5.1 step 1)",
         source.contains("createElement(\"wavy-composer\")"));
+  }
+
+  public void testJ2clCreateSurfaceStaysHiddenUntilNewWaveRequested() {
+    String source =
+        readSourceFile(
+            "j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/"
+                + "J2clComposeSurfaceView.java");
+    assertTrue(
+        "J2CL create host must start hidden so the New Wave composer does not "
+            + "occupy the selected-wave panel before the user asks for it.",
+        source.contains("createHost.hidden = true"));
+    assertTrue(
+        "J2CL New Wave focus must reveal the create host before focusing title/body.",
+        source.contains("createHost.hidden = false"));
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -262,6 +262,11 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         "Root-shell New Wave must use a dedicated visible create child host so "
             + "J2clComposeSurfaceView does not clear the reply/toolbar hosts.",
         source.contains(
+            "createSiblingHostBefore(selectedWaveComposeHost, \"j2cl-root-create-host\")"));
+    assertFalse(
+        "Root-shell New Wave must not create the dedicated create host inside "
+            + "sidecar-selected-compose because that breaks the :empty collapse sentinel.",
+        source.contains(
             "createChildHost(selectedWaveComposeHost, \"j2cl-root-create-host\")"));
     assertFalse(
         "Root-shell New Wave must not bind createHost to searchView.getComposeHost(), "
@@ -764,5 +769,13 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
     assertTrue(
         "J2CL New Wave focus must reveal the create host before focusing title/body.",
         source.contains("createHost.hidden = false"));
+    assertTrue(
+        "J2CL New Wave button path must reveal before checking title-input disabled state.",
+        source.indexOf("revealCreateSurface();", source.indexOf("public void focusCreateSurface()"))
+            < source.indexOf("if (!createTitleInput.disabled)", source.indexOf("public void focusCreateSurface()")));
+    assertTrue(
+        "J2CL New Wave shortcut path must reveal before checking body-input disabled state.",
+        source.indexOf("revealCreateSurface();", source.indexOf("public void focusCreateComposer()"))
+            < source.indexOf("if (!createInput.disabled)", source.indexOf("public void focusCreateComposer()")));
   }
 }


### PR DESCRIPTION
## Summary
- Mount the J2CL root-shell create composer in a dedicated selected-wave compose child host instead of the hidden legacy search card.
- Keep the create host hidden until New Wave / shortcut focus reveals it, so it does not permanently occupy the wave panel.
- Add regression locks for visible-host binding and hidden-until-requested create lifecycle.

Refs #1161

## Self-review
- Root cause confirmed from current main: `J2clRootShellController` constructed `J2clComposeSurfaceView(searchView.getComposeHost(), selectedReplyHost)`, while root-shell CSS hides the legacy search card.
- Rejected the first naive parent-host fix because `J2clComposeSurfaceView` clears `createHost.innerHTML`, which would remove reply/toolbar child hosts and make the composer visible by default.
- Final fix uses a dedicated create child host under the visible selected-wave compose area and reveals it only from `focusCreateSurface()` / `focusCreateComposer()`.

## Verification
- RED: `sbt --batch 'Test/testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellIntegrationTest'` failed on `testRootShellCreateSurfaceMountsInVisibleSelectedWaveHost` before the fix.\n- RED: focused `testJ2clCreateSurfaceStaysHiddenUntilNewWaveRequested` failed before hidden/reveal lifecycle was added.\n- GREEN: `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json && sbt --batch 'Test/testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellIntegrationTest' && git diff --check` passed, 36/36.\n\nNo Claude review was used per current instruction; relying on self-review and PR review comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Wave composer is mounted in the visible wave panel and integrates with New Wave controls.
* **Behavior Changes**
  * Composer starts hidden and is revealed only when New Wave is requested; focus now reliably sets cursor into title/body after reveal.
* **Tests**
  * Integration tests added to verify mounting and reveal/focus behavior.
* **Chores**
  * Release changelog entry added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->