### PR TITLE
test(j2cl): stabilize mention visual parity gate

### DIFF
--- a/wave/config/changelog.d/2026-05-03-j2cl-mention-visual-parity-harness.json
+++ b/wave/config/changelog.d/2026-05-03-j2cl-mention-visual-parity-harness.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-03-j2cl-mention-visual-parity-harness",
+  "version": "Issue #1161",
+  "date": "2026-05-03",
+  "title": "J2CL mention visual parity coverage",
+  "summary": "Stabilizes the J2CL/GWT mention-popover visual parity gate on deterministic authored wave content.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Moves the mention-popover visual parity check off the seeded Welcome wave so inline reply hydration no longer hides the composer during audit runs."
+      ]
+    }
+  ]
+}

--- a/wave/src/e2e/j2cl-gwt-parity/tests/visual-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/visual-parity.spec.ts
@@ -867,7 +867,13 @@ test.describe("G-PORT-9 visual parity gates", () => {
     test.info().annotations.push({ type: "test-user", description: creds.address });
     await registerAndSignIn(page, BASE_URL, creds);
 
-    await prepareJ2clWelcome(page);
+    const gwtAuthor = new GwtPage(page, BASE_URL);
+    const { waveId, rootBlipId } = await authorSingleBlipWave(
+      page,
+      gwtAuthor,
+      "Mention visual parity root blip"
+    );
+    await openWaveByIdJ2cl(page, waveId, rootBlipId);
     const composer = await openInlineComposerJ2cl(page);
     const trigger = (await readMentionTriggerLetterJ2cl(composer)) || creds.address.charAt(0);
     await waitForParticipantsJ2cl(composer, 10_000);
@@ -878,7 +884,14 @@ test.describe("G-PORT-9 visual parity gates", () => {
 
     const gwtPage = await page.context().newPage();
     try {
-      const gwt = await prepareGwtWelcome(gwtPage);
+      const gwt = new GwtPage(gwtPage, BASE_URL);
+      await gwt.gotoWave(waveId);
+      await gwt.assertInboxLoaded();
+      await expect(
+        gwtPage.locator(`[data-blip-id="${rootBlipId}"]`).first(),
+        "GWT authored wave must render the root blip for mention visual parity"
+      ).toBeVisible({ timeout: 30_000 });
+      await stabilizeVisualPage(gwtPage);
       await openInlineComposerGwt(gwt);
       await typeAtMentionTriggerGwt(gwtPage, gwt, `@${trigger}`);
       await gwtPage.mouse.move(24, 24);


### PR DESCRIPTION
## Summary
- Continue #1161 current-main parity audit after #1190 merged.
- Move the mention-popover visual parity gate from the seeded Welcome wave to deterministic authored wave content.
- This avoids Welcome-wave inline-thread hydration replacing the J2CL inline composer before the test types the mention trigger.

## Evidence
- Before the fix: full parity harness reached 20/21 passed; `visual-parity.spec.ts:865` timed out for 5 minutes waiting for `wave-blip:first wavy-composer[data-inline-composer=true]` after Welcome-wave hydration.
- Focused rerun reproduced the same hang until interrupted.
- After the fix: `WAVE_E2E_BASE_URL=http://127.0.0.1:9917 npx playwright test tests/visual-parity.spec.ts:865 --workers=1 --retries=0` -> 1 passed.
- Full parity: `WAVE_E2E_BASE_URL=http://127.0.0.1:9917 npx playwright test --workers=1 --retries=0` -> 21 passed, 0 failed.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json` -> passed.
- `git diff --check` -> passed.

Refs #1161
Refs #904


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved visual parity issues with the mention-popover feature to ensure consistent appearance during inline reply interactions.

* **Tests**
  * Enhanced visual parity test methodology for improved reliability and accuracy in cross-implementation verification of wave rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->