### PR TITLE
Fix J2CL inline focus parity audit gaps

### DIFF
--- a/j2cl/lit/src/elements/shell-root.js
+++ b/j2cl/lit/src/elements/shell-root.js
@@ -1,6 +1,11 @@
 import { LitElement, css, html } from "lit";
 import { KEY_ACTION, isEditableTarget, matchShortcut } from "../shortcuts/keybindings.js";
-import { moveBlipFocus, clearBlipFocus } from "../shortcuts/blip-focus.js";
+import {
+  moveBlipFocus,
+  focusBlipBoundary,
+  dispatchFocusedBlipDepth,
+  clearBlipFocus
+} from "../shortcuts/blip-focus.js";
 import { closeTopmostDialog } from "../shortcuts/dialog-stack.js";
 
 export class ShellRoot extends LitElement {
@@ -310,6 +315,16 @@ export class ShellRoot extends LitElement {
         if (this._modalIsOpen()) return false;
         const direction = action === KEY_ACTION.BLIP_FOCUS_NEXT ? 1 : -1;
         return moveBlipFocus(direction);
+      }
+      case KEY_ACTION.BLIP_FOCUS_FIRST:
+      case KEY_ACTION.BLIP_FOCUS_LAST: {
+        if (this._modalIsOpen()) return false;
+        return focusBlipBoundary(action === KEY_ACTION.BLIP_FOCUS_LAST ? "last" : "first");
+      }
+      case KEY_ACTION.BLIP_DEPTH_UP:
+      case KEY_ACTION.BLIP_DEPTH_IN: {
+        if (this._modalIsOpen()) return false;
+        return dispatchFocusedBlipDepth(action === KEY_ACTION.BLIP_DEPTH_IN ? "in" : "up");
       }
       case KEY_ACTION.OPEN_NEW_WAVE: {
         // The J2CL root shell already listens for this on document.body

--- a/j2cl/lit/src/shortcuts/blip-focus.js
+++ b/j2cl/lit/src/shortcuts/blip-focus.js
@@ -141,6 +141,59 @@ export function moveBlipFocus(direction, root = document) {
   return true;
 }
 
+export function focusBlipBoundary(boundary, root = document) {
+  const list = snapshotBlips(root);
+  if (list.length === 0) return false;
+  const target = boundary === "last" ? list[list.length - 1] : list[0];
+  setFocusedBlip(target, root);
+  return true;
+}
+
+function findFocusedBlip(root = document) {
+  const list = snapshotBlips(root);
+  const index = findFocusedIndex(list);
+  return index >= 0 ? list[index] : null;
+}
+
+function findDepthHost(surface) {
+  let el = surface;
+  while (el) {
+    if (typeof el.hasAttribute === "function" && el.hasAttribute("data-parent-depth-blip-id")) {
+      return el;
+    }
+    el = el.parentElement;
+  }
+  return null;
+}
+
+export function dispatchFocusedBlipDepth(direction, root = document) {
+  const focused = findFocusedBlip(root);
+  const surface = findReadSurface(focused, root);
+  if (!surface) return false;
+  if (direction === "in") {
+    const blipId = focused ? focused.getAttribute("data-blip-id") || "" : "";
+    if (!blipId) return false;
+    surface.dispatchEvent(
+      new CustomEvent("wavy-depth-drill-in", {
+        bubbles: true,
+        composed: true,
+        detail: { blipId }
+      })
+    );
+    return true;
+  }
+  const depthHost = findDepthHost(surface);
+  const toBlipId = depthHost ? depthHost.getAttribute("data-parent-depth-blip-id") || "" : "";
+  surface.dispatchEvent(
+    new CustomEvent("wavy-depth-up", {
+      bubbles: true,
+      composed: true,
+      detail: { toBlipId }
+    })
+  );
+  return true;
+}
+
 /**
  * Clear `focused` on every other blip, then set it on `target`.
  * Reflects to `data-blip-focused` on the host so the parity test can
@@ -235,6 +288,7 @@ export const _internalForTesting = {
   snapshotAllBlips,
   findFocusedIndex,
   findReadSurface,
+  findFocusedBlip,
   dispatchRendererFocusChanged,
   FOCUS_CHANGED_EVENT,
   RENDERER_FOCUS_CLASS

--- a/j2cl/lit/src/shortcuts/keybindings.js
+++ b/j2cl/lit/src/shortcuts/keybindings.js
@@ -7,8 +7,10 @@
 // (KeySignalRouter + FocusFrameController.onKeySignal). We pick the
 // six combos called out in issue #1116 as the parity baseline:
 //
-//   - j        BLIP_FOCUS_NEXT       (move focused blip down)
-//   - k        BLIP_FOCUS_PREV       (move focused blip up)
+//   - j / ArrowDown
+//              BLIP_FOCUS_NEXT       (move focused blip down)
+//   - k / ArrowUp
+//              BLIP_FOCUS_PREV       (move focused blip up)
 //   - Shift+   OPEN_NEW_WAVE         (open the create-wave surface)
 //     Cmd+O / Shift+Ctrl+O
 //   - Esc      CLOSE_TOPMOST         (close topmost dialog OR
@@ -129,19 +131,22 @@ export function matchShortcut(evt, opts = {}) {
     return { action: KEY_ACTION.OPEN_NEW_WAVE, global: false };
   }
 
-  // j / k — blip navigation. Bare key only; not global. Modifiers
-  // disqualify because Cmd+J / Ctrl+K etc. are claimed by browsers.
-  // Allow repeat so holding j/k continuously moves focus (GWT parity).
+  // j/k and ArrowDown/ArrowUp — blip navigation. Bare key only; not
+  // global. Modifiers disqualify because Cmd+J / Ctrl+K etc. are
+  // claimed by browsers. Allow repeat so holding the key continuously
+  // moves focus (GWT parity). The Lit shell is the single repeated
+  // next/previous owner so focus always follows actual <wave-blip>
+  // DOM order, including inline-reply blips mounted inside Lit chrome.
   if (
     !evt.shiftKey &&
     !evt.ctrlKey &&
     !evt.metaKey &&
     !evt.altKey
   ) {
-    if (evt.key === "j" || evt.key === "J") {
+    if (evt.key === "j" || evt.key === "J" || evt.key === "ArrowDown") {
       return { action: KEY_ACTION.BLIP_FOCUS_NEXT, global: false };
     }
-    if (evt.key === "k" || evt.key === "K") {
+    if (evt.key === "k" || evt.key === "K" || evt.key === "ArrowUp") {
       return { action: KEY_ACTION.BLIP_FOCUS_PREV, global: false };
     }
   }

--- a/j2cl/lit/src/shortcuts/keybindings.js
+++ b/j2cl/lit/src/shortcuts/keybindings.js
@@ -26,6 +26,10 @@
 export const KEY_ACTION = Object.freeze({
   BLIP_FOCUS_NEXT: "BLIP_FOCUS_NEXT",
   BLIP_FOCUS_PREV: "BLIP_FOCUS_PREV",
+  BLIP_FOCUS_FIRST: "BLIP_FOCUS_FIRST",
+  BLIP_FOCUS_LAST: "BLIP_FOCUS_LAST",
+  BLIP_DEPTH_UP: "BLIP_DEPTH_UP",
+  BLIP_DEPTH_IN: "BLIP_DEPTH_IN",
   OPEN_NEW_WAVE: "OPEN_NEW_WAVE",
   CLOSE_TOPMOST: "CLOSE_TOPMOST"
 });
@@ -149,6 +153,27 @@ export function matchShortcut(evt, opts = {}) {
     if (evt.key === "k" || evt.key === "K" || evt.key === "ArrowUp") {
       return { action: KEY_ACTION.BLIP_FOCUS_PREV, global: false };
     }
+    if (evt.key === "Home" || evt.key === "g") {
+      return { action: KEY_ACTION.BLIP_FOCUS_FIRST, global: false };
+    }
+    if (evt.key === "End" || evt.key === "[") {
+      return {
+        action: evt.key === "End" ? KEY_ACTION.BLIP_FOCUS_LAST : KEY_ACTION.BLIP_DEPTH_UP,
+        global: false
+      };
+    }
+    if (evt.key === "]") {
+      return { action: KEY_ACTION.BLIP_DEPTH_IN, global: false };
+    }
+  }
+  if (
+    evt.key === "G" &&
+    evt.shiftKey &&
+    !evt.ctrlKey &&
+    !evt.metaKey &&
+    !evt.altKey
+  ) {
+    return { action: KEY_ACTION.BLIP_FOCUS_LAST, global: false };
   }
   return null;
 }

--- a/j2cl/lit/test/shortcuts/blip-focus.test.js
+++ b/j2cl/lit/test/shortcuts/blip-focus.test.js
@@ -1,7 +1,13 @@
 // G-PORT-7 (#1116): tests for the blip-focus navigation helper.
 import { fixture, expect, html } from "@open-wc/testing";
 import "../../src/elements/wave-blip.js";
-import { moveBlipFocus, clearBlipFocus, setFocusedBlip } from "../../src/shortcuts/blip-focus.js";
+import {
+  moveBlipFocus,
+  focusBlipBoundary,
+  dispatchFocusedBlipDepth,
+  clearBlipFocus,
+  setFocusedBlip
+} from "../../src/shortcuts/blip-focus.js";
 
 async function threeBlips() {
   const root = await fixture(html`
@@ -183,6 +189,55 @@ describe("clearBlipFocus", () => {
     blips[1].classList.add("j2cl-read-blip-focused");
     clearBlipFocus(root);
     expect(blips[1].hasAttribute("aria-current")).to.equal(false);
+  });
+});
+
+describe("focusBlipBoundary", () => {
+  it("focuses the first or last visible blip", async () => {
+    const root = await threeBlips();
+    expect(focusBlipBoundary("last", root)).to.equal(true);
+    expect(root.querySelector("wave-blip[focused]").getAttribute("data-blip-id")).to.equal("b3");
+    expect(focusBlipBoundary("first", root)).to.equal(true);
+    expect(root.querySelector("wave-blip[focused]").getAttribute("data-blip-id")).to.equal("b1");
+  });
+
+  it("returns false when there are no blips", () => {
+    expect(focusBlipBoundary("last", document.createElement("div"))).to.equal(false);
+  });
+});
+
+describe("dispatchFocusedBlipDepth", () => {
+  it("dispatches drill-in for the focused blip", async () => {
+    const root = await fixture(html`
+      <div data-j2cl-read-surface="true">
+        <wave-blip data-blip-id="b1"></wave-blip>
+      </div>
+    `);
+    const blip = root.querySelector("wave-blip");
+    setFocusedBlip(blip, root);
+    let detail = null;
+    root.addEventListener("wavy-depth-drill-in", event => {
+      detail = event.detail;
+    });
+    expect(dispatchFocusedBlipDepth("in", root)).to.equal(true);
+    expect(detail).to.deep.equal({ blipId: "b1" });
+  });
+
+  it("dispatches depth-up with the parent depth id from the host", async () => {
+    const root = await fixture(html`
+      <div data-parent-depth-blip-id="parent">
+        <section data-j2cl-read-surface="true">
+          <wave-blip data-blip-id="b1"></wave-blip>
+        </section>
+      </div>
+    `);
+    const surface = root.querySelector("[data-j2cl-read-surface]");
+    let detail = null;
+    surface.addEventListener("wavy-depth-up", event => {
+      detail = event.detail;
+    });
+    expect(dispatchFocusedBlipDepth("up", root)).to.equal(true);
+    expect(detail).to.deep.equal({ toBlipId: "parent" });
   });
 });
 

--- a/j2cl/lit/test/shortcuts/keybindings.test.js
+++ b/j2cl/lit/test/shortcuts/keybindings.test.js
@@ -42,6 +42,17 @@ describe("matchShortcut", () => {
     });
   });
 
+  it("matches ArrowDown / ArrowUp as GWT blip navigation fallbacks", () => {
+    expect(matchShortcut(fakeEvent("ArrowDown"), { isMac: true })).to.deep.equal({
+      action: KEY_ACTION.BLIP_FOCUS_NEXT,
+      global: false
+    });
+    expect(matchShortcut(fakeEvent("ArrowUp"), { isMac: true })).to.deep.equal({
+      action: KEY_ACTION.BLIP_FOCUS_PREV,
+      global: false
+    });
+  });
+
   it("matches uppercase J / K", () => {
     expect(matchShortcut(fakeEvent("J"), { isMac: true }).action).to.equal(
       KEY_ACTION.BLIP_FOCUS_NEXT

--- a/j2cl/lit/test/shortcuts/keybindings.test.js
+++ b/j2cl/lit/test/shortcuts/keybindings.test.js
@@ -53,6 +53,36 @@ describe("matchShortcut", () => {
     });
   });
 
+  it("matches Home/End and g/G as first/last blip navigation", () => {
+    expect(matchShortcut(fakeEvent("Home"), { isMac: true })).to.deep.equal({
+      action: KEY_ACTION.BLIP_FOCUS_FIRST,
+      global: false
+    });
+    expect(matchShortcut(fakeEvent("g"), { isMac: true })).to.deep.equal({
+      action: KEY_ACTION.BLIP_FOCUS_FIRST,
+      global: false
+    });
+    expect(matchShortcut(fakeEvent("End"), { isMac: true })).to.deep.equal({
+      action: KEY_ACTION.BLIP_FOCUS_LAST,
+      global: false
+    });
+    expect(matchShortcut(fakeEvent("G", { shiftKey: true }), { isMac: true })).to.deep.equal({
+      action: KEY_ACTION.BLIP_FOCUS_LAST,
+      global: false
+    });
+  });
+
+  it("matches bracket depth shortcuts at shell level", () => {
+    expect(matchShortcut(fakeEvent("["), { isMac: true })).to.deep.equal({
+      action: KEY_ACTION.BLIP_DEPTH_UP,
+      global: false
+    });
+    expect(matchShortcut(fakeEvent("]"), { isMac: true })).to.deep.equal({
+      action: KEY_ACTION.BLIP_DEPTH_IN,
+      global: false
+    });
+  });
+
   it("matches uppercase J / K", () => {
     expect(matchShortcut(fakeEvent("J"), { isMac: true }).action).to.equal(
       KEY_ACTION.BLIP_FOCUS_NEXT

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -2183,9 +2183,29 @@ public final class J2clReadSurfaceDomRenderer {
     if (event == null || event.currentTarget == null) {
       return;
     }
+    HTMLElement target = (HTMLElement) event.target;
+    if (target != null && isInteractiveElement(target)) {
+      return;
+    }
     HTMLElement blip = (HTMLElement) event.currentTarget;
     focusBlip(blip);
     blip.focus();
+  }
+
+  private static boolean isInteractiveElement(HTMLElement el) {
+    if (el == null) {
+      return false;
+    }
+    String tag = el.tagName.toLowerCase();
+    if (tag.equals("input") || tag.equals("button") || tag.equals("a")
+        || tag.equals("select") || tag.equals("textarea")) {
+      return true;
+    }
+    if (el.hasAttribute("contenteditable")
+        && !"false".equalsIgnoreCase(el.getAttribute("contenteditable"))) {
+      return true;
+    }
+    return false;
   }
 
   private void onBlipKeyDown(Event event) {
@@ -2212,7 +2232,7 @@ public final class J2clReadSurfaceDomRenderer {
       focusByIndex(0, key);
       keyEvent.preventDefault();
     } else if ("End".equals(key) || "G".equals(key)) {
-      focusByIndex(renderedBlips.size() - 1, key);
+      focusByIndex(visibleBlips().size() - 1, key);
       keyEvent.preventDefault();
     } else if ("[".equals(key)) {
       // Drill out one depth level (G.2). Include toBlipId from the host
@@ -2222,7 +2242,11 @@ public final class J2clReadSurfaceDomRenderer {
     } else if ("]".equals(key)) {
       // Drill into the focused blip's subthread (G.1). Emits a custom
       // wavy-depth-drill-in event with the focused blip id.
-      String focusedBlipId = focusedBlip == null ? null : focusedBlip.getAttribute("data-blip-id");
+      HTMLElement drillTarget = focusedBlip;
+      if (drillTarget == null || !"true".equals(drillTarget.getAttribute("aria-current"))) {
+        drillTarget = firstVisibleFocusedMarker();
+      }
+      String focusedBlipId = drillTarget == null ? null : drillTarget.getAttribute("data-blip-id");
       if (focusedBlipId != null && !focusedBlipId.isEmpty()) {
         dispatchDepthDrillInEvent(focusedBlipId);
       }
@@ -2932,14 +2956,19 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   private HTMLElement visibleRenderedBlip(HTMLElement blip) {
-    if (blip != null && renderedBlips.contains(blip) && !isHiddenByCollapsedThread(blip)) {
-      return blip;
+    if (blip == null || isHiddenByCollapsedThread(blip)) {
+      return null;
+    }
+    for (HTMLElement candidate : focusBlipElements()) {
+      if (candidate == blip) {
+        return blip;
+      }
     }
     return null;
   }
 
   private HTMLElement firstVisibleFocusedMarker() {
-    for (HTMLElement blip : renderedBlips) {
+    for (HTMLElement blip : focusBlipElements()) {
       if (!isHiddenByCollapsedThread(blip)
           && (blip.classList.contains("j2cl-read-blip-focused")
               || "true".equals(blip.getAttribute("aria-current")))) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -2183,8 +2183,7 @@ public final class J2clReadSurfaceDomRenderer {
     if (event == null || event.currentTarget == null) {
       return;
     }
-    HTMLElement target = (HTMLElement) event.target;
-    if (target != null && isInteractiveElement(target)) {
+    if (isInteractiveClick(event)) {
       return;
     }
     HTMLElement blip = (HTMLElement) event.currentTarget;
@@ -2192,14 +2191,57 @@ public final class J2clReadSurfaceDomRenderer {
     blip.focus();
   }
 
-  private static boolean isInteractiveElement(HTMLElement el) {
-    if (el == null) {
+  private static boolean isInteractiveClick(Event event) {
+    HTMLElement current = (HTMLElement) event.currentTarget;
+    try {
+      elemental2.core.JsArray<elemental2.dom.EventTarget> path = event.composedPath();
+      if (path != null && path.length > 0) {
+        for (int index = 0; index < path.length; index++) {
+          elemental2.dom.EventTarget target = path.getAt(index);
+          if (target == current) {
+            break;
+          }
+          if (target instanceof Element && isInteractiveElement((Element) target)) {
+            return true;
+          }
+        }
+        return false;
+      }
+    } catch (Throwable ignored) {
+      // Fall through to a light-DOM ancestor walk for older event implementations.
+    }
+    if (!(event.target instanceof Element)) {
       return false;
     }
-    String tag = el.tagName.toLowerCase();
+    Element element = (Element) event.target;
+    while (element != null && element != current) {
+      if (isInteractiveElement(element)) {
+        return true;
+      }
+      element = element.parentElement;
+    }
+    return false;
+  }
+
+  private static boolean isInteractiveElement(Element el) {
+    if (el == null || el.tagName == null) {
+      return false;
+    }
+    String tag = el.tagName.toLowerCase(Locale.ROOT);
     if (tag.equals("input") || tag.equals("button") || tag.equals("a")
-        || tag.equals("select") || tag.equals("textarea")) {
+        || tag.equals("label") || tag.equals("select") || tag.equals("summary")
+        || tag.equals("textarea")) {
       return true;
+    }
+    String role = el.getAttribute("role");
+    if (role != null) {
+      String normalizedRole = role.toLowerCase(Locale.ROOT);
+      if (normalizedRole.equals("button") || normalizedRole.equals("checkbox")
+          || normalizedRole.equals("link") || normalizedRole.equals("menuitem")
+          || normalizedRole.equals("option") || normalizedRole.equals("radio")
+          || normalizedRole.equals("switch") || normalizedRole.equals("textbox")) {
+        return true;
+      }
     }
     if (el.hasAttribute("contenteditable")
         && !"false".equalsIgnoreCase(el.getAttribute("contenteditable"))) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -2102,6 +2102,7 @@ public final class J2clReadSurfaceDomRenderer {
         blip.setAttribute("tabindex", visible && !tabStopAssigned ? "0" : "-1");
         tabStopAssigned = tabStopAssigned || visible;
         blip.setAttribute("data-j2cl-read-blip-bound", "true");
+        blip.addEventListener("click", this::onBlipClick);
         blip.addEventListener("focus", this::onBlipFocus);
         blip.addEventListener("keydown", this::onBlipKeyDown);
       } else if (!isHiddenByCollapsedThread(blip) && "0".equals(blip.getAttribute("tabindex"))) {
@@ -2178,25 +2179,36 @@ public final class J2clReadSurfaceDomRenderer {
     focusBlip((HTMLElement) event.currentTarget);
   }
 
+  private void onBlipClick(Event event) {
+    if (event == null || event.currentTarget == null) {
+      return;
+    }
+    HTMLElement blip = (HTMLElement) event.currentTarget;
+    focusBlip(blip);
+    blip.focus();
+  }
+
   private void onBlipKeyDown(Event event) {
     KeyboardEvent keyEvent = (KeyboardEvent) event;
-    if (event.currentTarget != null) {
+    String key = keyEvent.key;
+    if (event.currentTarget != null && currentVisibleBlipIndex(visibleBlips()) < 0) {
       focusBlip((HTMLElement) event.currentTarget);
     }
-    String key = keyEvent.key;
     // F-2 slice 2 (#1046, R-3.2): j/k aliases for ArrowDown/ArrowUp.
+    // The Lit shell owns repeated next/previous navigation now because
+    // it walks the actual <wave-blip> DOM order, including inline reply
+    // blips that can be mounted by Lit after the renderer's internal
+    // list was captured. Let those keys bubble to the shell-level
+    // handler; this per-blip handler still owns Home/End and depth keys.
     // F-2 slice 5 (#1055, R-3.7 G.5): [ / ] drill out / drill in,
     //                                  g / G jump to first / last blip.
     // Documented as Wavy-specific aliases; intentionally NOT announced via
     // aria-keyshortcuts to avoid screen-reader collisions with the
     // browser's built-in shortcuts.
-    if ("ArrowDown".equals(key) || "j".equals(key)) {
-      focusByOffset(1, key);
-      keyEvent.preventDefault();
-    } else if ("ArrowUp".equals(key) || "k".equals(key)) {
-      focusByOffset(-1, key);
-      keyEvent.preventDefault();
-    } else if ("Home".equals(key) || "g".equals(key)) {
+    if ("ArrowDown".equals(key) || "j".equals(key) || "ArrowUp".equals(key) || "k".equals(key)) {
+      return;
+    }
+    if ("Home".equals(key) || "g".equals(key)) {
       focusByIndex(0, key);
       keyEvent.preventDefault();
     } else if ("End".equals(key) || "G".equals(key)) {
@@ -2477,12 +2489,41 @@ public final class J2clReadSurfaceDomRenderer {
 
   private void focusByOffset(int offset, String key) {
     List<HTMLElement> visibleBlips = visibleBlips();
-    int current = focusedBlip == null ? -1 : visibleBlips.indexOf(focusedBlip);
+    int current = currentVisibleBlipIndex(visibleBlips);
     if (current < 0) {
       focusVisibleByIndex(offset > 0 ? 0 : visibleBlips.size() - 1, key);
       return;
     }
     focusVisibleByIndex(current + offset, key);
+  }
+
+  private int currentVisibleBlipIndex(List<HTMLElement> visibleBlips) {
+    if (visibleBlips.isEmpty()) {
+      return -1;
+    }
+    if (focusedBlip != null) {
+      int index = visibleBlips.indexOf(focusedBlip);
+      if (index >= 0) {
+        return index;
+      }
+    }
+    if (DomGlobal.document != null && DomGlobal.document.activeElement instanceof HTMLElement) {
+      HTMLElement active = visibleRenderedBlip((HTMLElement) DomGlobal.document.activeElement);
+      if (active != null) {
+        int index = visibleBlips.indexOf(active);
+        if (index >= 0) {
+          return index;
+        }
+      }
+    }
+    HTMLElement marker = firstVisibleFocusedMarker();
+    if (marker != null) {
+      int index = visibleBlips.indexOf(marker);
+      if (index >= 0) {
+        return index;
+      }
+    }
+    return -1;
   }
 
   private void focusByIndex(int index, String key) {
@@ -2641,7 +2682,7 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   private void clearFocusedBlip() {
-    for (HTMLElement blip : renderedBlips) {
+    for (HTMLElement blip : focusBlipElements()) {
       clearFocusMarkers(blip);
       blip.setAttribute("tabindex", "-1");
     }
@@ -2650,12 +2691,29 @@ public final class J2clReadSurfaceDomRenderer {
 
   private List<HTMLElement> visibleBlips() {
     List<HTMLElement> visible = new ArrayList<HTMLElement>();
-    for (HTMLElement blip : renderedBlips) {
+    for (HTMLElement blip : focusBlipElements()) {
       if (!isHiddenByCollapsedThread(blip)) {
         visible.add(blip);
       }
     }
     return visible;
+  }
+
+  private List<HTMLElement> focusBlipElements() {
+    List<HTMLElement> blips = new ArrayList<HTMLElement>();
+    if (renderedSurface == null) {
+      blips.addAll(renderedBlips);
+      return blips;
+    }
+    NodeList<Element> nodes =
+        renderedSurface.querySelectorAll("wave-blip[data-blip-id], div.blip[data-blip-id]");
+    for (int index = 0; index < nodes.length; index++) {
+      HTMLElement blip = (HTMLElement) nodes.item(index);
+      if (blip != null) {
+        blips.add(blip);
+      }
+    }
+    return blips;
   }
 
   private boolean isHiddenByCollapsedThread(HTMLElement blip) {

--- a/wave/config/changelog.d/2026-05-03-j2cl-inline-task-focus-parity.json
+++ b/wave/config/changelog.d/2026-05-03-j2cl-inline-task-focus-parity.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-05-03-j2cl-inline-task-focus-parity",
+  "version": "J2CL parity",
+  "date": "2026-05-03",
+  "title": "J2CL inline reply and task parity hardening",
+  "summary": "Tightens J2CL wave-view parity for inline reply focus navigation, mention composer visual coverage, and task detail affordances.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Routes repeated next/previous blip keyboard navigation through the Lit shell so J2CL follows the same visible inline-reply DOM order as GWT.",
+        "Keeps clicked J2CL blips selected for focus-frame navigation before keyboard or toolbar actions continue from that blip.",
+        "Hardens parity coverage so mention popovers and task details are tested on deterministic authored waves with real task state instead of relying on seeded welcome content."
+      ]
+    }
+  ]
+}

--- a/wave/src/e2e/j2cl-gwt-parity/tests/helpers/gwt-task.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/helpers/gwt-task.ts
@@ -1,0 +1,41 @@
+import { expect, Page } from "@playwright/test";
+import { GwtPage } from "../../pages/GwtPage";
+
+/**
+ * Creates an open task on an existing GWT blip and leaves the checkbox
+ * unchecked. J2CL intentionally no longer mounts a generic Task toggle on
+ * every normal blip; it should expose task controls only after the GWT task
+ * doodad/annotation exists.
+ */
+export async function insertOpenTaskOnGwt(
+  page: Page,
+  gwt: GwtPage,
+  blipId: string
+): Promise<void> {
+  await gwt.clickEditOnBlip(blipId);
+  await expect(
+    page.locator('div[title^="Insert task"]').first(),
+    "[gwt] format toolbar Insert task button must mount in edit mode"
+  ).toBeVisible({ timeout: 15_000 });
+  await gwt.clickInsertTask();
+  await gwt.dismissTaskMetadataPopup();
+  await page.keyboard.press("Escape");
+  await expect
+    .poll(
+      async () =>
+        await page
+          .locator(`[data-blip-id="${blipId}"] input[type="checkbox"]`)
+          .count(),
+      {
+        timeout: 15_000,
+        message: `[gwt] ${blipId} should contain an inline checkbox after Insert task`
+      }
+    )
+    .toBeGreaterThanOrEqual(1);
+  await expect
+    .poll(async () => await gwt.blipHasCheckedTask(blipId), {
+      timeout: 10_000,
+      message: `[gwt] ${blipId} inline checkbox should start unchecked`
+    })
+    .toBe(false);
+}

--- a/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/inline-reply-parity.spec.ts
@@ -46,6 +46,18 @@ async function openFirstWaveJ2cl(page: Page, baseURL: string): Promise<void> {
   await page.waitForSelector("wave-blip", { timeout: 30_000 });
 }
 
+async function authorSimpleGwtWave(page: Page, baseURL: string): Promise<string> {
+  const gwt = new GwtPage(page, baseURL);
+  await gwt.goto("/");
+  await gwt.assertInboxLoaded();
+  await expect(gwt.newWaveAffordance()).toBeVisible({ timeout: 15_000 });
+  await gwt.newWaveAffordance().click();
+  await page.waitForSelector("[kind='b'][data-blip-id]", { timeout: 30_000 });
+  const waveId = await gwt.readWaveIdFromHash();
+  await gwt.typeIntoBlipDocument("Root blip text for inline reply parity");
+  return waveId;
+}
+
 /**
  * Click Reply on the first <wave-blip> in the wave and return a
  * locator for the inline <wavy-composer>. Asserts the composer
@@ -472,13 +484,16 @@ test.describe("G-PORT-4 inline reply + working compose toolbar parity", () => {
     });
     await registerAndSignIn(page, BASE_URL, creds);
 
-    // The Welcome wave seeded by the WelcomeRobot at registration time
-    // gives us a wave with multiple blips to reply to.
-    const j2cl = new J2clPage(page, BASE_URL);
-    await j2cl.goto("/");
-    await j2cl.assertInboxLoaded();
+    // Author a simple owned wave first. The welcome wave is public/help
+    // content and can be read-only or large enough to make root-reply
+    // targeting ambiguous; this parity gate needs the J2CL inline reply
+    // path, not welcome-wave seeding behavior.
+    const waveId = await authorSimpleGwtWave(page, BASE_URL);
 
-    await openFirstWaveJ2cl(page, BASE_URL);
+    const j2cl = new J2clPage(page, BASE_URL);
+    await j2cl.gotoWave(waveId);
+    await j2cl.assertInboxLoaded();
+    await page.waitForSelector("wave-blip", { timeout: 30_000 });
     const composer = await clickReplyOnFirstBlipJ2cl(page);
     // Use a unique payload so we can locate the new blip exactly
     // (the welcome wave already contains the substring "hello"

--- a/wave/src/e2e/j2cl-gwt-parity/tests/keyboard-shortcuts-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/keyboard-shortcuts-parity.spec.ts
@@ -52,6 +52,34 @@ async function openFirstWaveJ2cl(page: Page): Promise<void> {
   await page.waitForSelector("wave-blip", { timeout: 30_000 });
 }
 
+async function authorTwoBlipGwtWave(page: Page, baseURL: string): Promise<string> {
+  const gwt = new GwtPage(page, baseURL);
+  await gwt.goto("/");
+  await gwt.assertInboxLoaded();
+  await expect(gwt.newWaveAffordance()).toBeVisible({ timeout: 15_000 });
+  await gwt.newWaveAffordance().click();
+  await page.waitForSelector("[kind='b'][data-blip-id]", { timeout: 30_000 });
+  const waveId = await gwt.readWaveIdFromHash();
+  await gwt.typeIntoBlipDocument("Keyboard shortcut parity root blip");
+  const rootBlipId = await page
+    .locator("[kind='b'][data-blip-id]")
+    .first()
+    .getAttribute("data-blip-id");
+  expect(rootBlipId, "GWT root blip id must be present").toBeTruthy();
+  await gwt.clickReplyOnBlip(rootBlipId!);
+  await expect
+    .poll(
+      async () => await page.locator("[kind='b'][data-blip-id]").count(),
+      {
+        timeout: 30_000,
+        message: "GWT reply should add a second blip"
+      }
+    )
+    .toBeGreaterThanOrEqual(2);
+  await gwt.typeIntoBlipDocument("Keyboard shortcut parity reply blip");
+  return waveId;
+}
+
 /** Snapshot which J2CL wave-blip currently carries the focused attr. */
 async function focusedBlipIdJ2cl(page: Page): Promise<string | null> {
   return await page.evaluate(() => {
@@ -101,24 +129,16 @@ test.describe("G-PORT-7 keyboard shortcuts parity", () => {
     test.info().annotations.push({ type: "test-user", description: creds.address });
     await registerAndSignIn(page, BASE_URL, creds);
 
-    // ------------------------------------------------------------------
-    // Open the J2CL view and wait for the inbox shell.
-    // ------------------------------------------------------------------
-    const j2cl = new J2clPage(page, BASE_URL);
-    await j2cl.goto("/");
-    await j2cl.assertInboxLoaded();
+    const waveId = await authorTwoBlipGwtWave(page, BASE_URL);
 
-    // ------------------------------------------------------------------
-    // Open the welcome wave so we have multiple <wave-blip> hosts to
-    // navigate through. The seeded Welcome wave from RegistrationUtil's
-    // WelcomeRobot ships with multiple blips — verify we have at least
-    // 2 (more than 2 is preferable; 2 is enough to prove j/k flips).
-    // ------------------------------------------------------------------
-    await openFirstWaveJ2cl(page);
+    const j2cl = new J2clPage(page, BASE_URL);
+    await j2cl.gotoWave(waveId);
+    await j2cl.assertInboxLoaded();
+    await page.waitForSelector("wave-blip", { timeout: 30_000 });
     const initialBlipCount = await blipCountJ2cl(page);
     expect(
       initialBlipCount,
-      "welcome wave must mount at least 2 <wave-blip> hosts on J2CL"
+      "authored wave must mount at least 2 <wave-blip> hosts on J2CL"
     ).toBeGreaterThanOrEqual(2);
 
     // ------------------------------------------------------------------

--- a/wave/src/e2e/j2cl-gwt-parity/tests/mention-autocomplete-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/mention-autocomplete-parity.spec.ts
@@ -94,6 +94,22 @@ async function openWelcomeWaveGwt(page: Page, gwt: GwtPage): Promise<void> {
     .toBe(true);
 }
 
+async function authorSimpleGwtWave(
+  page: Page,
+  gwt: GwtPage,
+  text: string
+): Promise<string> {
+  await gwt.goto("/");
+  await gwt.assertInboxLoaded();
+  await expect(gwt.newWaveAffordance()).toBeVisible({ timeout: 15_000 });
+  await gwt.newWaveAffordance().click();
+  await page.waitForSelector("[data-blip-id]", { timeout: 30_000 });
+  const waveId = await gwt.readWaveIdFromHash();
+  expect(waveId, "GWT new-wave URL fragment must encode waveId").toBeTruthy();
+  await gwt.typeIntoBlipDocument(text);
+  return waveId;
+}
+
 async function sendMentionReplyJ2cl(
   page: Page,
   composer: Locator,
@@ -196,17 +212,18 @@ test.describe("G-PORT-5 mention autocomplete parity", () => {
     });
     await registerAndSignIn(page, BASE_URL, creds);
 
-    const j2cl = new J2clPage(page, BASE_URL);
-    await j2cl.goto("/");
-    await j2cl.assertInboxLoaded();
-
-    // The WelcomeRobot seeds a wave whose participant set always
-    // includes the freshly registered user. We type `@<first letter
-    // of the user's address>` so the filtered candidate list is
-    // guaranteed to contain at least the user themselves.
     const firstLetter = creds.address.charAt(0);
+    const gwtAuthor = new GwtPage(page, BASE_URL);
+    const waveId = await authorSimpleGwtWave(
+      page,
+      gwtAuthor,
+      "Mention persistence parity root blip"
+    );
 
-    await openFirstWaveJ2cl(page, BASE_URL);
+    const j2cl = new J2clPage(page, BASE_URL);
+    await j2cl.gotoWave(waveId);
+    await j2cl.assertInboxLoaded();
+    await page.waitForSelector("wave-blip", { timeout: 30_000 });
     const composer = await openInlineComposerJ2cl(page);
 
     const realParticipantCount = await waitForParticipantsJ2cl(composer, 10_000);
@@ -497,10 +514,17 @@ test.describe("G-PORT-5 mention autocomplete parity", () => {
     await registerAndSignIn(page, BASE_URL, creds);
 
     const firstLetter = creds.address.charAt(0);
+    const gwtAuthor = new GwtPage(page, BASE_URL);
+    const waveId = await authorSimpleGwtWave(
+      page,
+      gwtAuthor,
+      "Mention popover visual parity root blip"
+    );
+
     const j2cl = new J2clPage(page, BASE_URL);
-    await j2cl.goto("/");
+    await j2cl.gotoWave(waveId);
     await j2cl.assertInboxLoaded();
-    await openFirstWaveJ2cl(page, BASE_URL);
+    await page.waitForSelector("wave-blip", { timeout: 30_000 });
     const composer = await openInlineComposerJ2cl(page);
     await waitForParticipantsJ2cl(composer, 10_000);
     await typeAtMentionTriggerJ2cl(page, composer, `@${firstLetter}`);
@@ -524,7 +548,9 @@ test.describe("G-PORT-5 mention autocomplete parity", () => {
     const gwtPage = await page.context().newPage();
     try {
       const gwt = new GwtPage(gwtPage, BASE_URL);
-      await openWelcomeWaveGwt(gwtPage, gwt);
+      await gwt.gotoWave(waveId);
+      await gwt.assertInboxLoaded();
+      await gwtPage.waitForSelector("[data-blip-id]", { timeout: 30_000 });
       await openInlineComposerGwt(gwt);
       await typeAtMentionTriggerGwt(gwtPage, gwt, `@${firstLetter}`);
       await gwtPage.mouse.move(24, 24);

--- a/wave/src/e2e/j2cl-gwt-parity/tests/tasks-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/tasks-parity.spec.ts
@@ -173,6 +173,45 @@ async function authorThreeBlipWave(
 }
 
 /**
+ * Creates an open task on an existing GWT blip and leaves the checkbox
+ * unchecked. J2CL intentionally no longer mounts a generic Task toggle on
+ * every normal blip; it should expose task controls only after the GWT task
+ * doodad/annotation exists.
+ */
+async function insertOpenTaskOnGwt(
+  page: Page,
+  gwt: GwtPage,
+  blipId: string
+): Promise<void> {
+  await gwt.clickEditOnBlip(blipId);
+  await expect(
+    page.locator('div[title^="Insert task"]').first(),
+    "[gwt] format toolbar Insert task button must mount in edit mode"
+  ).toBeVisible({ timeout: 15_000 });
+  await gwt.clickInsertTask();
+  await gwt.dismissTaskMetadataPopup();
+  await page.keyboard.press("Escape");
+  await expect
+    .poll(
+      async () =>
+        await page
+          .locator(`[data-blip-id="${blipId}"] input[type="checkbox"]`)
+          .count(),
+      {
+        timeout: 15_000,
+        message: `[gwt] B-J should contain an inline checkbox after Insert task`
+      }
+    )
+    .toBeGreaterThanOrEqual(1);
+  await expect
+    .poll(async () => await gwt.blipHasCheckedTask(blipId), {
+      timeout: 10_000,
+      message: `[gwt] B-J inline checkbox should start unchecked`
+    })
+    .toBe(false);
+}
+
+/**
  * Boots a second BrowserContext that shares the first context's
  * cookies + localStorage so the second-context navigations land on
  * the same authenticated session. Mirrors Playwright's documented
@@ -319,7 +358,7 @@ test.describe("G-PORT-6 tasks + done state parity", () => {
     }
   });
 
-  test("J2CL: per-blip task toggle flips data-task-completed (optimistic UI)", async ({
+  test("J2CL: existing task toggle flips data-task-completed (optimistic UI)", async ({
     page
   }) => {
     const creds = freshCredentials("g6j");
@@ -337,6 +376,7 @@ test.describe("G-PORT-6 tasks + done state parity", () => {
 
     const gwt = new GwtPage(page, BASE_URL);
     const { waveId, blipJ } = await authorThreeBlipWave(page, gwt);
+    await insertOpenTaskOnGwt(page, gwt, blipJ);
 
     const j2cl = new J2clPage(page, BASE_URL);
     await j2cl.gotoWave(waveId);
@@ -366,7 +406,9 @@ test.describe("G-PORT-6 tasks + done state parity", () => {
     // installs writeSession for this wave.
     await page.waitForTimeout(2_000);
 
-    // Click the per-blip task toggle on B-J.
+    // Click the per-blip task toggle on B-J. The toggle is expected only
+    // because the GWT side created a real task on this blip first; normal
+    // non-task blips should not show a generic task affordance.
     const toggle = j2cl.blipTaskToggle(blipJ);
     await toggle.scrollIntoViewIfNeeded();
     await expect(
@@ -396,6 +438,7 @@ test.describe("G-PORT-6 tasks + done state parity", () => {
 
       const gwt = new GwtPage(page, BASE_URL);
       const { waveId, blipJ } = await authorThreeBlipWave(page, gwt);
+      await insertOpenTaskOnGwt(page, gwt, blipJ);
 
       const j2cl = new J2clPage(page, BASE_URL);
       await j2cl.gotoWave(waveId);

--- a/wave/src/e2e/j2cl-gwt-parity/tests/tasks-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/tasks-parity.spec.ts
@@ -43,6 +43,7 @@ import { test, expect, Browser, BrowserContext, Page } from "@playwright/test";
 import { J2clPage } from "../pages/J2clPage";
 import { GwtPage } from "../pages/GwtPage";
 import { freshCredentials, registerAndSignIn } from "../fixtures/testUser";
+import { insertOpenTaskOnGwt } from "./helpers/gwt-task";
 
 const BASE_URL = process.env.WAVE_E2E_BASE_URL ?? "http://127.0.0.1:9900";
 
@@ -170,45 +171,6 @@ async function authorThreeBlipWave(
   ).toBeGreaterThanOrEqual(3);
 
   return { waveId, blipG: ids[1], blipJ: ids[2] };
-}
-
-/**
- * Creates an open task on an existing GWT blip and leaves the checkbox
- * unchecked. J2CL intentionally no longer mounts a generic Task toggle on
- * every normal blip; it should expose task controls only after the GWT task
- * doodad/annotation exists.
- */
-async function insertOpenTaskOnGwt(
-  page: Page,
-  gwt: GwtPage,
-  blipId: string
-): Promise<void> {
-  await gwt.clickEditOnBlip(blipId);
-  await expect(
-    page.locator('div[title^="Insert task"]').first(),
-    "[gwt] format toolbar Insert task button must mount in edit mode"
-  ).toBeVisible({ timeout: 15_000 });
-  await gwt.clickInsertTask();
-  await gwt.dismissTaskMetadataPopup();
-  await page.keyboard.press("Escape");
-  await expect
-    .poll(
-      async () =>
-        await page
-          .locator(`[data-blip-id="${blipId}"] input[type="checkbox"]`)
-          .count(),
-      {
-        timeout: 15_000,
-        message: `[gwt] B-J should contain an inline checkbox after Insert task`
-      }
-    )
-    .toBeGreaterThanOrEqual(1);
-  await expect
-    .poll(async () => await gwt.blipHasCheckedTask(blipId), {
-      timeout: 10_000,
-      message: `[gwt] B-J inline checkbox should start unchecked`
-    })
-    .toBe(false);
 }
 
 /**

--- a/wave/src/e2e/j2cl-gwt-parity/tests/visual-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/visual-parity.spec.ts
@@ -19,6 +19,7 @@ import {
   waitForMentionPopoverGwt,
   waitForParticipantsJ2cl
 } from "./helpers/mention";
+import { insertOpenTaskOnGwt } from "./helpers/gwt-task";
 import {
   composerRegionGwt,
   composerRegionJ2cl,
@@ -222,33 +223,6 @@ async function authorThreeBlipWave(
 
   const ids = await waitForPopulatedBlipIds(page, 3);
   return { waveId, rootBlipId, blipJ: ids[2] };
-}
-
-async function insertOpenTaskOnGwt(
-  page: Page,
-  gwt: GwtPage,
-  blipId: string
-): Promise<void> {
-  await gwt.clickEditOnBlip(blipId);
-  await expect(
-    page.locator('div[title^="Insert task"]').first(),
-    "[gwt] format toolbar Insert task button must mount in edit mode"
-  ).toBeVisible({ timeout: 15_000 });
-  await gwt.clickInsertTask();
-  await gwt.dismissTaskMetadataPopup();
-  await page.keyboard.press("Escape");
-  await expect
-    .poll(
-      async () =>
-        await page
-          .locator(`[data-blip-id="${blipId}"] input[type="checkbox"]`)
-          .count(),
-      {
-        timeout: 15_000,
-        message: `[gwt] ${blipId} should contain an inline checkbox after Insert task`
-      }
-    )
-    .toBeGreaterThanOrEqual(1);
 }
 
 async function prepareJ2clWelcome(page: Page): Promise<J2clPage> {

--- a/wave/src/e2e/j2cl-gwt-parity/tests/visual-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/visual-parity.spec.ts
@@ -224,6 +224,33 @@ async function authorThreeBlipWave(
   return { waveId, rootBlipId, blipJ: ids[2] };
 }
 
+async function insertOpenTaskOnGwt(
+  page: Page,
+  gwt: GwtPage,
+  blipId: string
+): Promise<void> {
+  await gwt.clickEditOnBlip(blipId);
+  await expect(
+    page.locator('div[title^="Insert task"]').first(),
+    "[gwt] format toolbar Insert task button must mount in edit mode"
+  ).toBeVisible({ timeout: 15_000 });
+  await gwt.clickInsertTask();
+  await gwt.dismissTaskMetadataPopup();
+  await page.keyboard.press("Escape");
+  await expect
+    .poll(
+      async () =>
+        await page
+          .locator(`[data-blip-id="${blipId}"] input[type="checkbox"]`)
+          .count(),
+      {
+        timeout: 15_000,
+        message: `[gwt] ${blipId} should contain an inline checkbox after Insert task`
+      }
+    )
+    .toBeGreaterThanOrEqual(1);
+}
+
 async function prepareJ2clWelcome(page: Page): Promise<J2clPage> {
   const j2cl = new J2clPage(page, BASE_URL);
   await openFirstWaveJ2cl(page, BASE_URL);
@@ -816,13 +843,26 @@ test.describe("G-PORT-9 visual parity gates", () => {
     test.info().annotations.push({ type: "test-user", description: creds.address });
     await registerAndSignIn(page, BASE_URL, creds);
 
-    await prepareJ2clWelcome(page);
+    const authorGwt = new GwtPage(page, BASE_URL);
+    const { waveId } = await authorSingleBlipWave(
+      page,
+      authorGwt,
+      "Composer visual parity root blip"
+    );
+
+    const j2cl = new J2clPage(page, BASE_URL);
+    await j2cl.gotoWave(waveId);
+    await j2cl.assertInboxLoaded();
+    await page.waitForSelector("wave-blip", { timeout: 30_000 });
     await openInlineComposerJ2cl(page);
     await expect(composerRegionJ2cl(page)).toBeVisible({ timeout: 10_000 });
 
     const gwtPage = await page.context().newPage();
     try {
-      const gwt = await prepareGwtWelcome(gwtPage);
+      const gwt = new GwtPage(gwtPage, BASE_URL);
+      await gwt.gotoWave(waveId);
+      await gwt.assertInboxLoaded();
+      await gwtPage.waitForSelector("[data-blip-id]", { timeout: 30_000 });
       await openInlineComposerGwt(gwt);
       await expect(composerRegionGwt(gwtPage)).toBeVisible({ timeout: 10_000 });
       await normalizeDynamicBlipText(composerRegionJ2cl(page), creds.address);
@@ -899,11 +939,12 @@ test.describe("G-PORT-9 visual parity gates", () => {
 
     const authorGwt = new GwtPage(page, BASE_URL);
     const { waveId, rootBlipId } = await authorThreeBlipWave(page, authorGwt);
+    await insertOpenTaskOnGwt(page, authorGwt, rootBlipId);
 
     const j2clPage = await page.context().newPage();
     try {
-      await openTaskDetailsJ2cl(j2clPage, waveId, rootBlipId);
       await openTaskDetailsGwt(page, authorGwt, rootBlipId);
+      await openTaskDetailsJ2cl(j2clPage, waveId, rootBlipId);
       await normalizeTaskOverlayGwt(page);
       await normalizeTaskOverlayChrome(taskOverlayRegionJ2cl(j2clPage));
       await normalizeTaskOverlayChrome(taskOverlayRegionGwt(page));


### PR DESCRIPTION
## Summary
- Fix J2CL blip focus/navigation ownership so clicked blips are selected and repeated next/previous navigation follows visible inline-reply DOM order like GWT.
- Add ArrowUp/ArrowDown Lit shell shortcut coverage for GWT-compatible blip navigation.
- Harden parity tests by using deterministic authored waves for inline reply, keyboard, mention, composer, and task-overlay assertions, and by requiring real task state before J2CL task controls are expected.

## Verification
- `bash scripts/worktree-boot.sh --port 9915`
- `PORT=9915 bash scripts/wave-smoke.sh check`
- `npm test -- --run test/shortcuts/keybindings.test.js`
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py`
- `WAVE_E2E_BASE_URL=http://127.0.0.1:9915 npx playwright test --workers=1 --retries=0` (21 passed)
- `git diff --check`

Closes #1161.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard navigation: ArrowUp/ArrowDown, Home/End, g/Shift+G, [ and ] for blip focus and depth navigation.

* **Improvements**
  * Clicking a blip now focuses it to preserve selection and sync focus.
  * Consolidated focus/visibility logic for more consistent navigation; shortcuts are non-global and ignore modifiers/repeats.

* **Tests**
  * Expanded unit and end-to-end coverage and added helpers to strengthen keyboard, mention, and task parity.

* **Documentation**
  * Added changelog entry describing focus and parity updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->