### PR TITLE
test(j2cl): harden parity harness focus flows

### DIFF
--- a/wave/config/changelog.d/2026-05-03-j2cl-parity-harness-focus.json
+++ b/wave/config/changelog.d/2026-05-03-j2cl-parity-harness-focus.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-03-j2cl-parity-harness-focus",
+  "version": "PR #1192",
+  "date": "2026-05-03",
+  "title": "J2CL parity harness focus stability",
+  "summary": "Stabilized the J2CL/GWT parity harness around keyboard focus and mention selection so parity regressions are caught reliably.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Made the parity tests drive J2CL blip navigation and GWT mention selection from deterministic focus state."
+      ]
+    }
+  ]
+}

--- a/wave/src/e2e/j2cl-gwt-parity/tests/helpers/mention.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/helpers/mention.ts
@@ -176,6 +176,26 @@ export async function typeAtMentionTriggerGwt(
   await expect(editor, "GWT editor must be present before typing a mention trigger").toBeVisible({
     timeout: 10_000
   });
+  await focusGwtEditor(editor, "GWT editor must own focus before typing a mention trigger");
+  await page.keyboard.type(literal, { delay: 20 });
+  await page.waitForTimeout(350);
+}
+
+export async function dispatchMentionKeyGwt(
+  page: Page,
+  gwt: GwtPage,
+  key: string
+): Promise<void> {
+  const editor = gwt.gwtActiveEditableDocument();
+  await expect(editor, `GWT editor must be visible before ${key}`).toBeVisible({
+    timeout: 5_000
+  });
+  await focusGwtEditor(editor, `GWT editor must own focus before ${key}`);
+  await page.keyboard.press(key);
+  await page.waitForTimeout(150);
+}
+
+async function focusGwtEditor(editor: Locator, message: string): Promise<void> {
   await editor.evaluate((el) => {
     const target = el as HTMLElement;
     target.focus();
@@ -187,22 +207,15 @@ export async function typeAtMentionTriggerGwt(
     selection.removeAllRanges();
     selection.addRange(range);
   });
-  await page.keyboard.type(literal, { delay: 20 });
-  await page.waitForTimeout(350);
-}
-
-export async function dispatchMentionKeyGwt(
-  page: Page,
-  gwt: GwtPage,
-  key: string
-): Promise<void> {
-  const editor = gwt.gwtActiveEditableDocument();
-  await expect(editor, `GWT editor must be focused before ${key}`).toBeVisible({
-    timeout: 5_000
-  });
-  await editor.evaluate((el) => (el as HTMLElement).focus());
-  await page.keyboard.press(key);
-  await page.waitForTimeout(150);
+  await expect
+    .poll(
+      async () =>
+        await editor.evaluate(
+          (el) => el === document.activeElement || el.contains(document.activeElement)
+        ),
+      { message, timeout: 5_000 }
+    )
+    .toBe(true);
 }
 
 export async function readRenderedMentionsGwt(scope: Locator): Promise<

--- a/wave/src/e2e/j2cl-gwt-parity/tests/helpers/mention.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/helpers/mention.ts
@@ -173,22 +173,34 @@ export async function typeAtMentionTriggerGwt(
   literal: string
 ): Promise<void> {
   const editor = gwt.gwtActiveEditableDocument();
-  await editor.click({ timeout: 10_000 });
-  await editor.evaluate((el) => (el as HTMLElement).focus());
-  await expect
-    .poll(
-      async () =>
-        await editor.evaluate(
-          (el) => el === document.activeElement || el.contains(document.activeElement)
-        ),
-      { message: "GWT editor must own focus before typing a mention trigger", timeout: 5_000 }
-    )
-    .toBe(true);
+  await expect(editor, "GWT editor must be present before typing a mention trigger").toBeVisible({
+    timeout: 10_000
+  });
+  await editor.evaluate((el) => {
+    const target = el as HTMLElement;
+    target.focus();
+    const selection = window.getSelection();
+    if (!selection) return;
+    const range = document.createRange();
+    range.selectNodeContents(target);
+    range.collapse(false);
+    selection.removeAllRanges();
+    selection.addRange(range);
+  });
   await page.keyboard.type(literal, { delay: 20 });
   await page.waitForTimeout(350);
 }
 
-export async function dispatchMentionKeyGwt(page: Page, key: string): Promise<void> {
+export async function dispatchMentionKeyGwt(
+  page: Page,
+  gwt: GwtPage,
+  key: string
+): Promise<void> {
+  const editor = gwt.gwtActiveEditableDocument();
+  await expect(editor, `GWT editor must be focused before ${key}`).toBeVisible({
+    timeout: 5_000
+  });
+  await editor.evaluate((el) => (el as HTMLElement).focus());
   await page.keyboard.press(key);
   await page.waitForTimeout(150);
 }

--- a/wave/src/e2e/j2cl-gwt-parity/tests/keyboard-shortcuts-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/keyboard-shortcuts-parity.spec.ts
@@ -114,6 +114,25 @@ async function clearBlipFocusBeforeShortcutDrive(page: Page): Promise<void> {
       }
     )
     .toBeNull();
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(() => {
+          let active: Element | null = document.activeElement;
+          while (active instanceof HTMLElement && active.shadowRoot?.activeElement) {
+            active = active.shadowRoot.activeElement;
+          }
+          return (
+            active?.matches?.("input, textarea, [contenteditable='true'], [data-composer-body]") ??
+            false
+          );
+        }),
+      {
+        timeout: 5_000,
+        message: "J2CL shortcut drive should start with shell focus, not an editable control"
+      }
+    )
+    .toBe(false);
 }
 
 /**

--- a/wave/src/e2e/j2cl-gwt-parity/tests/keyboard-shortcuts-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/keyboard-shortcuts-parity.spec.ts
@@ -97,6 +97,34 @@ async function blipCountJ2cl(page: Page): Promise<number> {
   });
 }
 
+/** Start keyboard navigation from the shell, not from a pre-focused blip. */
+async function clearBlipFocusBeforeShortcutDrive(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const active = document.activeElement as HTMLElement | null;
+    if (active && typeof active.blur === "function") {
+      active.blur();
+    }
+    document.querySelectorAll("wave-blip").forEach((blip) => {
+      blip.removeAttribute("focused");
+      blip.removeAttribute("data-blip-focused");
+      blip.removeAttribute("aria-current");
+      blip.classList.remove("j2cl-read-blip-focused");
+      if (blip.getAttribute("tabindex") === "0") {
+        blip.setAttribute("tabindex", "-1");
+      }
+    });
+  });
+  await expect
+    .poll(
+      async () => await focusedBlipIdJ2cl(page),
+      {
+        timeout: 5_000,
+        message: "J2CL shortcut drive should start without a focused blip"
+      }
+    )
+    .toBeNull();
+}
+
 /**
  * Drive the focus-next shortcut N times on J2CL (j key). Returns the
  * final focused blip id so callers can assert progression.
@@ -146,11 +174,12 @@ test.describe("G-PORT-7 keyboard shortcuts parity", () => {
     // blip; the second j must move to a different blip. Shift+Cmd+O
     // and Esc are tested OUTSIDE the input chain — first move focus
     // away from the search input so j/k actually drive the shell
-    // handler instead of the search box.
+    // handler instead of the search box. Do not click a blip here:
+    // Chromium/Linux may focus the clicked root blip, which makes the
+    // first j legitimately advance to the reply and leaves the second j
+    // clamped at the end of this two-blip wave.
     // ------------------------------------------------------------------
-    await page.locator("wave-blip").first().click({ position: { x: 4, y: 4 } });
-    // Click on the wave panel margin to clear any text selection/focus.
-    await page.mouse.click(4, 200);
+    await clearBlipFocusBeforeShortcutDrive(page);
 
     const firstFocus = await pressJN(page, 1);
     expect(

--- a/wave/src/e2e/j2cl-gwt-parity/tests/keyboard-shortcuts-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/keyboard-shortcuts-parity.spec.ts
@@ -99,21 +99,12 @@ async function blipCountJ2cl(page: Page): Promise<number> {
 
 /** Start keyboard navigation from the shell, not from a pre-focused blip. */
 async function clearBlipFocusBeforeShortcutDrive(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    const active = document.activeElement as HTMLElement | null;
-    if (active && typeof active.blur === "function") {
-      active.blur();
-    }
-    document.querySelectorAll("wave-blip").forEach((blip) => {
-      blip.removeAttribute("focused");
-      blip.removeAttribute("data-blip-focused");
-      blip.removeAttribute("aria-current");
-      blip.classList.remove("j2cl-read-blip-focused");
-      if (blip.getAttribute("tabindex") === "0") {
-        blip.setAttribute("tabindex", "-1");
-      }
-    });
-  });
+  await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+  for (let attempt = 0; attempt < 4; attempt++) {
+    if ((await focusedBlipIdJ2cl(page)) === null) break;
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(80);
+  }
   await expect
     .poll(
       async () => await focusedBlipIdJ2cl(page),

--- a/wave/src/e2e/j2cl-gwt-parity/tests/mention-autocomplete-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/mention-autocomplete-parity.spec.ts
@@ -45,19 +45,6 @@ import { compareLocatorScreenshots } from "./helpers/visualDiff";
 
 const BASE_URL = process.env.WAVE_E2E_BASE_URL ?? "http://127.0.0.1:9900";
 
-/**
- * On the J2CL view: open the first wave in the inbox by clicking its
- * search-rail card. Returns once at least one <wave-blip> mounts.
- */
-async function openFirstWaveJ2cl(page: Page, baseURL: string): Promise<void> {
-  await page.goto(`${baseURL}/?view=j2cl-root`, { waitUntil: "domcontentloaded" });
-  await page.waitForSelector("shell-root", { timeout: 15_000 });
-  const card = page.locator("wavy-search-rail-card[data-digest-card]:visible").first();
-  await expect(card).toBeVisible({ timeout: 30_000 });
-  await card.click({ timeout: 15_000 });
-  await page.waitForSelector("wave-blip", { timeout: 30_000 });
-}
-
 async function authorSimpleGwtWave(
   page: Page,
   gwt: GwtPage,

--- a/wave/src/e2e/j2cl-gwt-parity/tests/mention-autocomplete-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/mention-autocomplete-parity.spec.ts
@@ -58,42 +58,6 @@ async function openFirstWaveJ2cl(page: Page, baseURL: string): Promise<void> {
   await page.waitForSelector("wave-blip", { timeout: 30_000 });
 }
 
-async function openWelcomeWaveGwt(page: Page, gwt: GwtPage): Promise<void> {
-  await gwt.goto("/");
-  await gwt.assertInboxLoaded();
-  await expect
-    .poll(
-      async () =>
-        await page.evaluate(() =>
-          document.body.innerText.includes("Welcome to SupaWave")
-        ),
-      {
-        message: "GWT inbox must surface the seeded Welcome wave",
-        timeout: 30_000
-      }
-    )
-    .toBe(true);
-
-  await page.waitForTimeout(2_500);
-  const digest = page.locator("text=Welcome to SupaWave").first();
-  await expect(digest).toBeVisible({ timeout: 10_000 });
-  await digest.click({ timeout: 15_000 });
-  await page.waitForTimeout(6_000);
-
-  await expect
-    .poll(
-      async () =>
-        await page.evaluate(() =>
-          document.body.innerText.includes("This welcome wave is your dock")
-        ),
-      {
-        message: "GWT view must render the welcome wave's body",
-        timeout: 20_000
-      }
-    )
-    .toBe(true);
-}
-
 async function authorSimpleGwtWave(
   page: Page,
   gwt: GwtPage,

--- a/wave/src/e2e/j2cl-gwt-parity/tests/mention-autocomplete-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/mention-autocomplete-parity.spec.ts
@@ -417,7 +417,11 @@ test.describe("G-PORT-5 mention autocomplete parity", () => {
     await registerAndSignIn(page, BASE_URL, creds);
 
     const gwt = new GwtPage(page, BASE_URL);
-    await openWelcomeWaveGwt(page, gwt);
+    await authorSimpleGwtWave(
+      page,
+      gwt,
+      "GWT mention autocomplete parity root blip"
+    );
 
     const firstLetter = creds.address.charAt(0);
     const initialBlipCount = await gwt.gwtBlips().count();
@@ -436,7 +440,7 @@ test.describe("G-PORT-5 mention autocomplete parity", () => {
     ).toBeGreaterThanOrEqual(1);
     const initialIndex = mention.activeIndex;
 
-    await dispatchMentionKeyGwt(page, "ArrowDown");
+    await dispatchMentionKeyGwt(page, gwt, "ArrowDown");
     mention = await readMentionStateGwt(page);
     if (mention.candidateCount > 1) {
       expect(
@@ -452,7 +456,7 @@ test.describe("G-PORT-5 mention autocomplete parity", () => {
     const expectedAddress = mention.activeAddress;
     expect(expectedAddress, "GWT active mention candidate must carry an address").not.toBe("");
 
-    await dispatchMentionKeyGwt(page, "Enter");
+    await dispatchMentionKeyGwt(page, gwt, "Enter");
     const editor = gwt.gwtActiveEditableDocument();
     await expect
       .poll(

--- a/wave/src/e2e/j2cl-gwt-parity/tests/visual-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/visual-parity.spec.ts
@@ -13,7 +13,6 @@ import {
   dispatchComposerKeyJ2cl,
   openInlineComposerGwt,
   openInlineComposerJ2cl,
-  readMentionTriggerLetterJ2cl,
   typeAtMentionTriggerGwt,
   typeAtMentionTriggerJ2cl,
   waitForMentionPopoverGwt,
@@ -875,7 +874,11 @@ test.describe("G-PORT-9 visual parity gates", () => {
     );
     await openWaveByIdJ2cl(page, waveId, rootBlipId);
     const composer = await openInlineComposerJ2cl(page);
-    const trigger = (await readMentionTriggerLetterJ2cl(composer)) || creds.address.charAt(0);
+    // Use the signed-in user's address as the common cross-view trigger.
+    // J2CL may include harness-only participant candidates; GWT's legacy
+    // popup is sourced from wave participants and can legitimately return
+    // no candidates for those harness-only entries.
+    const trigger = creds.address.charAt(0).toLowerCase();
     await waitForParticipantsJ2cl(composer, 10_000);
     await typeAtMentionTriggerJ2cl(page, composer, `@${trigger}`);
     await dispatchComposerKeyJ2cl(composer, "ArrowDown");


### PR DESCRIPTION
## Summary
- harden the J2CL keyboard shortcut parity test so it starts from shell focus rather than a pre-focused root blip
- make GWT mention parity refocus the active editor before typing and before ArrowDown/Enter selection
- keep mention visual parity on a cross-view participant trigger that both J2CL and GWT can resolve

## Issue
- Follow-up for #1161 after #1191 merged while the local parity rerun exposed harness focus instability.

## Verification
- `PORT=9917 bash scripts/wave-smoke.sh check`
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`
- `git diff --check`
- `cd wave/src/e2e/j2cl-gwt-parity && npm ci`
- `WAVE_E2E_BASE_URL=http://127.0.0.1:9917 npx playwright test --workers=1 --retries=0` (21 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved e2e reliability for mention autocomplete, mention popover visuals, and keyboard navigation by ensuring tests clear focus before shortcuts, start from a consistent state, and drive mention selection consistently.

* **Refactor**
  * Deterministic editor focusing and caret placement were standardized in test helpers to streamline setup and interactions across parity suites.

* **Chores**
  * Added a changelog entry documenting the harness stabilization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->