### PR TITLE
fix(j2cl): align blip focus after parity merge

### DIFF
--- a/j2cl/lit/src/shortcuts/blip-focus.js
+++ b/j2cl/lit/src/shortcuts/blip-focus.js
@@ -237,6 +237,7 @@ export function setFocusedBlip(target, root = document) {
   // stale previously-clicked blip host from remaining the key target
   // across combined keyboard workflows.
   try {
+    if (!target.hasAttribute("tabindex")) target.setAttribute("tabindex", "-1");
     target.focus({ preventScroll: true });
   } catch (_) {
     try {
@@ -278,6 +279,9 @@ export function clearBlipFocus(root = document) {
       blip.removeAttribute("aria-current");
       if ("focused" in blip) blip.focused = false;
       blip.classList.remove(RENDERER_FOCUS_CLASS);
+      // Reset tabindex if the renderer's native focus listener promoted it to
+      // "0" — leaving "0" makes the blip tabbable and renders it as active.
+      if (blip.getAttribute("tabindex") === "0") blip.setAttribute("tabindex", "-1");
       if (!surface) surface = findReadSurface(blip, root);
       cleared = true;
     }

--- a/j2cl/lit/src/shortcuts/blip-focus.js
+++ b/j2cl/lit/src/shortcuts/blip-focus.js
@@ -232,14 +232,19 @@ export function setFocusedBlip(target, root = document) {
   if (typeof target.scrollIntoView === "function") {
     target.scrollIntoView({ block: "nearest", inline: "nearest" });
   }
-  // Keep DOM focus where the shell-level keyboard handler received it.
-  // Moving browser focus onto the <wave-blip> host makes the next
-  // repeated j/k keydown target the custom element itself; in the
-  // viewport-windowed read surface that event can be consumed at the
-  // current blip boundary before the renderer has grown the next window.
-  // GWT's focus frame is visual state rather than native DOM focus, so
-  // the parity behavior is to reflect focus via attributes/classes and
-  // leave keyboard ownership with the shell.
+  // Keep native focus aligned with the visual focus marker. j/k still
+  // bubbles to the shell-level handler, but moving DOM focus prevents a
+  // stale previously-clicked blip host from remaining the key target
+  // across combined keyboard workflows.
+  try {
+    target.focus({ preventScroll: true });
+  } catch (_) {
+    try {
+      target.focus();
+    } catch (_) {
+      // Some test hosts may not implement focus(); visual focus still works.
+    }
+  }
   target.dispatchEvent(
     new CustomEvent(FOCUS_CHANGED_EVENT, {
       bubbles: true,

--- a/j2cl/lit/test/shortcuts/blip-focus.test.js
+++ b/j2cl/lit/test/shortcuts/blip-focus.test.js
@@ -190,6 +190,16 @@ describe("clearBlipFocus", () => {
     clearBlipFocus(root);
     expect(blips[1].hasAttribute("aria-current")).to.equal(false);
   });
+
+  it("resets tabindex=0 promoted by renderer focus listener so blip is not tabbable after Esc", async () => {
+    const root = await threeBlips();
+    const blips = Array.from(root.querySelectorAll("wave-blip"));
+    setFocusedBlip(blips[0], root);
+    // Simulate the renderer's native focus listener promoting tabindex to "0".
+    blips[0].setAttribute("tabindex", "0");
+    expect(clearBlipFocus(root)).to.equal(true);
+    expect(blips[0].getAttribute("tabindex")).to.not.equal("0");
+  });
 });
 
 describe("focusBlipBoundary", () => {

--- a/wave/config/changelog.d/2026-05-03-j2cl-blip-focus-keyboard-parity.json
+++ b/wave/config/changelog.d/2026-05-03-j2cl-blip-focus-keyboard-parity.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-03-j2cl-blip-focus-keyboard-parity",
+  "version": "PR #1190",
+  "date": "2026-05-03",
+  "title": "J2CL blip keyboard focus parity",
+  "summary": "Keeps J2CL blip keyboard navigation aligned with the visual focus marker during repeated shortcut use.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Moves native focus to the visually focused J2CL blip so repeated next/previous blip shortcuts continue from the current blip instead of a stale earlier target."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Follow-up to #1189: carry the final J2CL focus alignment fix that was pushed after #1189 merged and therefore was not included in merge commit c3f87434f.
- Align native DOM focus with the visual `wave-blip[focused]` marker so repeated shell-owned j/k navigation does not keep targeting a stale previously-clicked blip host.
- Keep scope to `j2cl/lit/src/shortcuts/blip-focus.js` only.

## Verification
- `npm ci` in `j2cl/lit`
- `npm test -- --run test/shortcuts/keybindings.test.js test/shortcuts/blip-focus.test.js` -> 51 passed, 0 failed
- `scripts/worktree-file-store.sh --source /Users/vega/devroot/incubator-wave` -> linked local file store
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json` -> passed
- `bash scripts/worktree-boot.sh --port 9916` -> passed after changelog assembly
- `PORT=9916 bash scripts/wave-smoke.sh check` -> ROOT/GWT/J2CL/sidecar/webclient all 200/present
- `npm ci` in `wave/src/e2e/j2cl-gwt-parity`
- `WAVE_E2E_BASE_URL=http://127.0.0.1:9916 npx playwright test tests/keyboard-shortcuts-parity.spec.ts --workers=1 --retries=0` -> 3 passed, 0 failed
- `git diff --check` -> passed

Notes: the first local full keyboard parity run hit a transient authored-wave propagation assertion with only one mounted J2CL blip. The exact failing test passed on immediate rerun, and the full keyboard parity file then passed 3/3 against the same foreground server.

Refs #1161
Refs #904


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Keyboard focus now moves to the visually focused blip so next/previous shortcuts start from the current item, improving keyboard navigation and accessibility.

* **Tests**
  * Added a test to ensure clearing focus also removes promoted tabbability (blip is no longer tabbable after Esc).

* **Documentation**
  * Added a changelog entry describing the keyboard focus parity fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->