### PR TITLE
fix(j2cl): align New Wave composer with GWT layout

### DIFF
--- a/j2cl/lit/src/elements/composer-shell.js
+++ b/j2cl/lit/src/elements/composer-shell.js
@@ -12,16 +12,17 @@ export class ComposerShell extends LitElement {
 
     .shell {
       display: grid;
-      gap: 14px;
-      padding: 14px;
-      border: 1px solid var(--shell-color-divider-subtle, #e5edf5);
-      border-radius: 16px;
+      gap: 12px;
+      padding: 8px;
+      border: 1px solid var(--shell-color-divider-subtle, #e2e8f0);
+      border-radius: 4px;
       background: var(--shell-color-surface-shell, #fff);
     }
 
     h2,
     h3 {
       margin: 0 0 8px;
+      font-size: 1.05rem;
     }
   `;
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -568,7 +568,7 @@ public final class J2clComposeSurfaceController {
     void onCurrentUserAddress(String address);
   }
   private boolean createSubmitting;
-  private String createStatusText = "Create a self-owned wave inside the root shell.";
+  private String createStatusText = "";
   private String createErrorText = "";
   private J2clSidecarWriteSession writeSession;
   private String lastSelectedWaveId;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -95,7 +95,7 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
 
     HTMLFormElement createForm = (HTMLFormElement) DomGlobal.document.createElement("form");
     createForm.setAttribute("slot", "create");
-    createForm.className = "j2cl-compose-create-form";
+    createForm.className = "j2cl-compose-create-form sidecar-compose-form";
     shell.appendChild(createForm);
 
     // J-UI-3 (#1081, R-5.1): single-line title input above the body textarea.
@@ -103,6 +103,7 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     // we declare the body textarea first so the title-input's Enter handler
     // can reference it without tripping definite-assignment.
     createInput = (HTMLTextAreaElement) DomGlobal.document.createElement("textarea");
+    createInput.className = "j2cl-compose-create-body sidecar-compose-textarea";
     createInput.setAttribute("aria-label", "New wave content");
     createInput.setAttribute("placeholder", "Start a new wave");
     createInput.rows = 4;
@@ -116,7 +117,7 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
 
     createTitleInput = (HTMLInputElement) DomGlobal.document.createElement("input");
     createTitleInput.type = "text";
-    createTitleInput.className = "j2cl-compose-create-title";
+    createTitleInput.className = "j2cl-compose-create-title sidecar-compose-input";
     createTitleInput.setAttribute("aria-label", "New wave title");
     createTitleInput.setAttribute("placeholder", "Title");
     createTitleInput.setAttribute("autocomplete", "off");

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -501,6 +501,28 @@ shell-root[data-wave-controls-compact="true"] wavy-wave-nav-row {
   margin-top: 14px;
 }
 
+.j2cl-compose-create-form {
+  max-width: 680px;
+}
+
+.sidecar-compose-input {
+  width: 100%;
+  border: 1px solid #c8d5e6;
+  border-radius: 4px;
+  background: #ffffff;
+  color: #1a202c;
+  font: inherit;
+  line-height: 1.4;
+  padding: 9px 10px;
+  box-sizing: border-box;
+}
+
+.sidecar-compose-input:focus {
+  outline: none;
+  border-color: #0077b6;
+  box-shadow: 0 0 0 3px rgba(0, 119, 182, 0.10);
+}
+
 .sidecar-compose-textarea {
   width: 100%;
   min-height: 112px;

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -505,6 +505,10 @@ shell-root[data-wave-controls-compact="true"] wavy-wave-nav-row {
   max-width: 680px;
 }
 
+.sidecar-compose-form composer-submit-affordance {
+  justify-self: start;
+}
+
 .sidecar-compose-input {
   width: 100%;
   border: 1px solid #c8d5e6;

--- a/wave/config/changelog.d/2026-05-02-j2cl-create-wave-gwt-layout.json
+++ b/wave/config/changelog.d/2026-05-02-j2cl-create-wave-gwt-layout.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-02-j2cl-create-wave-gwt-layout",
+  "version": "Issue #1161",
+  "date": "2026-05-02",
+  "title": "J2CL New Wave composer layout parity",
+  "summary": "Makes the J2CL root-shell New Wave composer match the stacked GWT compose-card layout.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Stacks the New Wave title, body, and Create wave controls vertically instead of letting them paint as one inline row.",
+        "Removes the implementation-facing default helper text from the create composer so the card stays focused on title, body, and submit controls."
+      ]
+    }
+  ]
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -870,12 +870,25 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         "Root-shell create form needs a bounded card width matching the "
             + "legacy GWT compose column rather than stretching controls "
             + "across the entire wave panel",
-        css.contains(".j2cl-compose-create-form") && css.contains("max-width"));
+        java.util.regex.Pattern.compile(
+                "\\.j2cl-compose-create-form\\s*\\{[^}]*\\bmax-width\\s*:\\s*680px\\s*;")
+            .matcher(css)
+            .find());
 
     String shellSource = readSourceFile("j2cl/lit/src/elements/composer-shell.js");
     assertTrue(
         "The create shell should use the same compact, low-radius card "
             + "language as the GWT compose block rather than a large rounded panel",
-        shellSource.contains("border-radius: 4px") && shellSource.contains("font-size: 1.05rem"));
+        java.util.regex.Pattern.compile(
+                "\\.shell\\s*\\{[^}]*\\bborder-radius\\s*:\\s*4px\\s*;")
+            .matcher(shellSource)
+            .find());
+    assertTrue(
+        "Composer-shell headings should use the same compact font size as "
+            + "the GWT compose block rather than large decorative headings",
+        java.util.regex.Pattern.compile(
+                "h2[^{]*\\{[^}]*\\bfont-size\\s*:\\s*1\\.05rem\\s*;")
+            .matcher(shellSource)
+            .find());
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -837,4 +837,45 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         source.indexOf("revealCreateSurface();", source.indexOf("public void focusCreateComposer()"))
             < source.indexOf("if (!createInput.disabled)", source.indexOf("public void focusCreateComposer()")));
   }
+
+  public void testRootShellCreateWaveUsesGwtLikeStackedComposeLayout() {
+    String source =
+        readSourceFile(
+            "j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/"
+                + "J2clComposeSurfaceView.java");
+    assertTrue(
+        "Root-shell create form must reuse the sidecar compose grid so "
+            + "title, body, and Create wave button stack like GWT instead "
+            + "of painting as one inline row",
+        source.contains("j2cl-compose-create-form sidecar-compose-form"));
+    assertTrue(
+        "New-wave title input must carry the shared compose-input class "
+            + "so it has GWT-like width, spacing, and focus chrome",
+        source.contains("j2cl-compose-create-title sidecar-compose-input"));
+    assertTrue(
+        "New-wave body textarea must carry the shared compose-textarea "
+            + "class so it fills the compose card instead of sitting inline",
+        source.contains("j2cl-compose-create-body sidecar-compose-textarea"));
+    assertFalse(
+        "Root-shell create wave should not show implementation copy like "
+            + "'self-owned wave inside the root shell' in the compose card; "
+            + "GWT keeps the create surface focused on the title/body/button.",
+        readSourceFile(
+                "j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/"
+                    + "J2clComposeSurfaceController.java")
+            .contains("Create a self-owned wave inside the root shell."));
+
+    String css = readSourceFile("j2cl/src/main/webapp/assets/sidecar.css");
+    assertTrue(
+        "Root-shell create form needs a bounded card width matching the "
+            + "legacy GWT compose column rather than stretching controls "
+            + "across the entire wave panel",
+        css.contains(".j2cl-compose-create-form") && css.contains("max-width"));
+
+    String shellSource = readSourceFile("j2cl/lit/src/elements/composer-shell.js");
+    assertTrue(
+        "The create shell should use the same compact, low-radius card "
+            + "language as the GWT compose block rather than a large rounded panel",
+        shellSource.contains("border-radius: 4px") && shellSource.contains("font-size: 1.05rem"));
+  }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -874,6 +874,14 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
                 "\\.j2cl-compose-create-form\\s*\\{[^}]*\\bmax-width\\s*:\\s*680px\\s*;")
             .matcher(css)
             .find());
+    assertTrue(
+        "composer-submit-affordance inside a grid compose form must not stretch "
+            + "to full row width; it needs justify-self: start to stay compact",
+        java.util.regex.Pattern.compile(
+                "\\.sidecar-compose-form\\s+composer-submit-affordance\\s*\\{"
+                    + "[^}]*\\bjustify-self\\s*:\\s*start\\s*;")
+            .matcher(css)
+            .find());
 
     String shellSource = readSourceFile("j2cl/lit/src/elements/composer-shell.js");
     assertTrue(


### PR DESCRIPTION
## Summary
- stacks the J2CL root-shell New Wave title, body, and submit controls using the existing GWT-like sidecar compose grid
- tightens the composer shell card radius/padding/title scale to match the flatter GWT compose block
- removes implementation-facing default helper text from the New Wave card

## Self-review
- Kept the fix narrow to the create-wave surface shown in the screenshot.
- Reused existing sidecar compose classes instead of introducing a separate visual language.
- Preserved create submission/status behavior; only the default idle helper copy is removed.

## Verification
- RED: `sbt --batch 'Test/testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellIntegrationTest'` failed on `testRootShellCreateWaveUsesGwtLikeStackedComposeLayout` before the fix.\n- GREEN: `npm test -- --files test/composer-shell.test.js` -> 2 passed, 0 failed.\n- GREEN: `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json && sbt --batch 'Test/testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellIntegrationTest'` -> 40 passed, 0 failed.\n- GREEN: `sbt --batch j2clSearchBuild && git diff --check` -> passed.\n\nNo Claude Code review used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Composer create form now stacks vertically with a bounded card width for a tighter layout
  * Reduced spacing, padding, and refined flatter border radius
  * Adjusted heading sizing for consistency
  * Improved input styling and focus states for clearer visual feedback
  * Removed default helper/status text from the create composer

* **Tests**
  * Added integration test verifying the stacked compose layout and visual rules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->