### PR TITLE
fix(j2cl): restore read state navigation parity

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -836,11 +836,13 @@ public final class J2clSelectedWaveController
               previousModel
                   .withViewportState(mergedState)
                   .withReadBlips(
-                      J2clSelectedWaveProjector.applyViewportMetadataFallbacks(
-                          mergedState.getLoadedReadBlips(),
-                          metadataFallbacks,
-                          selectedDigestItem,
-                          /* preserveFallbackBooleans= */ true));
+                      J2clSelectedWaveProjector.applyReadStateToReadBlips(
+                          J2clSelectedWaveProjector.applyViewportMetadataFallbacks(
+                              mergedState.getLoadedReadBlips(),
+                              metadataFallbacks,
+                              selectedDigestItem,
+                              /* preserveFallbackBooleans= */ true),
+                          currentReadState));
           if (!responseManifest.isEmpty()) {
             // Viewport rendering consumes the manifest directly for depth and
             // ordering. Do not expand model readBlips here: fragment windows

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -2,6 +2,7 @@ package org.waveprotocol.box.j2cl.search;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -157,6 +158,9 @@ public final class J2clSelectedWaveProjector {
       read = false;
       readStateKnown = false;
     }
+    if (readStateMatchesWave) {
+      readBlips = applyReadStateToReadBlips(readBlips, readState);
+    }
     // Only surface the "stale" banner when we actually have a known read-state
     // to be stale about — an initial fetch failure with no prior snapshot would
     // otherwise claim the unread count is stale even though no count exists.
@@ -307,7 +311,7 @@ public final class J2clSelectedWaveProjector {
         previous.getReconnectCount(),
         previous.getParticipantIds(),
         previous.getContentEntries(),
-        previous.getReadBlips(),
+        applyReadStateToReadBlips(previous.getReadBlips(), readStateMatchesWave ? readState : null),
         previous.getViewportState(),
         previous.getInteractionBlips(),
         previous.getWriteSession(),
@@ -320,6 +324,47 @@ public final class J2clSelectedWaveProjector {
         // document and must not flatten threading.
         .withConversationManifest(previous.getConversationManifest())
         .withLockState(previous.getLockState());
+  }
+
+  public static List<J2clReadBlip> applyReadStateToReadBlips(
+      List<J2clReadBlip> readBlips, SidecarSelectedWaveReadState readState) {
+    if (readBlips == null || readBlips.isEmpty() || readState == null) {
+      return readBlips;
+    }
+    Set<String> unreadIds = new HashSet<String>(readState.getUnreadBlipIds());
+    if (unreadIds.isEmpty() && readState.getUnreadCount() <= 0) {
+      return markAllRead(readBlips);
+    }
+    if (unreadIds.isEmpty()) {
+      return readBlips;
+    }
+    List<J2clReadBlip> updated = new ArrayList<J2clReadBlip>(readBlips.size());
+    boolean changed = false;
+    for (J2clReadBlip blip : readBlips) {
+      if (blip == null || blip.getBlipId().isEmpty()) {
+        updated.add(blip);
+        continue;
+      }
+      J2clReadBlip next = blip.withUnread(unreadIds.contains(blip.getBlipId()));
+      changed |= next != blip;
+      updated.add(next);
+    }
+    return changed ? updated : readBlips;
+  }
+
+  private static List<J2clReadBlip> markAllRead(List<J2clReadBlip> readBlips) {
+    List<J2clReadBlip> updated = new ArrayList<J2clReadBlip>(readBlips.size());
+    boolean changed = false;
+    for (J2clReadBlip blip : readBlips) {
+      if (blip == null) {
+        updated.add(null);
+        continue;
+      }
+      J2clReadBlip next = blip.withUnread(false);
+      changed |= next != blip;
+      updated.add(next);
+    }
+    return changed ? updated : readBlips;
   }
 
   private static String appendStatus(String base, String suffix) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -341,7 +341,7 @@ public final class J2clSelectedWaveProjector {
     List<J2clReadBlip> updated = new ArrayList<J2clReadBlip>(readBlips.size());
     boolean changed = false;
     for (J2clReadBlip blip : readBlips) {
-      if (blip == null || blip.getBlipId().isEmpty()) {
+      if (blip == null || blip.getBlipId() == null || blip.getBlipId().isEmpty()) {
         updated.add(blip);
         continue;
       }
@@ -999,7 +999,7 @@ public final class J2clSelectedWaveProjector {
     }
     Map<String, J2clReadBlip> blipsById = new LinkedHashMap<String, J2clReadBlip>();
     for (J2clReadBlip blip : readBlips) {
-      if (blip == null || blip.getBlipId().isEmpty()) {
+      if (blip == null || blip.getBlipId() == null || blip.getBlipId().isEmpty()) {
         continue;
       }
       blipsById.put(blip.getBlipId(), blip);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -554,10 +554,17 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
 
   private int focusedBlipIndex(List<HTMLElement> blips) {
     elemental2.dom.Element active = DomGlobal.document.activeElement;
+    if (active != null) {
+      for (int index = 0; index < blips.size(); index++) {
+        HTMLElement blip = blips.get(index);
+        if (blip == active || blip.contains(active)) {
+          return index;
+        }
+      }
+    }
     for (int index = 0; index < blips.size(); index++) {
       HTMLElement blip = blips.get(index);
-      if ((active != null && (blip == active || blip.contains(active)))
-          || blip.hasAttribute("focused")
+      if (blip.hasAttribute("focused")
           || "true".equals(blip.getAttribute("data-blip-focused"))
           || blip.classList.contains("j2cl-read-blip-focused")) {
         return index;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -554,12 +554,12 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
 
   private int focusedBlipIndex(List<HTMLElement> blips) {
     elemental2.dom.Element active = DomGlobal.document.activeElement;
-    if (active == null) {
-      return -1;
-    }
     for (int index = 0; index < blips.size(); index++) {
       HTMLElement blip = blips.get(index);
-      if (blip == active || blip.contains(active)) {
+      if ((active != null && (blip == active || blip.contains(active)))
+          || blip.hasAttribute("focused")
+          || blip.hasAttribute("data-blip-focused")
+          || blip.classList.contains("j2cl-read-blip-focused")) {
         return index;
       }
     }
@@ -573,6 +573,15 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     List<HTMLElement> blips = renderedBlips();
     for (HTMLElement blip : blips) {
       blip.setAttribute("tabindex", blip == target ? "0" : "-1");
+      if (blip == target) {
+        blip.setAttribute("focused", "");
+        blip.setAttribute("data-blip-focused", "true");
+        blip.classList.add("j2cl-read-blip-focused");
+      } else {
+        blip.removeAttribute("focused");
+        blip.removeAttribute("data-blip-focused");
+        blip.classList.remove("j2cl-read-blip-focused");
+      }
     }
     FocusOptionsType focusOptions = FocusOptionsType.create();
     focusOptions.setPreventScroll(true);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -558,7 +558,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       HTMLElement blip = blips.get(index);
       if ((active != null && (blip == active || blip.contains(active)))
           || blip.hasAttribute("focused")
-          || blip.hasAttribute("data-blip-focused")
+          || "true".equals(blip.getAttribute("data-blip-focused"))
           || blip.classList.contains("j2cl-read-blip-focused")) {
         return index;
       }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -576,10 +576,12 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       if (blip == target) {
         blip.setAttribute("focused", "");
         blip.setAttribute("data-blip-focused", "true");
+        blip.setAttribute("aria-current", "true");
         blip.classList.add("j2cl-read-blip-focused");
       } else {
         blip.removeAttribute("focused");
         blip.removeAttribute("data-blip-focused");
+        blip.removeAttribute("aria-current");
         blip.classList.remove("j2cl-read-blip-focused");
       }
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveReadState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveReadState.java
@@ -1,5 +1,9 @@
 package org.waveprotocol.box.j2cl.transport;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Per-user unread/read state for a single selected wave. Populated from the
  * server's {@code /read-state} endpoint (issue #931).
@@ -8,11 +12,21 @@ public final class SidecarSelectedWaveReadState {
   private final String waveId;
   private final int unreadCount;
   private final boolean read;
+  private final List<String> unreadBlipIds;
 
   public SidecarSelectedWaveReadState(String waveId, int unreadCount, boolean read) {
+    this(waveId, unreadCount, read, Collections.<String>emptyList());
+  }
+
+  public SidecarSelectedWaveReadState(
+      String waveId, int unreadCount, boolean read, List<String> unreadBlipIds) {
     this.waveId = waveId;
     this.unreadCount = unreadCount;
     this.read = read;
+    this.unreadBlipIds =
+        unreadBlipIds == null
+            ? Collections.<String>emptyList()
+            : Collections.unmodifiableList(new ArrayList<String>(unreadBlipIds));
   }
 
   public String getWaveId() {
@@ -25,5 +39,9 @@ public final class SidecarSelectedWaveReadState {
 
   public boolean isRead() {
     return read;
+  }
+
+  public List<String> getUnreadBlipIds() {
+    return unreadBlipIds;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -320,7 +320,8 @@ public final class SidecarTransportCodec {
     String waveId = getString(root, "waveId");
     int unreadCount = getInt(root, "unreadCount");
     boolean read = getBoolean(root, "isRead");
-    return new SidecarSelectedWaveReadState(waveId, unreadCount, read);
+    List<String> unreadBlipIds = getStringList(root, "unreadBlipIds");
+    return new SidecarSelectedWaveReadState(waveId, unreadCount, read, unreadBlipIds);
   }
 
   public static boolean decodeRpcFinishedFailed(Map<String, Object> envelope) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -113,6 +113,64 @@ public class J2clSelectedWaveProjectorTest {
   }
 
   @Test
+  public void projectAppliesServerUnreadBlipIdsToReadModels() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            fragmentUpdate("b+root", "Root text", "b+reply", "Reply text"),
+            null,
+            0,
+            new SidecarSelectedWaveReadState(
+                WAVE_ID, 1, false, Arrays.asList("b+reply")),
+            false);
+
+    Assert.assertEquals(2, projected.getReadBlips().size());
+    Assert.assertFalse(projected.getReadBlips().get(0).isUnread());
+    Assert.assertEquals("b+reply", projected.getReadBlips().get(1).getBlipId());
+    Assert.assertTrue(projected.getReadBlips().get(1).isUnread());
+  }
+
+  @Test
+  public void reprojectReadStateAppliesServerUnreadBlipIdsToExistingReadModels() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            fragmentUpdate("b+root", "Root text", "b+reply", "Reply text"),
+            null,
+            0);
+
+    J2clSelectedWaveModel reprojected =
+        J2clSelectedWaveProjector.reprojectReadState(
+            projected,
+            digest("Wave A", "snippet", 1),
+            new SidecarSelectedWaveReadState(
+                WAVE_ID, 1, false, Arrays.asList("b+reply")),
+            false);
+
+    Assert.assertEquals(2, reprojected.getReadBlips().size());
+    Assert.assertFalse(reprojected.getReadBlips().get(0).isUnread());
+    Assert.assertTrue(reprojected.getReadBlips().get(1).isUnread());
+  }
+
+  @Test
+  public void applyReadStatePreservesExistingBlipMarkersWhenUnreadIdsAreAbsent() {
+    java.util.List<J2clReadBlip> blips =
+        Arrays.asList(
+            new J2clReadBlip("b+root", "Root").withUnread(false),
+            new J2clReadBlip("b+reply", "Reply").withUnread(true));
+
+    java.util.List<J2clReadBlip> projected =
+        J2clSelectedWaveProjector.applyReadStateToReadBlips(
+            blips, new SidecarSelectedWaveReadState(WAVE_ID, 1, false));
+
+    Assert.assertSame(blips, projected);
+    Assert.assertFalse(projected.get(0).isUnread());
+    Assert.assertTrue(projected.get(1).isUnread());
+  }
+
+  @Test
   public void staleFlagPreservesPriorCountAndAnnotatesStatus() {
     J2clSelectedWaveModel fresh =
         J2clSelectedWaveProjector.project(
@@ -3604,6 +3662,29 @@ public class J2clSelectedWaveProjectorTest {
         Arrays.asList("user@example.com"),
         new ArrayList<SidecarSelectedWaveDocument>(),
         null);
+  }
+
+  private static SidecarSelectedWaveUpdate fragmentUpdate(
+      String firstBlipId, String firstText, String secondBlipId, String secondText) {
+    return new SidecarSelectedWaveUpdate(
+        1,
+        WAVELET_NAME,
+        true,
+        CHANNEL_ID,
+        9L,
+        "HASH",
+        Arrays.asList("user@example.com"),
+        Collections.<SidecarSelectedWaveDocument>emptyList(),
+        new SidecarSelectedWaveFragments(
+            9L,
+            0L,
+            9L,
+            Arrays.asList(
+                new SidecarSelectedWaveFragmentRange("blip:" + firstBlipId, 0L, 9L),
+                new SidecarSelectedWaveFragmentRange("blip:" + secondBlipId, 0L, 9L)),
+            Arrays.asList(
+                new SidecarSelectedWaveFragment("blip:" + firstBlipId, firstText, 0, 0),
+                new SidecarSelectedWaveFragment("blip:" + secondBlipId, secondText, 0, 0))));
   }
 
   private static SidecarSelectedWaveDocument lockDocument(String lockState) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -636,6 +636,37 @@ public class J2clSelectedWaveViewChromeTest {
   }
 
   @Test
+  public void navRowNextAndPreviousUseFocusedBlipMarkerAfterToolbarButtonTakesFocus() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+    view.render(navigationModel());
+    HTMLElement first = (HTMLElement) host.querySelector("wave-blip[data-blip-id='b+1']");
+    HTMLElement second = (HTMLElement) host.querySelector("wave-blip[data-blip-id='b+2']");
+    HTMLElement third = (HTMLElement) host.querySelector("wave-blip[data-blip-id='b+3']");
+    HTMLElement row = (HTMLElement) host.querySelector("wavy-wave-nav-row");
+    Assert.assertNotNull(first);
+    Assert.assertNotNull(second);
+    Assert.assertNotNull(third);
+    Assert.assertNotNull(row);
+
+    second.setAttribute("focused", "");
+    second.setAttribute("data-blip-focused", "true");
+    row.focus();
+
+    dispatchNavEvent(view.getCardElement(), "wave-nav-next-requested");
+
+    Assert.assertEquals(
+        "nav action must continue from the focused blip marker, not the clicked toolbar button",
+        third,
+        DomGlobal.document.activeElement);
+
+    dispatchNavEvent(view.getCardElement(), "wave-nav-previous-requested");
+
+    Assert.assertEquals(second, DomGlobal.document.activeElement);
+  }
+
+  @Test
   public void navRowRecentEndUnreadAndMentionEventsMoveFocusedBlip() {
     assumeBrowserDom();
     HTMLElement host = createHost();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -653,6 +653,10 @@ public class J2clSelectedWaveViewChromeTest {
     second.setAttribute("focused", "");
     second.setAttribute("data-blip-focused", "true");
     row.focus();
+    Assert.assertEquals(
+        "Precondition: nav row owns focus before dispatching toolbar navigation events",
+        row,
+        DomGlobal.document.activeElement);
 
     dispatchNavEvent(view.getCardElement(), "wave-nav-next-requested");
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -660,10 +660,14 @@ public class J2clSelectedWaveViewChromeTest {
         "nav action must continue from the focused blip marker, not the clicked toolbar button",
         third,
         DomGlobal.document.activeElement);
+    Assert.assertEquals("true", third.getAttribute("aria-current"));
+    Assert.assertFalse(second.hasAttribute("aria-current"));
 
     dispatchNavEvent(view.getCardElement(), "wave-nav-previous-requested");
 
     Assert.assertEquals(second, DomGlobal.document.activeElement);
+    Assert.assertEquals("true", second.getAttribute("aria-current"));
+    Assert.assertFalse(third.hasAttribute("aria-current"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -13,13 +13,15 @@ public class SidecarTransportCodecTest {
   @Test
   public void decodeSelectedWaveReadStateReadsEndpointJson() {
     String json =
-        "{\"waveId\":\"example.com/w+abc\",\"unreadCount\":4,\"isRead\":false}";
+        "{\"waveId\":\"example.com/w+abc\",\"unreadCount\":4,\"isRead\":false,"
+            + "\"unreadBlipIds\":[\"b+2\",\"b+7\"]}";
 
     SidecarSelectedWaveReadState state = SidecarTransportCodec.decodeSelectedWaveReadState(json);
 
     Assert.assertEquals("example.com/w+abc", state.getWaveId());
     Assert.assertEquals(4, state.getUnreadCount());
     Assert.assertFalse(state.isRead());
+    Assert.assertEquals(Arrays.asList("b+2", "b+7"), state.getUnreadBlipIds());
   }
 
   @Test
@@ -31,6 +33,7 @@ public class SidecarTransportCodecTest {
     Assert.assertEquals("example.com/w+abc", state.getWaveId());
     Assert.assertEquals(0, state.getUnreadCount());
     Assert.assertFalse(state.isRead());
+    Assert.assertTrue(state.getUnreadBlipIds().isEmpty());
   }
 
   @Test

--- a/wave/config/changelog.d/2026-05-03-j2cl-read-nav-parity.json
+++ b/wave/config/changelog.d/2026-05-03-j2cl-read-nav-parity.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-05-03-j2cl-read-nav-parity",
+  "version": "J2CL parity",
+  "date": "2026-05-03",
+  "title": "J2CL read-state and navigation parity",
+  "summary": "Restores per-blip unread markers and toolbar navigation behavior in the J2CL wave view.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Adds per-blip unread IDs to the selected-wave read-state response so J2CL can mark unread blips inside the wave, not only show the aggregate unread count.",
+        "Keeps newly loaded J2CL viewport fragments aligned with the current read state so the search list and visible blip markers update after read-state refreshes.",
+        "Preserves the focused blip while using wave navigation toolbar buttons so previous, next, recent, and unread navigation commands keep moving from the current blip instead of losing context to the toolbar."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServlet.java
@@ -24,6 +24,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 
 import org.waveprotocol.box.server.authentication.SessionManager;
 import org.waveprotocol.box.server.authentication.WebSessions;
@@ -101,17 +102,31 @@ public final class SelectedWaveReadStateServlet extends HttpServlet {
       return;
     }
 
-    writeJson(resp, rawWaveId, result.getUnreadCount(), result.isRead());
+    writeJson(resp, rawWaveId, result.getUnreadCount(), result.isRead(), result.getUnreadBlipIds());
   }
 
   private static void writeJson(
-      HttpServletResponse resp, String waveId, int unreadCount, boolean isRead)
+      HttpServletResponse resp,
+      String waveId,
+      int unreadCount,
+      boolean isRead,
+      List<String> unreadBlipIds)
       throws IOException {
     resp.setStatus(HttpServletResponse.SC_OK);
     resp.setContentType("application/json; charset=utf-8");
     StringBuilder body = new StringBuilder(64);
     body.append("{\"waveId\":\"").append(escapeJson(waveId)).append("\",\"unreadCount\":")
-        .append(unreadCount).append(",\"isRead\":").append(isRead).append('}');
+        .append(unreadCount).append(",\"isRead\":").append(isRead)
+        .append(",\"unreadBlipIds\":[");
+    if (unreadBlipIds != null) {
+      for (int i = 0; i < unreadBlipIds.size(); i++) {
+        if (i > 0) {
+          body.append(',');
+        }
+        body.append('"').append(escapeJson(unreadBlipIds.get(i))).append('"');
+      }
+    }
+    body.append("]}");
     try (var w = resp.getWriter()) {
       w.append(body.toString());
       w.flush();

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServlet.java
@@ -119,11 +119,16 @@ public final class SelectedWaveReadStateServlet extends HttpServlet {
         .append(unreadCount).append(",\"isRead\":").append(isRead)
         .append(",\"unreadBlipIds\":[");
     if (unreadBlipIds != null) {
-      for (int i = 0; i < unreadBlipIds.size(); i++) {
-        if (i > 0) {
+      boolean first = true;
+      for (String blipId : unreadBlipIds) {
+        if (blipId == null) {
+          continue;
+        }
+        if (!first) {
           body.append(',');
         }
-        body.append('"').append(escapeJson(unreadBlipIds.get(i))).append('"');
+        body.append('"').append(escapeJson(blipId)).append('"');
+        first = false;
       }
     }
     body.append("]}");

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
@@ -24,6 +24,9 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import com.google.wave.api.SearchResult.Digest;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.waveprotocol.box.server.CoreSettingsNames;
 import org.waveprotocol.box.server.util.WaveletDataUtil;
 import org.waveprotocol.wave.model.id.IdUtil;
@@ -61,25 +64,40 @@ public class SelectedWaveReadStateHelper {
     private final boolean accessAllowed;
     private final int unreadCount;
     private final boolean read;
+    private final List<String> unreadBlipIds;
 
-    private Result(boolean exists, boolean accessAllowed, int unreadCount, boolean read) {
+    private Result(
+        boolean exists,
+        boolean accessAllowed,
+        int unreadCount,
+        boolean read,
+        List<String> unreadBlipIds) {
       this.exists = exists;
       this.accessAllowed = accessAllowed;
       this.unreadCount = unreadCount;
       this.read = read;
+      this.unreadBlipIds =
+          unreadBlipIds == null
+              ? Collections.<String>emptyList()
+              : Collections.unmodifiableList(new ArrayList<String>(unreadBlipIds));
     }
 
     public boolean exists() { return exists; }
     public boolean accessAllowed() { return accessAllowed; }
     public int getUnreadCount() { return unreadCount; }
     public boolean isRead() { return read; }
+    public List<String> getUnreadBlipIds() { return unreadBlipIds; }
 
     public static Result notFound() {
-      return new Result(false, false, 0, true);
+      return new Result(false, false, 0, true, Collections.<String>emptyList());
     }
 
     public static Result found(int unreadCount) {
-      return new Result(true, true, unreadCount, unreadCount <= 0);
+      return found(unreadCount, Collections.<String>emptyList());
+    }
+
+    public static Result found(int unreadCount, List<String> unreadBlipIds) {
+      return new Result(true, true, unreadCount, unreadCount <= 0, unreadBlipIds);
     }
   }
 
@@ -129,7 +147,9 @@ public class SelectedWaveReadStateHelper {
 
     try {
       Digest digest = digester.build(user, view);
-      return Result.found(Math.max(0, digest.getUnreadCount()));
+      return Result.found(
+          Math.max(0, digest.getUnreadCount()),
+          digester.getUnreadBlipIds(user, view));
     } catch (RuntimeException e) {
       LOG.warning("read-state: digest build failed for " + waveId, e);
       throw e;

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
@@ -22,7 +22,6 @@ package org.waveprotocol.box.server.waveserver;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
-import com.google.wave.api.SearchResult.Digest;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -146,12 +145,12 @@ public class SelectedWaveReadStateHelper {
     }
 
     try {
-      Digest digest = digester.build(user, view);
+      WaveDigester.UnreadBlipState readState = digester.getUnreadBlipState(user, view);
       return Result.found(
-          Math.max(0, digest.getUnreadCount()),
-          digester.getUnreadBlipIds(user, view));
+          Math.max(0, readState.getUnreadCount()),
+          readState.getUnreadBlipIds());
     } catch (RuntimeException e) {
-      LOG.warning("read-state: digest build failed for " + waveId, e);
+      LOG.warning("read-state: unread state build failed for " + waveId, e);
       throw e;
     }
   }

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveDigester.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveDigester.java
@@ -244,6 +244,85 @@ public class WaveDigester {
     return digest;
   }
 
+  /**
+   * Returns the unread conversational blip ids for the same viewer/wave input
+   * used to build search digests. This mirrors {@link #build} rather than
+   * deriving from raw document ids so J2CL read-state uses the GWT
+   * conversation/supplement semantics and skips non-conversation documents.
+   */
+  public List<String> getUnreadBlipIds(ParticipantId participant, WaveViewData wave) {
+    if (wave == null) {
+      return Collections.emptyList();
+    }
+    ObservableWaveletData root = null;
+    ObservableWaveletData other = null;
+    List<ObservableWaveletData> conversationalWavelets = new ArrayList<ObservableWaveletData>();
+    for (ObservableWaveletData waveletData : wave.getWavelets()) {
+      WaveletId waveletId = waveletData.getWaveletId();
+      if (IdUtil.isConversationRootWaveletId(waveletId)) {
+        root = waveletData;
+        conversationalWavelets.add(waveletData);
+      } else if (IdUtil.isConversationalId(waveletId)) {
+        conversationalWavelets.add(waveletData);
+        other = waveletData;
+      }
+    }
+    ObservableWaveletData convWavelet = root != null ? root : other;
+    if (convWavelet == null) {
+      return Collections.emptyList();
+    }
+    Map<ObservableWaveletData, OpBasedWavelet> waveletAdapters =
+        new IdentityHashMap<ObservableWaveletData, OpBasedWavelet>();
+    OpBasedWavelet wavelet = getOrCreateReadOnlyWavelet(convWavelet, waveletAdapters);
+    if (!WaveletBasedConversation.waveletHasConversation(wavelet)) {
+      return Collections.emptyList();
+    }
+    ObservableConversationView conversations = conversationUtil.buildConversation(wavelet);
+    SupplementedWave supplement =
+        buildSupplement(
+            participant,
+            conversations,
+            findViewerUserDataWavelet(participant, wave.getWavelets()),
+            conversationalWavelets,
+            waveletAdapters);
+    return collectUnreadBlipIds(
+        convWavelet, conversationalWavelets, supplement, conversations, waveletAdapters);
+  }
+
+  private List<String> collectUnreadBlipIds(
+      WaveletData convWavelet,
+      Iterable<? extends ObservableWaveletData> conversationalWavelets,
+      SupplementedWave supplement,
+      ObservableConversationView conversations,
+      Map<ObservableWaveletData, OpBasedWavelet> waveletAdapters) {
+    if (convWavelet == null || supplement == null || conversations == null) {
+      return Collections.emptyList();
+    }
+    List<String> unreadBlipIds = new ArrayList<String>();
+    ObservableConversation rootConversation = chooseDigestConversation(conversations);
+    for (ObservableWaveletData conversationalWavelet : conversationalWavelets) {
+      ObservableConversation conversation;
+      if (conversationalWavelet == convWavelet) {
+        conversation = rootConversation;
+      } else {
+        OpBasedWavelet wavelet = getOrCreateReadOnlyWavelet(conversationalWavelet, waveletAdapters);
+        if (!WaveletBasedConversation.waveletHasConversation(wavelet)) {
+          continue;
+        }
+        conversation = chooseDigestConversation(conversationUtil.buildConversation(wavelet));
+      }
+      if (conversation == null) {
+        continue;
+      }
+      for (ConversationBlip blip : BlipIterators.breadthFirst(conversation)) {
+        if (supplement.isUnread(blip)) {
+          unreadBlipIds.add(blip.getId());
+        }
+      }
+    }
+    return unreadBlipIds;
+  }
+
   static ObservableWaveletData findViewerUserDataWavelet(
       ParticipantId participant, Iterable<? extends ObservableWaveletData> wavelets) {
     if (participant == null || wavelets == null) {

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveDigester.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveDigester.java
@@ -74,6 +74,48 @@ public class WaveDigester {
   private static final int PARTICIPANTS_SNIPPET_LENGTH = 5;
   private static final String EMPTY_WAVELET_TITLE = "";
 
+  public static final class UnreadBlipState {
+    private final int unreadCount;
+    private final List<String> unreadBlipIds;
+
+    public UnreadBlipState(List<String> unreadBlipIds) {
+      this.unreadBlipIds =
+          unreadBlipIds == null
+              ? Collections.<String>emptyList()
+              : Collections.unmodifiableList(new ArrayList<String>(unreadBlipIds));
+      this.unreadCount = this.unreadBlipIds.size();
+    }
+
+    public int getUnreadCount() {
+      return unreadCount;
+    }
+
+    public List<String> getUnreadBlipIds() {
+      return unreadBlipIds;
+    }
+  }
+
+  private static final class DigestContext {
+    private final ObservableWaveletData convWavelet;
+    private final List<ObservableWaveletData> conversationalWavelets;
+    private final SupplementedWave supplement;
+    private final ObservableConversationView conversations;
+    private final Map<ObservableWaveletData, OpBasedWavelet> waveletAdapters;
+
+    private DigestContext(
+        ObservableWaveletData convWavelet,
+        List<ObservableWaveletData> conversationalWavelets,
+        SupplementedWave supplement,
+        ObservableConversationView conversations,
+        Map<ObservableWaveletData, OpBasedWavelet> waveletAdapters) {
+      this.convWavelet = convWavelet;
+      this.conversationalWavelets = conversationalWavelets;
+      this.supplement = supplement;
+      this.conversations = conversations;
+      this.waveletAdapters = waveletAdapters;
+    }
+  }
+
   @Inject
   public WaveDigester(ConversationUtil conversationUtil) {
     this.conversationUtil = conversationUtil;
@@ -199,43 +241,16 @@ public class WaveDigester {
   public Digest build(ParticipantId participant, WaveViewData wave) {
 
     Digest digest;
-
-    // Note: the indexing infrastructure only supports single-conversation
-    // snippeting, but unread state must reflect all conversational wavelets.
-    ObservableWaveletData root = null;
-    ObservableWaveletData other = null;
-    List<ObservableWaveletData> conversationalWavelets = new ArrayList<ObservableWaveletData>();
-    for (ObservableWaveletData waveletData : wave.getWavelets()) {
-      WaveletId waveletId = waveletData.getWaveletId();
-      if (IdUtil.isConversationRootWaveletId(waveletId)) {
-        root = waveletData;
-        conversationalWavelets.add(waveletData);
-      } else if (IdUtil.isConversationalId(waveletId)) {
-        conversationalWavelets.add(waveletData);
-        other = waveletData;
-      }
-    }
-    ObservableWaveletData udw = findViewerUserDataWavelet(participant, wave.getWavelets());
-    Map<ObservableWaveletData, OpBasedWavelet> waveletAdapters =
-        new IdentityHashMap<ObservableWaveletData, OpBasedWavelet>();
-
-    ObservableWaveletData convWavelet = root != null ? root : other;
-    SupplementedWave supplement = null;
-    ObservableConversationView conversations = null;
-    if (convWavelet != null) {
-      OpBasedWavelet wavelet = getOrCreateReadOnlyWavelet(convWavelet, waveletAdapters);
-      if (WaveletBasedConversation.waveletHasConversation(wavelet)) {
-        conversations = conversationUtil.buildConversation(wavelet);
-        supplement =
-            buildSupplement(
-                participant, conversations, udw, conversationalWavelets, waveletAdapters);
-      }
-    }
-    if (conversations != null) {
+    DigestContext context = buildDigestContext(participant, wave);
+    if (context.conversations != null) {
       // This is a conversational wave. Produce a conversational digest.
       digest =
           generateDigest(
-              conversations, supplement, convWavelet, conversationalWavelets, waveletAdapters);
+              context.conversations,
+              context.supplement,
+              context.convWavelet,
+              context.conversationalWavelets,
+              context.waveletAdapters);
     } else {
       // It is unknown how to present this wave.
       digest = generateEmptyorUnknownDigest(wave);
@@ -251,9 +266,26 @@ public class WaveDigester {
    * conversation/supplement semantics and skips non-conversation documents.
    */
   public List<String> getUnreadBlipIds(ParticipantId participant, WaveViewData wave) {
+    return getUnreadBlipState(participant, wave).getUnreadBlipIds();
+  }
+
+  public UnreadBlipState getUnreadBlipState(ParticipantId participant, WaveViewData wave) {
+    DigestContext context = buildDigestContext(participant, wave);
+    return new UnreadBlipState(
+        collectUnreadBlipIds(
+            context.convWavelet,
+            context.conversationalWavelets,
+            context.supplement,
+            context.conversations,
+            context.waveletAdapters));
+  }
+
+  private DigestContext buildDigestContext(ParticipantId participant, WaveViewData wave) {
     if (wave == null) {
-      return Collections.emptyList();
+      return emptyDigestContext();
     }
+    // Note: the indexing infrastructure only supports single-conversation
+    // snippeting, but unread state must reflect all conversational wavelets.
     ObservableWaveletData root = null;
     ObservableWaveletData other = null;
     List<ObservableWaveletData> conversationalWavelets = new ArrayList<ObservableWaveletData>();
@@ -269,13 +301,18 @@ public class WaveDigester {
     }
     ObservableWaveletData convWavelet = root != null ? root : other;
     if (convWavelet == null) {
-      return Collections.emptyList();
+      return new DigestContext(
+          null,
+          conversationalWavelets,
+          null,
+          null,
+          new IdentityHashMap<ObservableWaveletData, OpBasedWavelet>());
     }
     Map<ObservableWaveletData, OpBasedWavelet> waveletAdapters =
         new IdentityHashMap<ObservableWaveletData, OpBasedWavelet>();
     OpBasedWavelet wavelet = getOrCreateReadOnlyWavelet(convWavelet, waveletAdapters);
     if (!WaveletBasedConversation.waveletHasConversation(wavelet)) {
-      return Collections.emptyList();
+      return new DigestContext(convWavelet, conversationalWavelets, null, null, waveletAdapters);
     }
     ObservableConversationView conversations = conversationUtil.buildConversation(wavelet);
     SupplementedWave supplement =
@@ -285,8 +322,17 @@ public class WaveDigester {
             findViewerUserDataWavelet(participant, wave.getWavelets()),
             conversationalWavelets,
             waveletAdapters);
-    return collectUnreadBlipIds(
+    return new DigestContext(
         convWavelet, conversationalWavelets, supplement, conversations, waveletAdapters);
+  }
+
+  private static DigestContext emptyDigestContext() {
+    return new DigestContext(
+        null,
+        Collections.<ObservableWaveletData>emptyList(),
+        null,
+        null,
+        new IdentityHashMap<ObservableWaveletData, OpBasedWavelet>());
   }
 
   private List<String> collectUnreadBlipIds(

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServletTest.java
@@ -130,7 +130,8 @@ public final class SelectedWaveReadStateServletTest extends TestCase {
     when(sessionManager.getLoggedInUser(any())).thenReturn(USER);
     SelectedWaveReadStateHelper helper = mock(SelectedWaveReadStateHelper.class);
     when(helper.computeReadState(any(ParticipantId.class), any(WaveId.class)))
-        .thenReturn(SelectedWaveReadStateHelper.Result.found(4));
+        .thenReturn(SelectedWaveReadStateHelper.Result.found(4,
+            java.util.Arrays.asList("b+2", "b+7")));
 
     SelectedWaveReadStateServlet servlet =
         new SelectedWaveReadStateServlet(sessionManager, helper);
@@ -146,6 +147,8 @@ public final class SelectedWaveReadStateServletTest extends TestCase {
     String json = body.toString();
     assertTrue("body missing unreadCount: " + json, json.contains("\"unreadCount\":4"));
     assertTrue("body missing isRead: " + json, json.contains("\"isRead\":false"));
+    assertTrue("body missing unreadBlipIds: " + json,
+        json.contains("\"unreadBlipIds\":[\"b+2\",\"b+7\"]"));
     assertTrue("body missing waveId: " + json, json.contains("\"waveId\":\"" + VALID_WAVE_ID + "\""));
   }
 

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelperTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelperTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableSet;
-import com.google.wave.api.SearchResult.Digest;
+import java.util.Arrays;
 import junit.framework.TestCase;
 import org.mockito.ArgumentCaptor;
 import org.waveprotocol.wave.model.id.IdUtil;
@@ -69,9 +69,8 @@ public final class SelectedWaveReadStateHelperTest extends TestCase {
     stubWaveletContainer(waveMap, USER_UDW, userUdw);
     stubWaveletContainer(waveMap, OTHER_UDW, otherUdw);
 
-    Digest digest = mock(Digest.class);
-    when(digest.getUnreadCount()).thenReturn(2);
-    when(digester.build(eq(USER), any(WaveViewData.class))).thenReturn(digest);
+    when(digester.getUnreadBlipState(eq(USER), any(WaveViewData.class)))
+        .thenReturn(new WaveDigester.UnreadBlipState(Arrays.asList("b+1", "b+2")));
 
     SelectedWaveReadStateHelper.Result result = helper.computeReadState(USER, WAVE_ID);
 
@@ -79,7 +78,7 @@ public final class SelectedWaveReadStateHelperTest extends TestCase {
     assertEquals(2, result.getUnreadCount());
 
     ArgumentCaptor<WaveViewData> viewCaptor = ArgumentCaptor.forClass(WaveViewData.class);
-    verify(digester).build(eq(USER), viewCaptor.capture());
+    verify(digester).getUnreadBlipState(eq(USER), viewCaptor.capture());
     WaveViewData digestedView = viewCaptor.getValue();
     assertNotNull(digestedView.getWavelet(ACCESSIBLE_CONV));
     assertNull(digestedView.getWavelet(RESTRICTED_CONV));
@@ -121,9 +120,8 @@ public final class SelectedWaveReadStateHelperTest extends TestCase {
     when(otherUdwContainer.copyWaveletData()).thenThrow(new WaveletStateException("boom"));
     when(waveMap.getWavelet(WaveletName.of(WAVE_ID, OTHER_UDW))).thenReturn(otherUdwContainer);
 
-    Digest digest = mock(Digest.class);
-    when(digest.getUnreadCount()).thenReturn(1);
-    when(digester.build(eq(USER), any(WaveViewData.class))).thenReturn(digest);
+    when(digester.getUnreadBlipState(eq(USER), any(WaveViewData.class)))
+        .thenReturn(new WaveDigester.UnreadBlipState(Arrays.asList("b+1")));
 
     SelectedWaveReadStateHelper.Result result = helper.computeReadState(USER, WAVE_ID);
 
@@ -131,7 +129,7 @@ public final class SelectedWaveReadStateHelperTest extends TestCase {
     assertEquals(1, result.getUnreadCount());
 
     ArgumentCaptor<WaveViewData> viewCaptor = ArgumentCaptor.forClass(WaveViewData.class);
-    verify(digester).build(eq(USER), viewCaptor.capture());
+    verify(digester).getUnreadBlipState(eq(USER), viewCaptor.capture());
     WaveViewData digestedView = viewCaptor.getValue();
     assertNotNull(digestedView.getWavelet(ACCESSIBLE_CONV));
     assertNull(digestedView.getWavelet(OTHER_UDW));


### PR DESCRIPTION
## Summary
- Add per-blip unread IDs to the selected-wave read-state response so J2CL can render unread markers inside the wave, not only aggregate unread counts.
- Apply read-state updates to projected read blips and newly loaded viewport fragments so search/read UI state stays aligned after blips are marked read.
- Preserve focused-blip markers while using the wave navigation toolbar so previous/next/recent/unread navigation continues from the current blip instead of losing context to the clicked toolbar button.

Refs #904

## Verification
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`
- `sbt --batch 'Test/testOnly org.waveprotocol.box.server.rpc.SelectedWaveReadStateServletTest org.waveprotocol.box.server.waveserver.SelectedWaveReadStateHelperTest'`
- `sbt --batch j2clSearchBuild`
- `sbt --batch 'Test/testOnly org.waveprotocol.box.j2cl.search.J2clSelectedWaveProjectorTest org.waveprotocol.box.j2cl.search.J2clSelectedWaveViewChromeTest org.waveprotocol.box.j2cl.transport.SidecarTransportCodecTest org.waveprotocol.box.server.rpc.SelectedWaveReadStateServletTest org.waveprotocol.box.server.waveserver.SelectedWaveReadStateHelperTest'` (JVM server tests executed: 10 passed; J2CL tests are covered by the J2CL search tasks)
- `sbt --batch j2clSearchTest`
- `sbt --batch Test/compile`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-message unread indicators restored and applied from server-provided unread IDs.

* **Bug Fixes**
  * Read-state now merges per-message unread markers when refreshing viewport fragments.
  * Toolbar navigation preserves and restores the focused message after focus shifts; focus detection now respects explicit focus markers.
  * Server responses now include per-message unread IDs and are consumed by the client.

* **Documentation**
  * Added changelog entry describing read/nav parity fixes.

* **Tests**
  * Added tests validating unread-ID handling and navigation/focus behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->