### PR TITLE
fix(j2cl): hide debug chrome in wave panel

### DIFF
--- a/j2cl/lit/src/elements/composer-inline-reply.js
+++ b/j2cl/lit/src/elements/composer-inline-reply.js
@@ -75,17 +75,9 @@ export class ComposerInlineReply extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.addEventListener("composer-focus-request", this._handleFocusRequest);
-    // V-2 (#1100): default the debug-overlay property from the body
-    // class set by HtmlRenderer. Page-load value is stable, so a
-    // single read here is sufficient. Skip if already set programmatically
-    // (property would be true) so a pre-connect assignment isn't clobbered.
-    if (!this.hasAttribute("debug-overlay") && this.debugOverlay === false) {
-      this.debugOverlay = !!(
-        typeof document !== "undefined" &&
-        document.body &&
-        document.body.classList.contains("j2cl-debug-overlay-on")
-      );
-    }
+    // Do not inherit the page-level debug flag into the reply surface.
+    // Raw target labels are only visible when this element explicitly
+    // carries [debug-overlay].
   }
 
   disconnectedCallback() {

--- a/j2cl/lit/src/elements/composer-inline-reply.js
+++ b/j2cl/lit/src/elements/composer-inline-reply.js
@@ -14,8 +14,9 @@ export class ComposerInlineReply extends LitElement {
     commandStatus: { type: String, attribute: "command-status" },
     commandError: { type: String, attribute: "command-error" },
     // V-2 (#1100): when off (default), the "Reply target: <id>" line
-    // does not render. connectedCallback() reads it from the body class
-    // set by HtmlRenderer (SSR); tests set the attribute directly.
+    // does not render. This intentionally avoids page-level debug
+    // inheritance and only respects this element's [debug-overlay]
+    // attribute/property; tests may set the attribute directly.
     debugOverlay: { type: Boolean, attribute: "debug-overlay", reflect: true }
   };
 

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -586,18 +586,9 @@ export class WavyComposer extends LitElement {
     super.connectedCallback();
     this.addEventListener("composer-focus-request", this._handleFocusRequest);
     document.addEventListener("selectionchange", this._handleSelectionChange);
-    // V-2 (#1100): default debugOverlay from the body class set by
-    // HtmlRenderer when j2cl-debug-overlay is on. Body-class is page-
-    // load-stable, so a single read at connect is sufficient. Skip if
-    // already set programmatically (true) so a pre-connect assignment
-    // isn't clobbered when the attribute is absent.
-    if (!this.hasAttribute("debug-overlay") && this.debugOverlay === false) {
-      this.debugOverlay = !!(
-        typeof document !== "undefined" &&
-        document.body &&
-        document.body.classList.contains("j2cl-debug-overlay-on")
-      );
-    }
+    // Do not inherit the page-level debug flag into user-facing composers.
+    // Raw reply target IDs are only visible when this element explicitly
+    // carries [debug-overlay].
     // F-3.S2 (#1038, R-5.4 step 6): listen for the H.20 Insert-task
     // action emitted by the floating wavy format toolbar mounted in
     // the toolbar slot. The action is composer-local (per-composer,

--- a/j2cl/lit/test/composer-inline-reply.test.js
+++ b/j2cl/lit/test/composer-inline-reply.test.js
@@ -45,6 +45,21 @@ describe("<composer-inline-reply>", () => {
     expect(el.renderRoot.textContent).to.include("Root blip");
   });
 
+  it("does not inherit the page debug overlay into the visible reply target line", async () => {
+    document.body.classList.add("j2cl-debug-overlay-on");
+    try {
+      const el = await fixture(html`
+        <composer-inline-reply available target-label="b+raw"></composer-inline-reply>
+      `);
+      await el.updateComplete;
+      expect(el.debugOverlay).to.equal(false);
+      expect(el.renderRoot.textContent).to.not.include("Reply target:");
+      expect(el.renderRoot.textContent).to.not.include("b+raw");
+    } finally {
+      document.body.classList.remove("j2cl-debug-overlay-on");
+    }
+  });
+
   it("emits draft-change and reply-submit events when available", async () => {
     const el = await fixture(html`
       <composer-inline-reply available target-label="Root blip"></composer-inline-reply>

--- a/j2cl/lit/test/wavy-composer.test.js
+++ b/j2cl/lit/test/wavy-composer.test.js
@@ -91,6 +91,24 @@ describe("<wavy-composer>", () => {
     expect(replyParagraphs[0].textContent).to.include("Root blip");
   });
 
+  it("does not inherit the page debug overlay into the visible reply target line", async () => {
+    document.body.classList.add("j2cl-debug-overlay-on");
+    try {
+      const el = await fixture(html`
+        <wavy-composer available reply-target-blip-id="b42" target-label="b+raw"></wavy-composer>
+      `);
+      await el.updateComplete;
+      const targetText = Array.from(el.renderRoot.querySelectorAll("p.target"))
+        .map((p) => p.textContent)
+        .join("\n");
+      expect(el.debugOverlay).to.equal(false);
+      expect(targetText).to.not.include("Reply target:");
+      expect(targetText).to.not.include("b+raw");
+    } finally {
+      document.body.classList.remove("j2cl-debug-overlay-on");
+    }
+  });
+
   it("reflects reply-target-blip-id as a data attribute on the inner wavy-compose-card", async () => {
     const el = await fixture(html`
       <wavy-composer available reply-target-blip-id="b42" target-label="Yuri"></wavy-composer>

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -832,7 +832,7 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
    * the shell element is missing entirely (sidecar / parity-test
    * surfaces that do not paint a `<shell-root>`).
    */
-  private static boolean readInlineRichComposerFlag() {
+  static boolean readInlineRichComposerFlag() {
     Object shell =
         DomGlobal.document.querySelector(
             "shell-root[data-j2cl-inline-rich-composer=\"true\"]");

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -587,7 +587,9 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
       current =
           current.parentElement instanceof HTMLElement ? (HTMLElement) current.parentElement : null;
     }
-    return null;
+    return DomGlobal.document.scrollingElement instanceof HTMLElement
+        ? (HTMLElement) DomGlobal.document.scrollingElement
+        : null;
   }
 
   private void mirrorComposerState(HTMLElement composer, J2clComposeSurfaceModel model) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -246,6 +246,13 @@ public final class J2clRootShellController {
     liveSurfaceController.start();
   }
 
+  /**
+   * Transitional overload: defaults to inline-rich-composer mode (inlineRichComposerEnabled=true).
+   *
+   * @deprecated Prefer {@link #editStateForWriteSession(J2clSidecarWriteSession, boolean)} and
+   *     pass the resolved flag value explicitly.
+   */
+  @Deprecated
   static J2clToolbarSurfaceController.EditState editStateForWriteSession(
       J2clSidecarWriteSession writeSession) {
     return editStateForWriteSession(writeSession, true);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -76,6 +76,7 @@ public final class J2clRootShellController {
         createChildHost(selectedWaveComposeHost, "j2cl-root-toolbar-host");
     HTMLElement selectedReplyHost =
         createChildHost(selectedWaveComposeHost, "j2cl-root-reply-host");
+    boolean inlineRichComposerEnabled = isInlineRichComposerEnabled(host);
     String rootShellSessionSeed = buildRootShellSessionSeed();
     final J2clSearchPanelController[] searchControllerRef = new J2clSearchPanelController[1];
     // J-UI-3 (#1081, R-5.1): on a successful create, prepend an optimistic
@@ -150,7 +151,7 @@ public final class J2clRootShellController {
                   selectedWaveId, writeSession, participantIds);
               toolbarController.onWriteSessionChanged(writeSession);
               toolbarController.onEditStateChanged(
-                  new J2clToolbarSurfaceController.EditState(false));
+                  editStateForWriteSession(writeSession, inlineRichComposerEnabled));
             },
             telemetrySink);
     selectedWaveControllerRef[0] = selectedWaveController;
@@ -247,7 +248,17 @@ public final class J2clRootShellController {
 
   static J2clToolbarSurfaceController.EditState editStateForWriteSession(
       J2clSidecarWriteSession writeSession) {
-    return new J2clToolbarSurfaceController.EditState(false);
+    return editStateForWriteSession(writeSession, true);
+  }
+
+  static J2clToolbarSurfaceController.EditState editStateForWriteSession(
+      J2clSidecarWriteSession writeSession, boolean inlineRichComposerEnabled) {
+    return new J2clToolbarSurfaceController.EditState(
+        writeSession != null && !inlineRichComposerEnabled);
+  }
+
+  static boolean isInlineRichComposerEnabled(HTMLElement host) {
+    return host != null && "true".equals(host.getAttribute("data-j2cl-inline-rich-composer"));
   }
 
   static boolean isReadSurfacePreviewHost(boolean hostMarked, boolean bodyMarked) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -258,7 +258,14 @@ public final class J2clRootShellController {
   }
 
   static boolean isInlineRichComposerEnabled(HTMLElement host) {
-    return host != null && "true".equals(host.getAttribute("data-j2cl-inline-rich-composer"));
+    if (host == null) {
+      return false;
+    }
+    // data-j2cl-inline-rich-composer is emitted on <shell-root>, not on the
+    // #j2cl-root-shell-workflow section where the controller is mounted.
+    elemental2.dom.Element shellRoot = host.closest("shell-root");
+    elemental2.dom.Element target = shellRoot != null ? shellRoot : host;
+    return "true".equals(target.getAttribute("data-j2cl-inline-rich-composer"));
   }
 
   static boolean isReadSurfacePreviewHost(boolean hostMarked, boolean bodyMarked) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -149,7 +149,8 @@ public final class J2clRootShellController {
               composeController.onSelectedWaveComposeContextChanged(
                   selectedWaveId, writeSession, participantIds);
               toolbarController.onWriteSessionChanged(writeSession);
-              toolbarController.onEditStateChanged(editStateForWriteSession(writeSession));
+              toolbarController.onEditStateChanged(
+                  new J2clToolbarSurfaceController.EditState(false));
             },
             telemetrySink);
     selectedWaveControllerRef[0] = selectedWaveController;
@@ -246,7 +247,7 @@ public final class J2clRootShellController {
 
   static J2clToolbarSurfaceController.EditState editStateForWriteSession(
       J2clSidecarWriteSession writeSession) {
-    return new J2clToolbarSurfaceController.EditState(writeSession != null);
+    return new J2clToolbarSurfaceController.EditState(false);
   }
 
   static boolean isReadSurfacePreviewHost(boolean hostMarked, boolean bodyMarked) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -691,7 +691,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     status.textContent = model.getStatusText();
     status.hidden = !model.isError();
     detail.textContent = model.getDetailText();
-    detail.hidden = true;
+    detail.hidden = !model.isError() && !isDebugOverlayOn();
     renderParticipantStrip(model.getParticipantIds());
     publishProfileOverlayParticipants(model.getParticipantIds());
     snippet.textContent = model.getSnippetText();
@@ -1138,7 +1138,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     status.textContent = model.getStatusText();
     status.hidden = !model.isError();
     detail.textContent = model.getDetailText();
-    detail.hidden = true;
+    detail.hidden = !model.isError() && !isDebugOverlayOn();
     if (model.isError()) {
       // Error is a terminal state: clear aria-busy so AT doesn't treat the
       // region as permanently loading. clearServerFirstMarkers() isn't called

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -691,7 +691,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     status.textContent = model.getStatusText();
     status.hidden = !model.isError();
     detail.textContent = model.getDetailText();
-    detail.hidden = !model.isError() && !isDebugOverlayOn();
+    detail.hidden = !model.isError();
     renderParticipantStrip(model.getParticipantIds());
     publishProfileOverlayParticipants(model.getParticipantIds());
     snippet.textContent = model.getSnippetText();
@@ -1138,7 +1138,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     status.textContent = model.getStatusText();
     status.hidden = !model.isError();
     detail.textContent = model.getDetailText();
-    detail.hidden = !model.isError() && !isDebugOverlayOn();
+    detail.hidden = !model.isError();
     if (model.isError()) {
       // Error is a terminal state: clear aria-busy so AT doesn't treat the
       // region as permanently loading. clearServerFirstMarkers() isn't called

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -176,6 +176,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     detail = (HTMLElement) DomGlobal.document.createElement("p");
     detail.className = "sidecar-selected-detail";
     markDebugOnly(detail);
+    detail.hidden = true;
     coldCard.appendChild(detail);
 
     // F-2 slice 5 (#1055, R-3.7 G.6): awareness pill — hidden by default
@@ -688,8 +689,9 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
             ? "sidecar-selected-status sidecar-selected-status-error"
             : "sidecar-selected-status";
     status.textContent = model.getStatusText();
-    status.hidden = !model.isError() && !isDebugOverlayOn();
+    status.hidden = !model.isError();
     detail.textContent = model.getDetailText();
+    detail.hidden = true;
     renderParticipantStrip(model.getParticipantIds());
     publishProfileOverlayParticipants(model.getParticipantIds());
     snippet.textContent = model.getSnippetText();
@@ -1134,8 +1136,9 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
             ? "sidecar-selected-status sidecar-selected-status-error"
             : "sidecar-selected-status";
     status.textContent = model.getStatusText();
-    status.hidden = !model.isError() && !isDebugOverlayOn();
+    status.hidden = !model.isError();
     detail.textContent = model.getDetailText();
+    detail.hidden = true;
     if (model.isError()) {
       // Error is a terminal state: clear aria-busy so AT doesn't treat the
       // region as permanently loading. clearServerFirstMarkers() isn't called

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java
@@ -12,21 +12,41 @@ import org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceModel;
 @J2clTestInput(J2clRootShellControllerTest.class)
 public class J2clRootShellControllerTest {
   @Test
-  public void editStateForWriteSessionKeepsLegacyToolbarInactiveWhenRichComposerIsOn() {
+  public void editStateForWriteSession_inlineRichOff_followsWriteSession() {
     FakeToolbarView view = new FakeToolbarView();
     J2clToolbarSurfaceController toolbarController =
         new J2clToolbarSurfaceController(view, action -> {});
 
     toolbarController.setViewActionsEnabled(false);
     toolbarController.start();
-    toolbarController.onEditStateChanged(J2clRootShellController.editStateForWriteSession(null));
 
+    // No write session — legacy toolbar stays inactive.
+    toolbarController.onEditStateChanged(
+        J2clRootShellController.editStateForWriteSession(null, false));
     Assert.assertFalse(view.model.hasAction(J2clDailyToolbarAction.BOLD));
 
+    // Write session present and inline-rich-composer disabled — legacy toolbar becomes active.
     toolbarController.onEditStateChanged(
         J2clRootShellController.editStateForWriteSession(
-            new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root")));
+            new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"),
+            false));
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.BOLD));
+  }
 
+  @Test
+  public void editStateForWriteSession_inlineRichOn_alwaysDisablesLegacyToolbar() {
+    FakeToolbarView view = new FakeToolbarView();
+    J2clToolbarSurfaceController toolbarController =
+        new J2clToolbarSurfaceController(view, action -> {});
+
+    toolbarController.setViewActionsEnabled(false);
+    toolbarController.start();
+
+    // Even with a write session, legacy toolbar stays off when inline-rich-composer is active.
+    toolbarController.onEditStateChanged(
+        J2clRootShellController.editStateForWriteSession(
+            new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"),
+            true));
     Assert.assertFalse(view.model.hasAction(J2clDailyToolbarAction.BOLD));
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java
@@ -12,7 +12,7 @@ import org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceModel;
 @J2clTestInput(J2clRootShellControllerTest.class)
 public class J2clRootShellControllerTest {
   @Test
-  public void editStateForWriteSessionRequiresFullWriteSession() {
+  public void editStateForWriteSessionAlwaysDisablesLegacyToolbar() {
     FakeToolbarView view = new FakeToolbarView();
     J2clToolbarSurfaceController toolbarController =
         new J2clToolbarSurfaceController(view, action -> {});
@@ -27,7 +27,7 @@ public class J2clRootShellControllerTest {
         J2clRootShellController.editStateForWriteSession(
             new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root")));
 
-    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.BOLD));
+    Assert.assertFalse(view.model.hasAction(J2clDailyToolbarAction.BOLD));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java
@@ -58,11 +58,19 @@ public class J2clRootShellControllerTest {
 
     toolbarController.setViewActionsEnabled(false);
     toolbarController.start();
+
+    // Rich composer ON — legacy toolbar stays inactive.
+    toolbarController.onEditStateChanged(
+        J2clRootShellController.editStateForWriteSession(
+            new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"),
+            true));
+    Assert.assertFalse(view.model.hasAction(J2clDailyToolbarAction.BOLD));
+
+    // Rich composer turned OFF — legacy toolbar is restored.
     toolbarController.onEditStateChanged(
         J2clRootShellController.editStateForWriteSession(
             new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"),
             false));
-
     Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.BOLD));
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellControllerTest.java
@@ -12,7 +12,7 @@ import org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceModel;
 @J2clTestInput(J2clRootShellControllerTest.class)
 public class J2clRootShellControllerTest {
   @Test
-  public void editStateForWriteSessionAlwaysDisablesLegacyToolbar() {
+  public void editStateForWriteSessionKeepsLegacyToolbarInactiveWhenRichComposerIsOn() {
     FakeToolbarView view = new FakeToolbarView();
     J2clToolbarSurfaceController toolbarController =
         new J2clToolbarSurfaceController(view, action -> {});
@@ -28,6 +28,22 @@ public class J2clRootShellControllerTest {
             new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root")));
 
     Assert.assertFalse(view.model.hasAction(J2clDailyToolbarAction.BOLD));
+  }
+
+  @Test
+  public void editStateForWriteSessionRestoresLegacyToolbarWhenRichComposerIsOff() {
+    FakeToolbarView view = new FakeToolbarView();
+    J2clToolbarSurfaceController toolbarController =
+        new J2clToolbarSurfaceController(view, action -> {});
+
+    toolbarController.setViewActionsEnabled(false);
+    toolbarController.start();
+    toolbarController.onEditStateChanged(
+        J2clRootShellController.editStateForWriteSession(
+            new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"),
+            false));
+
+    Assert.assertTrue(view.model.hasAction(J2clDailyToolbarAction.BOLD));
   }
 
   @Test

--- a/wave/config/changelog.d/2026-05-02-j2cl-wave-debug-reply-toolbar-parity.json
+++ b/wave/config/changelog.d/2026-05-02-j2cl-wave-debug-reply-toolbar-parity.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-05-02-j2cl-wave-debug-reply-toolbar-parity",
+  "version": "Issue #1161",
+  "date": "2026-05-02",
+  "title": "J2CL wave chrome parity cleanup",
+  "summary": "Removes developer-only J2CL wave chrome from the user-facing wave panel and keeps inline replies anchored in place.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Hides raw live-update, channel, snapshot, and reply-target identifiers from the normal selected-wave and composer UI.",
+        "Stops writable waves from showing the legacy text-button formatting toolbar outside an active inline composer.",
+        "Preserves document scroll when opening an inline reply composer so the wave does not jump to the bottom."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -4722,7 +4722,11 @@ public final class HtmlRenderer {
     sb.append("              <p class=\"sidecar-selected-status\" hidden>")
         .append(escapeHtml(status))
         .append("</p>\n");
-    sb.append("              <p class=\"sidecar-selected-detail\" data-j2cl-debug-only=\"true\">")
+    sb.append("              <p class=\"sidecar-selected-detail\" data-j2cl-debug-only=\"true\"");
+    if (effectiveResult.getMode() == J2clSelectedWaveSnapshotRenderer.Mode.SNAPSHOT) {
+      sb.append(" hidden");
+    }
+    sb.append(">")
         .append(escapeHtml(detail))
         .append("</p>\n");
     // F-2 slice 5 (#1055, R-3.7 G.6): live-update awareness pill.

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -4945,7 +4945,7 @@ public final class HtmlRenderer {
       sb.append("    var status=workflow.querySelector('.sidecar-selected-status');\n");
       sb.append("    var detail=workflow.querySelector('.sidecar-selected-detail');\n");
       sb.append("    if(status){status.className='sidecar-selected-status sidecar-selected-status-error';status.textContent='Selected wave live upgrade failed.';status.hidden=false;}\n");
-      sb.append("    if(detail){detail.textContent='The J2CL root-shell bundle failed to load. Refresh to retry.';}\n");
+      sb.append("    if(detail){detail.hidden=false;detail.textContent='The J2CL root-shell bundle failed to load. Refresh to retry.';}\n");
       sb.append("    if(window.__j2clRootShellStat){window.__j2clRootShellStat('shell_swap','bundle-load-error',0,!!placeholder.getAttribute('data-j2cl-server-first-selected-wave'));}\n");
       sb.append("    return;\n");
       sb.append("  }\n");

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3940,7 +3940,7 @@ public final class HtmlRenderer {
     sb.append("              <h2 class=\"sidecar-selected-title\">Sample read-surface preview wave</h2>\n");
     sb.append("              <p class=\"sidecar-selected-unread\">3 unread</p>\n");
     sb.append("              <p class=\"sidecar-selected-status\" hidden>Read-surface preview fixture — every F-2 chrome affordance is mounted on this single URL.</p>\n");
-    sb.append("              <p class=\"sidecar-selected-detail\" data-j2cl-debug-only=\"true\">Open the version-history, profile, and depth-nav overlays via the floating controls; press <kbd>j</kbd>/<kbd>k</kbd> to move the focus frame.</p>\n");
+    sb.append("              <p class=\"sidecar-selected-detail\" data-j2cl-debug-only=\"true\" hidden>Open the version-history, profile, and depth-nav overlays via the floating controls; press <kbd>j</kbd>/<kbd>k</kbd> to move the focus frame.</p>\n");
     sb.append("              <output class=\"wavy-awareness-pill\" data-j2cl-awareness-pill=\"true\">2 new replies above</output>\n");
     sb.append("              <p class=\"sidecar-selected-participants\">alice@example.com, bob@example.com, carol@example.com</p>\n");
     sb.append("              <wavy-wave-nav-row data-j2cl-server-first-chrome=\"true\"></wavy-wave-nav-row>\n");
@@ -4722,7 +4722,7 @@ public final class HtmlRenderer {
     sb.append("              <p class=\"sidecar-selected-status\" hidden>")
         .append(escapeHtml(status))
         .append("</p>\n");
-    sb.append("              <p class=\"sidecar-selected-detail\" data-j2cl-debug-only=\"true\">")
+    sb.append("              <p class=\"sidecar-selected-detail\" data-j2cl-debug-only=\"true\" hidden>")
         .append(escapeHtml(detail))
         .append("</p>\n");
     // F-2 slice 5 (#1055, R-3.7 G.6): live-update awareness pill.

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -4722,7 +4722,7 @@ public final class HtmlRenderer {
     sb.append("              <p class=\"sidecar-selected-status\" hidden>")
         .append(escapeHtml(status))
         .append("</p>\n");
-    sb.append("              <p class=\"sidecar-selected-detail\" data-j2cl-debug-only=\"true\" hidden>")
+    sb.append("              <p class=\"sidecar-selected-detail\" data-j2cl-debug-only=\"true\">")
         .append(escapeHtml(detail))
         .append("</p>\n");
     // F-2 slice 5 (#1055, R-3.7 G.6): live-update awareness pill.

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -559,12 +559,10 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         source.contains(
             "toolbarController.onEditStateChanged(editStateForWriteSession(writeSession));"));
     assertTrue(
-        "editStateForWriteSession must keep the legacy top toolbar non-editing; "
-            + "the inline composer owns edit chrome",
-        java.util.regex.Pattern.compile(
-                "return\\s+new\\s+J2clToolbarSurfaceController\\.EditState\\(\\s*false\\s*\\)")
-            .matcher(source)
-            .find());
+        "editStateForWriteSession must keep the legacy top toolbar non-editing "
+            + "while the inline composer owns edit chrome, but restore it for "
+            + "the legacy-composer fallback",
+        source.contains("writeSession != null && !inlineRichComposerEnabled"));
   }
 
   public void testComposerInlineReplyCollapsesUntilAvailable() {
@@ -738,9 +736,16 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         "Selected-wave status must stay hidden unless it carries an actual error",
         source.contains("status.hidden = !model.isError();"));
     assertTrue(
-        "Selected-wave detail must be hidden outside errors and debug-overlay; "
-            + "channel/snapshot IDs must not paint in the wave header",
+        "Selected-wave detail must stay hidden unless it carries an actual error",
+        source.contains("detail.hidden = !model.isError();"));
+    assertFalse(
+        "Selected-wave detail visibility must not depend on the page debug flag; "
+            + "only real error states may expose diagnostics",
         source.contains("detail.hidden = !model.isError() && !isDebugOverlayOn();"));
+    assertEquals(
+        "Both live and preserved render paths must gate detail visibility on errors",
+        2,
+        countOccurrences(source, "detail.hidden = !model.isError();"));
   }
 
   public void testV2SidecarCssCarriesDebugOnlyHideRule() {

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -722,7 +722,7 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         html.contains("class=\"sidecar-selected-status\" data-j2cl-debug-only"));
     assertTrue(
         "Preview-fixture detail must carry data-j2cl-debug-only (V-2 #1100)",
-        html.contains("class=\"sidecar-selected-detail\" data-j2cl-debug-only=\"true\" hidden"));
+        html.contains("class=\"sidecar-selected-detail\" data-j2cl-debug-only=\"true\""));
   }
 
   public void testSelectedWaveStatusAndDetailStayHiddenOutsideErrors() {
@@ -738,9 +738,9 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         "Selected-wave status must stay hidden unless it carries an actual error",
         source.contains("status.hidden = !model.isError();"));
     assertTrue(
-        "Selected-wave detail must be explicitly hidden so channel/snapshot IDs "
-            + "do not paint in the wave header",
-        source.contains("detail.hidden = true;"));
+        "Selected-wave detail must be hidden outside errors and debug-overlay; "
+            + "channel/snapshot IDs must not paint in the wave header",
+        source.contains("detail.hidden = !model.isError() && !isDebugOverlayOn();"));
   }
 
   public void testV2SidecarCssCarriesDebugOnlyHideRule() {

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -543,6 +543,30 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         callCount);
   }
 
+  public void testRootShellDoesNotTreatWriteSessionAsVisibleEditToolbar() {
+    // A writable wave is not the same thing as an active editor. The root shell
+    // already mounts the icon-only floating <wavy-format-toolbar> inside the
+    // inline composer; feeding write-session presence into the legacy top
+    // toolbar paints the old Bold/Italic/... text-button wall on every writable
+    // selected wave.
+    String source =
+        readSourceFile(
+            "j2cl/src/main/java/org/waveprotocol/box/j2cl/root/"
+                + "J2clRootShellController.java");
+    assertFalse(
+        "J2clRootShellController must not make the legacy top toolbar editable "
+            + "just because a write session exists",
+        source.contains(
+            "toolbarController.onEditStateChanged(editStateForWriteSession(writeSession));"));
+    assertTrue(
+        "editStateForWriteSession must keep the legacy top toolbar non-editing; "
+            + "the inline composer owns edit chrome",
+        java.util.regex.Pattern.compile(
+                "return\\s+new\\s+J2clToolbarSurfaceController\\.EditState\\(\\s*false\\s*\\)")
+            .matcher(source)
+            .find());
+  }
+
   public void testComposerInlineReplyCollapsesUntilAvailable() {
     // Gap 3 partner: <composer-inline-reply> rendered "Reply target: ..."
     // + an empty Send-reply textarea on every selected wave even when
@@ -557,6 +581,18 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
                 ":host\\(:not\\(\\[available\\]\\)\\)\\s*\\{\\s*display\\s*:\\s*none\\s*;\\s*\\}")
             .matcher(source)
             .find());
+  }
+
+  public void testInlineComposerScrollPreservationFallsBackToDocumentScroller() {
+    String source =
+        readSourceFile(
+            "j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/"
+                + "J2clComposeSurfaceView.java");
+    assertTrue(
+        "Inline reply composer mounting must preserve document/body scroll too; "
+            + "otherwise focusing a newly mounted composer can jump to the bottom "
+            + "when no nested panel is independently scrollable",
+        source.contains("DomGlobal.document.scrollingElement"));
   }
 
   public void testWavyComposerCollapsesUntilAvailable() {
@@ -686,7 +722,25 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         html.contains("class=\"sidecar-selected-status\" data-j2cl-debug-only"));
     assertTrue(
         "Preview-fixture detail must carry data-j2cl-debug-only (V-2 #1100)",
-        html.contains("class=\"sidecar-selected-detail\" data-j2cl-debug-only=\"true\""));
+        html.contains("class=\"sidecar-selected-detail\" data-j2cl-debug-only=\"true\" hidden"));
+  }
+
+  public void testSelectedWaveStatusAndDetailStayHiddenOutsideErrors() {
+    String source =
+        readSourceFile(
+            "j2cl/src/main/java/org/waveprotocol/box/j2cl/search/"
+                + "J2clSelectedWaveView.java");
+    assertFalse(
+        "Selected-wave status must not become visible just because the page "
+            + "debug flag is enabled; raw live-update text is not product UI",
+        source.contains("status.hidden = !model.isError() && !isDebugOverlayOn();"));
+    assertTrue(
+        "Selected-wave status must stay hidden unless it carries an actual error",
+        source.contains("status.hidden = !model.isError();"));
+    assertTrue(
+        "Selected-wave detail must be explicitly hidden so channel/snapshot IDs "
+            + "do not paint in the wave header",
+        source.contains("detail.hidden = true;"));
   }
 
   public void testV2SidecarCssCarriesDebugOnlyHideRule() {


### PR DESCRIPTION
Refs #1161\n\n## Summary\n- hides raw J2CL live-update/channel/snapshot detail text from the selected-wave header outside real error states\n- prevents page-level debug-overlay state from exposing raw reply target IDs inside user-facing composer components\n- keeps the legacy root-shell text formatting toolbar inactive; inline composers continue to own the icon-only format toolbar\n- preserves document/body scroll when opening inline reply composers so focus does not jump the wave to the bottom\n\n## Self-review\n- Scope is limited to the latest manual parity gaps: developer strings, legacy toolbar wall, and inline reply scroll jump.\n- No Claude review used per instruction; relying on self-review and PR review comments.\n- Server-first Jakarta renderer path was updated so hidden detail behavior applies before J2CL upgrade as well as after client render.\n\n## Verification\n- RED before fix: npm test -- --files test/wavy-composer.test.js test/composer-inline-reply.test.js -> 71 passed, 2 failed\n- RED before fix: python3 scripts/assemble-changelog.py && sbt --batch 'Test/testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellIntegrationTest' -> 36 passed, 2 failed\n- GREEN: npm test -- --files test/wavy-composer.test.js test/composer-inline-reply.test.js -> 73 passed, 0 failed\n- GREEN: python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json && sbt --batch 'Test/testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellIntegrationTest' && git diff --check -> passed, 39/39\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve scroll position when opening inline reply composers to avoid jumps.
  * Toolbar no longer becomes editable solely from write-session state; tied to inline-composer setting.
  * Hide internal live/update/channel/snapshot/reply-target identifiers from normal UI.
  * Composer components and selected-wave debug details no longer inherit page-level debug overlay and start hidden unless explicitly enabled.
* **Tests**
  * Added unit and integration tests validating the above behaviors.
* **Chores**
  * Added changelog entry documenting the UI parity fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->