### PR TITLE
fix(j2cl): tighten wave thread chrome parity

### DIFF
--- a/j2cl/lit/src/elements/wave-blip-toolbar.js
+++ b/j2cl/lit/src/elements/wave-blip-toolbar.js
@@ -2,8 +2,7 @@ import { LitElement, css, html } from "lit";
 
 /**
  * <wave-blip-toolbar> — F-2 (#1037, R-3.1) per-blip action toolbar that
- * surfaces Reply (F.4), Edit (F.5), Link (F.7), Delete (F.6), and the
- * overflow trigger (future F-3 actions).
+ * surfaces Reply (F.4), Edit (F.5), Delete (F.6), and Link (F.7).
  *
  * F-3.S4 (#1038, R-5.6): the Delete button now emits a dedicated
  * `wave-blip-toolbar-delete` event so the compose surface can route
@@ -109,6 +108,7 @@ export class WaveBlipToolbar extends LitElement {
         type="button"
         data-toolbar-action="reply"
         aria-label="Reply to this blip"
+        title="Reply to this blip"
         @click=${() => this._emit("wave-blip-toolbar-reply")}
       >
         <span class="glyph" aria-hidden="true">↩</span><span class="label">Reply</span>
@@ -117,6 +117,7 @@ export class WaveBlipToolbar extends LitElement {
         type="button"
         data-toolbar-action="edit"
         aria-label="Edit this blip"
+        title="Edit this blip"
         @click=${() => this._emit("wave-blip-toolbar-edit")}
       >
         <span class="glyph" aria-hidden="true">✎</span><span class="label">Edit</span>
@@ -125,6 +126,7 @@ export class WaveBlipToolbar extends LitElement {
         type="button"
         data-toolbar-action="delete"
         aria-label="Delete this blip"
+        title="Delete this blip"
         @click=${() => this._emit("wave-blip-toolbar-delete")}
       >
         <span class="glyph" aria-hidden="true">✕</span><span class="label">Delete</span>
@@ -133,18 +135,10 @@ export class WaveBlipToolbar extends LitElement {
         type="button"
         data-toolbar-action="link"
         aria-label="Copy permalink to this blip"
+        title="Copy permalink to this blip"
         @click=${() => this._emit("wave-blip-toolbar-link")}
       >
         <span class="glyph" aria-hidden="true">§</span><span class="label">Link</span>
-      </button>
-      <button
-        type="button"
-        data-toolbar-action="overflow"
-        aria-label="More blip actions"
-        aria-haspopup="menu"
-        @click=${() => this._emit("wave-blip-toolbar-overflow")}
-      >
-        <span class="glyph" aria-hidden="true">⋯</span><span class="label">More</span>
       </button>
     `;
   }

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -15,7 +15,7 @@ import "./wavy-task-affordance.js";
  *   (docs/j2cl-plugin-slots.md) reflects them on `<wavy-blip-card>`.
  * - F-2 needs to layer on top: a header with the author display name
  *   + relative timestamp + full ISO datetime tooltip (F.1 / F.2 / F.3),
- *   a per-blip toolbar with Reply / Edit / Link / overflow that reveals
+   *   a per-blip toolbar with Reply / Edit / Delete / Link that reveals
  *   on focus or hover (F.4 / F.5 / F.6 / F.7), a compact thread affordance
  *   when the blip has children (F.10 + R-3.7 G.1 drill-in), and a `has-mention`
  *   reflection so the wave-nav-row can navigate by @-mentions (E.6 / E.7).
@@ -586,8 +586,6 @@ export class WaveBlip extends LitElement {
 
   render() {
     const tooltip = this.postedAtIso || this.postedAt;
-    const isRoot = this.blipDepth === "root";
-    const timestampSuffix = isRoot && this.postedAt ? " · root" : "";
     const palette = this._palette();
     const hasReplies = this.replyCount > 0;
     const visuallyFocused = this._visuallyFocused();
@@ -631,7 +629,7 @@ export class WaveBlip extends LitElement {
             title=${tooltip}
             datetime=${ifDefined(this.postedAtIso || undefined)}
           >
-            ${this.postedAt}${timestampSuffix}
+            ${this.postedAt}
           </time>
           <span class="toolbar" data-blip-toolbar-row="true">
           <wave-blip-toolbar

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -19,6 +19,7 @@
 
 body.j2cl-root-shell-page {
   margin: 0;
+  height: 100%;
   min-height: 100vh;
   background: #ffffff;
   color: var(--shell-color-text-primary);

--- a/j2cl/lit/test/wave-blip-toolbar.test.js
+++ b/j2cl/lit/test/wave-blip-toolbar.test.js
@@ -19,7 +19,7 @@ describe("<wave-blip-toolbar>", () => {
     expect(customElements.get("wave-blip-toolbar")).to.exist;
   });
 
-  it("renders Reply / Edit / Link / Delete / overflow buttons with stable data-toolbar-action keys", async () => {
+  it("renders only wired Reply / Edit / Link / Delete buttons with stable data-toolbar-action keys", async () => {
     const el = await fixture(html`
       <wave-blip-toolbar data-blip-id="b1" data-wave-id="w1"></wave-blip-toolbar>
     `);
@@ -29,7 +29,7 @@ describe("<wave-blip-toolbar>", () => {
     expect(el.renderRoot.querySelector("[data-toolbar-action='link']")).to.exist;
     // F-3.S4 (#1038, R-5.6 F.6)
     expect(el.renderRoot.querySelector("[data-toolbar-action='delete']")).to.exist;
-    expect(el.renderRoot.querySelector("[data-toolbar-action='overflow']")).to.exist;
+    expect(el.renderRoot.querySelector("[data-toolbar-action='overflow']")).to.not.exist;
   });
 
   it("each button has an aria-label that names the action", async () => {
@@ -45,17 +45,16 @@ describe("<wave-blip-toolbar>", () => {
       .to.equal("Copy permalink to this blip");
     expect(el.renderRoot.querySelector("[data-toolbar-action='delete']").getAttribute("aria-label"))
       .to.equal("Delete this blip");
-    expect(el.renderRoot.querySelector("[data-toolbar-action='overflow']").getAttribute("aria-label"))
-      .to.equal("More blip actions");
   });
 
-  it("overflow button is announced as a menu trigger (aria-haspopup='menu')", async () => {
+  it("each visible button has a hover title matching the ARIA action", async () => {
     const el = await fixture(html`
       <wave-blip-toolbar data-blip-id="b3" data-wave-id="w3"></wave-blip-toolbar>
     `);
     await el.updateComplete;
-    expect(el.renderRoot.querySelector("[data-toolbar-action='overflow']")
-      .getAttribute("aria-haspopup")).to.equal("menu");
+    for (const button of el.renderRoot.querySelectorAll("[data-toolbar-action]")) {
+      expect(button.getAttribute("title")).to.equal(button.getAttribute("aria-label"));
+    }
   });
 
   it("Reply button click emits wave-blip-toolbar-reply with blip context", async () => {
@@ -89,16 +88,6 @@ describe("<wave-blip-toolbar>", () => {
     setTimeout(() => el.renderRoot.querySelector("[data-toolbar-action='link']").click(), 0);
     const ev = await oneEvent(el, "wave-blip-toolbar-link");
     expect(ev.detail.blipId).to.equal("b6");
-  });
-
-  it("overflow button click emits wave-blip-toolbar-overflow", async () => {
-    const el = await fixture(html`
-      <wave-blip-toolbar data-blip-id="b7" data-wave-id="w7"></wave-blip-toolbar>
-    `);
-    await el.updateComplete;
-    setTimeout(() => el.renderRoot.querySelector("[data-toolbar-action='overflow']").click(), 0);
-    const ev = await oneEvent(el, "wave-blip-toolbar-overflow");
-    expect(ev.detail.blipId).to.equal("b7");
   });
 
   // F-3.S4 (#1038, R-5.6 F.6): the Delete button click emits a

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -227,6 +227,22 @@ describe("<wave-blip>", () => {
     expect(time.getAttribute("datetime")).to.equal("2026-04-26T12:00:00Z");
   });
 
+  it("does not append root-depth debug text to the visible timestamp", async () => {
+    const el = await fixture(html`
+      <wave-blip
+        data-blip-id="b9r"
+        data-wave-id="w9"
+        author-name="E"
+        posted-at="5m ago"
+        data-blip-depth="root"
+      ></wave-blip>
+    `);
+    await el.updateComplete;
+    const time = el.renderRoot.querySelector("time.posted");
+    expect(time.textContent.trim()).to.equal("5m ago");
+    expect(time.textContent).to.not.include("root");
+  });
+
   it("omits the datetime attribute entirely when postedAtIso is empty", async () => {
     // Empty datetime="" is invalid HTML and confuses ATs / validators. The
     // wrapper must skip the attribute (via lit's ifDefined directive)
@@ -564,7 +580,7 @@ describe("<wave-blip>", () => {
       expect(chevron.textContent.trim()).to.equal("▸"); // ▸
     });
 
-    it("root-depth blip appends ' · root' to the timestamp text", async () => {
+    it("root-depth blip keeps the timestamp free of debug depth text", async () => {
       const el = await fixture(html`
         <wave-blip
           data-blip-id="b44"
@@ -577,7 +593,8 @@ describe("<wave-blip>", () => {
       await el.updateComplete;
       const time = el.renderRoot.querySelector("time.posted");
       expect(time.textContent).to.contain("2 hours ago");
-      expect(time.textContent).to.contain("· root");
+      expect(time.textContent).to.not.contain("· root");
+      expect(time.textContent).to.not.contain("root");
     });
 
     it("reply-depth blip omits the root suffix", async () => {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -2498,14 +2498,13 @@ public final class J2clReadSurfaceDomRenderer {
     if (viewportEdgeListener == null || renderedWindowEntries.isEmpty()) {
       return;
     }
-    if (activeScrollTop() <= EDGE_SCROLL_THRESHOLD_PX) {
+    if (isNearTopEdge()) {
       lastScrollDirection = J2clViewportGrowthDirection.BACKWARD;
       if (requestEdgeIfPlaceholder(J2clViewportGrowthDirection.BACKWARD)) {
         return;
       }
     }
-    double distanceFromBottom = activeScrollHeight() - activeClientHeight() - activeScrollTop();
-    if (distanceFromBottom <= EDGE_SCROLL_THRESHOLD_PX) {
+    if (isNearBottomEdge()) {
       lastScrollDirection = J2clViewportGrowthDirection.FORWARD;
       if (requestEdgeIfPlaceholder(J2clViewportGrowthDirection.FORWARD)) {
         return;
@@ -2516,11 +2515,22 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   private boolean isNearEdge(String direction) {
-    if (J2clViewportGrowthDirection.isBackward(direction)) {
-      return activeScrollTop() <= EDGE_SCROLL_THRESHOLD_PX;
+    return J2clViewportGrowthDirection.isBackward(direction) ? isNearTopEdge() : isNearBottomEdge();
+  }
+
+  private boolean isNearTopEdge() {
+    if (hostOwnsVerticalScroll()) {
+      return host.scrollTop <= EDGE_SCROLL_THRESHOLD_PX;
     }
-    double distanceFromBottom = activeScrollHeight() - activeClientHeight() - activeScrollTop();
-    return distanceFromBottom <= EDGE_SCROLL_THRESHOLD_PX;
+    return host.getBoundingClientRect().top >= -EDGE_SCROLL_THRESHOLD_PX;
+  }
+
+  private boolean isNearBottomEdge() {
+    if (hostOwnsVerticalScroll()) {
+      return host.scrollHeight - host.clientHeight - host.scrollTop <= EDGE_SCROLL_THRESHOLD_PX;
+    }
+    return host.getBoundingClientRect().bottom - DomGlobal.window.innerHeight
+        <= EDGE_SCROLL_THRESHOLD_PX;
   }
 
   private double activeScrollTop() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -2070,7 +2070,13 @@ public final class J2clReadSurfaceDomRenderer {
     button.setAttribute("aria-expanded", "true");
     button.setAttribute("aria-label", "Collapse " + label);
     button.textContent = "\u2212";
-    button.addEventListener("click", event -> toggleThread(thread, button));
+    button.addEventListener(
+        "click",
+        event -> {
+          event.preventDefault();
+          event.stopPropagation();
+          toggleThread(thread, button);
+        });
     thread.insertBefore(button, thread.firstChild);
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -238,6 +238,7 @@ public final class J2clReadSurfaceDomRenderer {
     }
     if (!scrollListenerBound) {
       host.addEventListener("scroll", this::onHostScroll);
+      DomGlobal.window.addEventListener("scroll", this::onHostScroll);
       scrollListenerBound = true;
     }
   }
@@ -290,6 +291,7 @@ public final class J2clReadSurfaceDomRenderer {
     }
     if (!scrollListenerBound) {
       host.addEventListener("scroll", this::onHostScroll);
+      DomGlobal.window.addEventListener("scroll", this::onHostScroll);
       scrollListenerBound = true;
     }
   }
@@ -316,9 +318,12 @@ public final class J2clReadSurfaceDomRenderer {
       cancelAllDwellTimers();
       return;
     }
-    DOMRect hostRect = host.getBoundingClientRect();
-    double viewportHeight = hostRect.height;
-    if (viewportHeight <= 0) {
+    DOMRect rawHostRect = host.getBoundingClientRect();
+    // If the host is not a scroll container (the page scrolls instead), clip to
+    // the visual viewport so we don't treat the full content height as visible.
+    double[] effectiveHostBounds = clipRectToViewport(rawHostRect);
+    double effectiveHostHeight = effectiveHostBounds[3] - effectiveHostBounds[1];
+    if (effectiveHostHeight <= 0) {
       // Off-screen / detached host — no point scheduling.
       cancelAllDwellTimers();
       return;
@@ -341,7 +346,7 @@ public final class J2clReadSurfaceDomRenderer {
       if (markBlipReadInFlight.contains(blipId)) {
         continue;
       }
-      if (!isBlipInViewport(blip, hostRect)) {
+      if (!isBlipInViewport(blip, effectiveHostBounds)) {
         continue;
       }
       visibleUnreadIds.add(blipId);
@@ -388,7 +393,7 @@ public final class J2clReadSurfaceDomRenderer {
     if (blipEl == null
         || !blipEl.hasAttribute("unread")
         || isHiddenByCollapsedThread(blipEl)
-        || !isBlipInViewport(blipEl, host.getBoundingClientRect())) {
+        || !isBlipInViewport(blipEl, clipRectToViewport(host.getBoundingClientRect()))) {
       releaseGate.run();
       return;
     }
@@ -442,6 +447,82 @@ public final class J2clReadSurfaceDomRenderer {
     if (elementHeight > hostHeight
         && hostHeight > 0
         && intersectHeight / hostHeight >= VIEWPORT_INTERSECTION_THRESHOLD) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Clips a host DOMRect to the visual viewport (window bounds) and returns the
+   * effective bounds as a {@code double[4]} in {@code [left, top, right, bottom]}
+   * order. When the host is a page-level non-scrolling container, its raw
+   * {@code getBoundingClientRect()} may span the full document height; clamping
+   * it to {@code window.innerHeight} / {@code window.innerWidth} ensures only
+   * the currently-visible slice is treated as the effective viewport.
+   */
+  private static double[] clipRectToViewport(DOMRect hostRect) {
+    double vpLeft = 0;
+    double vpTop = 0;
+    double vpRight = DomGlobal.window.innerWidth;
+    double vpBottom = DomGlobal.window.innerHeight;
+    double left = Math.max(hostRect.left, vpLeft);
+    double top = Math.max(hostRect.top, vpTop);
+    double right = Math.min(hostRect.right, vpRight);
+    double bottom = Math.min(hostRect.bottom, vpBottom);
+    return new double[] {left, top, right, bottom};
+  }
+
+  /**
+   * Overload of {@link #isBlipInViewport(HTMLElement, DOMRect)} that accepts an
+   * effective host bounds array ({@code [left, top, right, bottom]}) produced by
+   * {@link #clipRectToViewport}. Used when the host element is not a scroll
+   * container and the raw DOMRect must be clipped to the visual viewport first.
+   */
+  private static boolean isBlipInViewport(HTMLElement blip, double[] effectiveBounds) {
+    return isElementInViewport(blip, effectiveBounds);
+  }
+
+  /**
+   * Overload of {@link #isElementInViewport(HTMLElement, DOMRect)} that accepts
+   * an effective host bounds array ({@code [left, top, right, bottom]}) as
+   * produced by {@link #clipRectToViewport}.
+   */
+  private static boolean isElementInViewport(HTMLElement element, double[] hostBounds) {
+    DOMRect elementRect = element.getBoundingClientRect();
+    double elementHeight = elementRect.height;
+    double elementWidth = elementRect.width;
+    if (elementHeight <= 0 || elementWidth <= 0) {
+      return false;
+    }
+    double hLeft = hostBounds[0];
+    double hTop = hostBounds[1];
+    double hRight = hostBounds[2];
+    double hBottom = hostBounds[3];
+    double hHeight = Math.max(0, hBottom - hTop);
+    double intersectTop = Math.max(elementRect.top, hTop);
+    double intersectBottom = Math.min(elementRect.bottom, hBottom);
+    double intersectHeight = intersectBottom - intersectTop;
+    if (intersectHeight <= 0) {
+      return false;
+    }
+    double intersectLeft = Math.max(elementRect.left, hLeft);
+    double intersectRight = Math.min(elementRect.right, hRight);
+    double intersectWidth = intersectRight - intersectLeft;
+    if (intersectWidth <= 0) {
+      return false;
+    }
+    double intersectArea = intersectHeight * intersectWidth;
+    double elementArea = elementHeight * elementWidth;
+    if (intersectArea / elementArea >= VIEWPORT_INTERSECTION_THRESHOLD) {
+      return true;
+    }
+    // Tall-blip exception: a blip taller than the viewport can never reach
+    // the area-ratio threshold. Use vertical coverage so narrow blips (e.g.
+    // deeply indented threads) can still qualify when the visible slice fills
+    // ≥ 50% of the viewport height.
+    if (elementHeight > hHeight
+        && hHeight > 0
+        && intersectHeight / hHeight >= VIEWPORT_INTERSECTION_THRESHOLD) {
       return true;
     }
     return false;
@@ -2470,15 +2551,18 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   private J2clReadWindowEntry visiblePlaceholder() {
-    DOMRect hostRect = host.getBoundingClientRect();
-    if (hostRect.height <= 0 || hostRect.width <= 0) {
+    DOMRect rawHostRect = host.getBoundingClientRect();
+    double[] effectiveHostBounds = clipRectToViewport(rawHostRect);
+    double effectiveHeight = effectiveHostBounds[3] - effectiveHostBounds[1];
+    double effectiveWidth = effectiveHostBounds[2] - effectiveHostBounds[0];
+    if (effectiveHeight <= 0 || effectiveWidth <= 0) {
       return null;
     }
     NodeList<Element> placeholders =
         host.querySelectorAll("[data-j2cl-viewport-placeholder='true']");
     for (int i = 0; i < placeholders.length; i++) {
       HTMLElement placeholderEl = (HTMLElement) placeholders.item(i);
-      if (placeholderEl == null || !isElementInViewport(placeholderEl, hostRect)) {
+      if (placeholderEl == null || !isElementInViewport(placeholderEl, effectiveHostBounds)) {
         continue;
       }
       String blipId = placeholderEl.getAttribute("data-placeholder-blip-id");

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -2523,8 +2523,9 @@ public final class J2clReadSurfaceDomRenderer {
     if (hostOwnsVerticalScroll()) {
       return hostIntersectsViewport() && host.scrollTop <= EDGE_SCROLL_THRESHOLD_PX;
     }
-    return host.getBoundingClientRect().top >= -EDGE_SCROLL_THRESHOLD_PX
-        && host.getBoundingClientRect().top <= EDGE_SCROLL_THRESHOLD_PX;
+    double distanceFromViewportTop = host.getBoundingClientRect().top;
+    return distanceFromViewportTop >= -EDGE_SCROLL_THRESHOLD_PX
+        && distanceFromViewportTop <= EDGE_SCROLL_THRESHOLD_PX;
   }
 
   private boolean isNearBottomEdge() {
@@ -2532,8 +2533,10 @@ public final class J2clReadSurfaceDomRenderer {
       return hostIntersectsViewport()
           && host.scrollHeight - host.clientHeight - host.scrollTop <= EDGE_SCROLL_THRESHOLD_PX;
     }
-    return host.getBoundingClientRect().bottom - DomGlobal.window.innerHeight
-        <= EDGE_SCROLL_THRESHOLD_PX;
+    double distanceFromViewportBottom =
+        host.getBoundingClientRect().bottom - DomGlobal.window.innerHeight;
+    return distanceFromViewportBottom >= -EDGE_SCROLL_THRESHOLD_PX
+        && distanceFromViewportBottom <= EDGE_SCROLL_THRESHOLD_PX;
   }
 
   private double activeScrollTop() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -527,12 +527,13 @@ public final class J2clReadSurfaceDomRenderer {
       return true;
     }
     // Tall-blip exception: a blip taller than the viewport can never reach
-    // the area-ratio threshold. Use vertical coverage so narrow blips (e.g.
-    // deeply indented threads) can still qualify when the visible slice fills
-    // ≥ 50% of the viewport height.
-    if (elementHeight > hHeight
-        && hHeight > 0
-        && intersectHeight / hHeight >= VIEWPORT_INTERSECTION_THRESHOLD) {
+    // the area-ratio threshold. Use vertical coverage against the actual
+    // viewport height (not the clipped host slice) so a partially-visible host
+    // doesn't prematurely mark blips read on a tiny intersection.
+    double viewportHeight = DomGlobal.window.innerHeight;
+    if (elementHeight > viewportHeight
+        && viewportHeight > 0
+        && intersectHeight / viewportHeight >= VIEWPORT_INTERSECTION_THRESHOLD) {
       return true;
     }
     return false;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -318,10 +318,7 @@ public final class J2clReadSurfaceDomRenderer {
       cancelAllDwellTimers();
       return;
     }
-    DOMRect rawHostRect = host.getBoundingClientRect();
-    // If the host is not a scroll container (the page scrolls instead), clip to
-    // the visual viewport so we don't treat the full content height as visible.
-    double[] effectiveHostBounds = clipRectToViewport(rawHostRect);
+    double[] effectiveHostBounds = effectiveViewportBounds();
     double effectiveHostHeight = effectiveHostBounds[3] - effectiveHostBounds[1];
     if (effectiveHostHeight <= 0) {
       // Off-screen / detached host — no point scheduling.
@@ -393,7 +390,7 @@ public final class J2clReadSurfaceDomRenderer {
     if (blipEl == null
         || !blipEl.hasAttribute("unread")
         || isHiddenByCollapsedThread(blipEl)
-        || !isBlipInViewport(blipEl, clipRectToViewport(host.getBoundingClientRect()))) {
+        || !isBlipInViewport(blipEl, effectiveViewportBounds())) {
       releaseGate.run();
       return;
     }
@@ -470,6 +467,18 @@ public final class J2clReadSurfaceDomRenderer {
     double right = Math.min(hostRect.right, vpRight);
     double bottom = Math.min(hostRect.bottom, vpBottom);
     return new double[] {left, top, right, bottom};
+  }
+
+  private double[] effectiveViewportBounds() {
+    DOMRect rawHostRect = host.getBoundingClientRect();
+    if (hostOwnsVerticalScroll()) {
+      return new double[] {rawHostRect.left, rawHostRect.top, rawHostRect.right, rawHostRect.bottom};
+    }
+    return clipRectToViewport(rawHostRect);
+  }
+
+  private boolean hostOwnsVerticalScroll() {
+    return host.scrollHeight > host.clientHeight + 1;
   }
 
   /**
@@ -2489,13 +2498,13 @@ public final class J2clReadSurfaceDomRenderer {
     if (viewportEdgeListener == null || renderedWindowEntries.isEmpty()) {
       return;
     }
-    if (host.scrollTop <= EDGE_SCROLL_THRESHOLD_PX) {
+    if (activeScrollTop() <= EDGE_SCROLL_THRESHOLD_PX) {
       lastScrollDirection = J2clViewportGrowthDirection.BACKWARD;
       if (requestEdgeIfPlaceholder(J2clViewportGrowthDirection.BACKWARD)) {
         return;
       }
     }
-    double distanceFromBottom = host.scrollHeight - host.clientHeight - host.scrollTop;
+    double distanceFromBottom = activeScrollHeight() - activeClientHeight() - activeScrollTop();
     if (distanceFromBottom <= EDGE_SCROLL_THRESHOLD_PX) {
       lastScrollDirection = J2clViewportGrowthDirection.FORWARD;
       if (requestEdgeIfPlaceholder(J2clViewportGrowthDirection.FORWARD)) {
@@ -2508,10 +2517,29 @@ public final class J2clReadSurfaceDomRenderer {
 
   private boolean isNearEdge(String direction) {
     if (J2clViewportGrowthDirection.isBackward(direction)) {
-      return host.scrollTop <= EDGE_SCROLL_THRESHOLD_PX;
+      return activeScrollTop() <= EDGE_SCROLL_THRESHOLD_PX;
     }
-    double distanceFromBottom = host.scrollHeight - host.clientHeight - host.scrollTop;
+    double distanceFromBottom = activeScrollHeight() - activeClientHeight() - activeScrollTop();
     return distanceFromBottom <= EDGE_SCROLL_THRESHOLD_PX;
+  }
+
+  private double activeScrollTop() {
+    return hostOwnsVerticalScroll() ? host.scrollTop : DomGlobal.window.pageYOffset;
+  }
+
+  private double activeClientHeight() {
+    return hostOwnsVerticalScroll() ? host.clientHeight : DomGlobal.window.innerHeight;
+  }
+
+  private double activeScrollHeight() {
+    if (hostOwnsVerticalScroll()) {
+      return host.scrollHeight;
+    }
+    HTMLElement documentElement = (HTMLElement) DomGlobal.document.documentElement;
+    HTMLElement body = DomGlobal.document.body;
+    double documentHeight = documentElement == null ? 0 : documentElement.scrollHeight;
+    double bodyHeight = body == null ? 0 : body.scrollHeight;
+    return Math.max(documentHeight, bodyHeight);
   }
 
   private void requestReachablePlaceholderAfterRender() {
@@ -2551,8 +2579,7 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   private J2clReadWindowEntry visiblePlaceholder() {
-    DOMRect rawHostRect = host.getBoundingClientRect();
-    double[] effectiveHostBounds = clipRectToViewport(rawHostRect);
+    double[] effectiveHostBounds = effectiveViewportBounds();
     double effectiveHeight = effectiveHostBounds[3] - effectiveHostBounds[1];
     double effectiveWidth = effectiveHostBounds[2] - effectiveHostBounds[0];
     if (effectiveHeight <= 0 || effectiveWidth <= 0) {
@@ -2640,7 +2667,15 @@ public final class J2clReadSurfaceDomRenderer {
     // Apply the layout delta to the browser's current scrollTop. This stays
     // correct whether the browser preserved scrollTop through the rebuild or
     // reset it while the old surface was detached.
-    host.scrollTop = Math.max(0, host.scrollTop + delta);
+    setActiveScrollTop(Math.max(0, activeScrollTop() + delta));
+  }
+
+  private void setActiveScrollTop(double scrollTop) {
+    if (hostOwnsVerticalScroll()) {
+      host.scrollTop = scrollTop;
+      return;
+    }
+    DomGlobal.window.scrollTo(DomGlobal.window.pageXOffset, scrollTop);
   }
 
   private void focusByOffset(int offset, String key) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -470,15 +470,16 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   private double[] effectiveViewportBounds() {
-    DOMRect rawHostRect = host.getBoundingClientRect();
-    if (hostOwnsVerticalScroll()) {
-      return new double[] {rawHostRect.left, rawHostRect.top, rawHostRect.right, rawHostRect.bottom};
-    }
-    return clipRectToViewport(rawHostRect);
+    return clipRectToViewport(host.getBoundingClientRect());
   }
 
   private boolean hostOwnsVerticalScroll() {
     return host.scrollHeight > host.clientHeight + 1;
+  }
+
+  private boolean hostIntersectsViewport() {
+    double[] bounds = clipRectToViewport(host.getBoundingClientRect());
+    return bounds[2] > bounds[0] && bounds[3] > bounds[1];
   }
 
   /**
@@ -2520,14 +2521,16 @@ public final class J2clReadSurfaceDomRenderer {
 
   private boolean isNearTopEdge() {
     if (hostOwnsVerticalScroll()) {
-      return host.scrollTop <= EDGE_SCROLL_THRESHOLD_PX;
+      return hostIntersectsViewport() && host.scrollTop <= EDGE_SCROLL_THRESHOLD_PX;
     }
-    return host.getBoundingClientRect().top >= -EDGE_SCROLL_THRESHOLD_PX;
+    return host.getBoundingClientRect().top >= -EDGE_SCROLL_THRESHOLD_PX
+        && host.getBoundingClientRect().top <= EDGE_SCROLL_THRESHOLD_PX;
   }
 
   private boolean isNearBottomEdge() {
     if (hostOwnsVerticalScroll()) {
-      return host.scrollHeight - host.clientHeight - host.scrollTop <= EDGE_SCROLL_THRESHOLD_PX;
+      return hostIntersectsViewport()
+          && host.scrollHeight - host.clientHeight - host.scrollTop <= EDGE_SCROLL_THRESHOLD_PX;
     }
     return host.getBoundingClientRect().bottom - DomGlobal.window.innerHeight
         <= EDGE_SCROLL_THRESHOLD_PX;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -1413,36 +1413,22 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     }
   }
 
-  // V-2 (#1100): the "Read." / "Selected digest is read." status words
-  // are dev-only; suppress them from the wave header unless the
-  // j2cl-debug-overlay flag is on (HtmlRenderer adds .j2cl-debug-overlay-on
-  // to <body> in that case, page-load-stable). Visible product text
-  // ("X unread.", "X unread in the selected digest.") flows through
-  // unchanged. The model's getUnreadText() is itself unchanged so
-  // existing tests and controllers still see the full string. The
-  // sentinel strings live in J2clSelectedWaveModel.formatUnreadText and
-  // resolveUnreadText — keep this list in lockstep.
+  // The "Read." / "Selected digest is read." words are model diagnostics,
+  // not wave chrome. GWT represents read state with blip/search highlighting,
+  // so suppress these strings even when the debug overlay flag is enabled.
+  // Visible product text ("X unread.", "X unread in the selected digest.")
+  // flows through unchanged. The model's getUnreadText() is itself unchanged
+  // so existing controllers still see the full string. The sentinel strings
+  // live in J2clSelectedWaveModel.formatUnreadText and resolveUnreadText.
   private static String effectiveUnreadText(J2clSelectedWaveModel model) {
     String text = model.getUnreadText();
     if (text == null || text.isEmpty()) {
       return "";
     }
-    if (isDebugOverlayOn()) {
-      return text;
-    }
     if ("Read.".equals(text) || "Selected digest is read.".equals(text)) {
       return "";
     }
     return text;
-  }
-
-  // V-2 (#1100): true iff <body> carries `j2cl-debug-overlay-on`. Read
-  // afresh per render rather than cached so the helper stays trivial
-  // and the value still reflects the body class. Body is null in
-  // headless GwtTest environments.
-  private static boolean isDebugOverlayOn() {
-    HTMLElement body = (HTMLElement) DomGlobal.document.body;
-    return body != null && body.classList.contains("j2cl-debug-overlay-on");
   }
 
   @SuppressWarnings("unchecked")

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -1,6 +1,7 @@
 html,
 body {
   margin: 0;
+  height: 100%;
   min-height: 100%;
   font-family: Arial, Helvetica, sans-serif;
   background: #ffffff;
@@ -281,9 +282,6 @@ shell-root[data-wave-controls-compact="true"] wavy-wave-nav-row {
   display: grid;
   gap: 0;
   margin-top: 0;
-  max-height: calc(100vh - 110px);
-  overflow-y: auto;
-  overscroll-behavior: contain;
   padding-right: 0;
 }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -91,6 +91,33 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void threadToggleClickDoesNotBubbleIntoBlipNavigation() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    host.innerHTML =
+        "<div class=\"wave-content\" data-wave-id=\"example.com/w+1\">"
+            + "<div class=\"conversation\" data-conv-id=\"c+root\">"
+            + "<div class=\"thread\" data-thread-id=\"t+root\">"
+            + "<div class=\"blip\" data-blip-id=\"b+root\">Root</div>"
+            + "<div class=\"inline-thread\" data-thread-id=\"t+inline\">"
+            + "<div class=\"blip\" data-blip-id=\"b+reply\">Reply</div>"
+            + "</div></div></div></div>";
+    final int[] bubbledClicks = {0};
+    host.addEventListener("click", evt -> bubbledClicks[0]++);
+
+    Assert.assertTrue(new J2clReadSurfaceDomRenderer(host).enhanceExistingSurface());
+    HTMLButtonElement toggle =
+        (HTMLButtonElement) host.querySelector(".j2cl-read-thread-toggle");
+
+    toggle.click();
+
+    Assert.assertEquals(
+        "Inline-thread toggle clicks must not bubble into blip focus/navigation handlers.",
+        0,
+        bubbledClicks[0]);
+  }
+
+  @Test
   public void enhanceExistingSurfaceIsIdempotentForThreadToggles() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();

--- a/wave/config/changelog.d/2026-05-04-j2cl-wave-thread-scroll-parity.json
+++ b/wave/config/changelog.d/2026-05-04-j2cl-wave-thread-scroll-parity.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-05-04-j2cl-wave-thread-scroll-parity",
+  "version": "J2CL parity",
+  "date": "2026-05-04",
+  "title": "J2CL wave thread and chrome parity",
+  "summary": "Tightens the J2CL wave panel so read-mode scrolling, inline-thread toggles, and blip chrome behave closer to the GWT wave view.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Removes the nested selected-wave scrollbar so the wave panel has a single vertical scroll path.",
+        "Keeps inline-thread expand and collapse clicks from bubbling into blip focus/navigation handlers.",
+        "Hides inert blip overflow chrome, adds hover tooltips to wired blip actions, and removes read/root debug text from normal wave chrome."
+      ]
+    }
+  ]
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -783,9 +783,15 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         "Both live and preserved render paths must gate detail visibility on errors",
         2,
         countOccurrences(source, "detail.hidden = !model.isError();"));
+    int unreadHelperStart = source.indexOf("private static String effectiveUnreadText");
+    assertTrue("J2clSelectedWaveView must define effectiveUnreadText", unreadHelperStart >= 0);
+    int unreadHelperEnd = source.indexOf("\n  @", unreadHelperStart);
+    String unreadHelper =
+        source.substring(
+            unreadHelperStart, unreadHelperEnd < 0 ? source.length() : unreadHelperEnd);
     assertFalse(
         "Selected-wave read-state text must not become visible through the debug overlay; GWT shows read state through highlighting.",
-        source.contains("if (isDebugOverlayOn())"));
+        unreadHelper.contains("isDebugOverlayOn()"));
   }
 
   public void testV2SidecarCssCarriesDebugOnlyHideRule() {

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -548,6 +548,11 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
     assertTrue(
         "Viewport dwell/placeholder math must clip page-level hosts to the visual viewport.",
         source.contains("effectiveViewportBounds()"));
+    assertTrue(
+        "Tall-blip visibility must compare against actual viewport height, not the clipped host slice.",
+        source.contains("DomGlobal.window.innerHeight")
+            && source.contains("elementHeight > viewportHeight")
+            && source.contains("intersectHeight / viewportHeight >= VIEWPORT_INTERSECTION_THRESHOLD"));
   }
 
   public void testJ2clToolbarOnlyEmitsEditActionsWhileEditing() {

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -503,6 +503,21 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
             "element.setAttribute(\"posted-at\", blipLabel(blip.getBlipId()));"));
   }
 
+  public void testSelectedWaveContentDoesNotOwnNestedVerticalScrollbar() {
+    String css = readSourceFile("j2cl/src/main/webapp/assets/sidecar.css");
+    java.util.regex.Matcher matcher =
+        java.util.regex.Pattern.compile("\\.sidecar-selected-content\\s*\\{([^}]*)\\}")
+            .matcher(css);
+    assertTrue("sidecar.css must define .sidecar-selected-content", matcher.find());
+    String block = matcher.group(1);
+    assertFalse(
+        "Selected wave content must not own an inner vertical scrollbar; the root page scrolls once.",
+        block.contains("overflow-y"));
+    assertFalse(
+        "Selected wave content must not clamp to viewport height; that creates a second wave-panel scrollbar.",
+        block.contains("max-height"));
+  }
+
   public void testJ2clToolbarOnlyEmitsEditActionsWhileEditing() {
     // Gap 3: the toolbar controller used to call addEditActions on
     // every render, regardless of editState.editable. The view's
@@ -746,6 +761,9 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         "Both live and preserved render paths must gate detail visibility on errors",
         2,
         countOccurrences(source, "detail.hidden = !model.isError();"));
+    assertFalse(
+        "Selected-wave read-state text must not become visible through the debug overlay; GWT shows read state through highlighting.",
+        source.contains("if (isDebugOverlayOn())"));
   }
 
   public void testV2SidecarCssCarriesDebugOnlyHideRule() {

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -533,8 +533,12 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         "Renderer must listen to page scroll events when selected wave content no longer owns a nested scrollbar.",
         source.contains("DomGlobal.window.addEventListener(\"scroll\", this::onHostScroll);"));
     assertTrue(
-        "Viewport edge loading must use the active scroll container, not hard-coded host.scrollTop.",
-        source.contains("activeScrollTop() <= EDGE_SCROLL_THRESHOLD_PX"));
+        "Viewport edge loading must use host-relative edge helpers, not hard-coded host.scrollTop in onHostScroll.",
+        source.contains("if (isNearTopEdge())")
+            && source.contains("if (isNearBottomEdge())")
+            && source.contains("host.getBoundingClientRect().top >= -EDGE_SCROLL_THRESHOLD_PX")
+            && source.contains(
+                "host.getBoundingClientRect().bottom - DomGlobal.window.innerHeight"));
     assertTrue(
         "Viewport dwell/placeholder math must clip page-level hosts to the visual viewport.",
         source.contains("effectiveViewportBounds()"));

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -505,17 +505,23 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
 
   public void testSelectedWaveContentDoesNotOwnNestedVerticalScrollbar() {
     String css = readSourceFile("j2cl/src/main/webapp/assets/sidecar.css");
-    java.util.regex.Matcher matcher =
-        java.util.regex.Pattern.compile("\\.sidecar-selected-content\\s*\\{([^}]*)\\}")
-            .matcher(css);
+    java.util.regex.Pattern rulePattern =
+        java.util.regex.Pattern.compile("[^{]*sidecar-selected-content[^{]*\\{([^}]*)\\}");
+    java.util.regex.Matcher matcher = rulePattern.matcher(css);
     assertTrue("sidecar.css must define .sidecar-selected-content", matcher.find());
-    String block = matcher.group(1);
+    boolean anyOverflowY = false;
+    boolean anyMaxHeight = false;
+    do {
+      String block = matcher.group(1);
+      if (block.contains("overflow-y")) anyOverflowY = true;
+      if (block.contains("max-height")) anyMaxHeight = true;
+    } while (matcher.find());
     assertFalse(
         "Selected wave content must not own an inner vertical scrollbar; the root page scrolls once.",
-        block.contains("overflow-y"));
+        anyOverflowY);
     assertFalse(
         "Selected wave content must not clamp to viewport height; that creates a second wave-panel scrollbar.",
-        block.contains("max-height"));
+        anyMaxHeight);
   }
 
   public void testJ2clToolbarOnlyEmitsEditActionsWhileEditing() {

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -537,8 +537,12 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         source.contains("if (isNearTopEdge())")
             && source.contains("if (isNearBottomEdge())")
             && source.contains("host.getBoundingClientRect().top >= -EDGE_SCROLL_THRESHOLD_PX")
+            && source.contains("host.getBoundingClientRect().top <= EDGE_SCROLL_THRESHOLD_PX")
             && source.contains(
                 "host.getBoundingClientRect().bottom - DomGlobal.window.innerHeight"));
+    assertTrue(
+        "Host-owned scroll path must be guarded by viewport intersection before arming edge/dwell logic.",
+        source.contains("hostIntersectsViewport()"));
     assertTrue(
         "Viewport dwell/placeholder math must clip page-level hosts to the visual viewport.",
         source.contains("effectiveViewportBounds()"));

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -524,6 +524,22 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         anyMaxHeight);
   }
 
+  public void testReadSurfaceRendererUsesActiveScrollContainerForViewportLoading() {
+    String source =
+        readSourceFile(
+            "j2cl/src/main/java/org/waveprotocol/box/j2cl/read/"
+                + "J2clReadSurfaceDomRenderer.java");
+    assertTrue(
+        "Renderer must listen to page scroll events when selected wave content no longer owns a nested scrollbar.",
+        source.contains("DomGlobal.window.addEventListener(\"scroll\", this::onHostScroll);"));
+    assertTrue(
+        "Viewport edge loading must use the active scroll container, not hard-coded host.scrollTop.",
+        source.contains("activeScrollTop() <= EDGE_SCROLL_THRESHOLD_PX"));
+    assertTrue(
+        "Viewport dwell/placeholder math must clip page-level hosts to the visual viewport.",
+        source.contains("effectiveViewportBounds()"));
+  }
+
   public void testJ2clToolbarOnlyEmitsEditActionsWhileEditing() {
     // Gap 3: the toolbar controller used to call addEditActions on
     // every render, regardless of editState.editable. The view's

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -536,10 +536,12 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         "Viewport edge loading must use host-relative edge helpers, not hard-coded host.scrollTop in onHostScroll.",
         source.contains("if (isNearTopEdge())")
             && source.contains("if (isNearBottomEdge())")
-            && source.contains("host.getBoundingClientRect().top >= -EDGE_SCROLL_THRESHOLD_PX")
-            && source.contains("host.getBoundingClientRect().top <= EDGE_SCROLL_THRESHOLD_PX")
+            && source.contains("distanceFromViewportTop >= -EDGE_SCROLL_THRESHOLD_PX")
+            && source.contains("distanceFromViewportTop <= EDGE_SCROLL_THRESHOLD_PX")
             && source.contains(
-                "host.getBoundingClientRect().bottom - DomGlobal.window.innerHeight"));
+                "host.getBoundingClientRect().bottom - DomGlobal.window.innerHeight")
+            && source.contains("distanceFromViewportBottom >= -EDGE_SCROLL_THRESHOLD_PX")
+            && source.contains("distanceFromViewportBottom <= EDGE_SCROLL_THRESHOLD_PX"));
     assertTrue(
         "Host-owned scroll path must be guarded by viewport intersection before arming edge/dwell logic.",
         source.contains("hostIntersectsViewport()"));


### PR DESCRIPTION
## Summary

Fixes a focused set of J2CL/GWT parity regressions from #1161 around the selected wave scroll surface, inline-thread controls, and blip chrome.

- Removes the nested selected-wave vertical scrollbar so the wave panel uses one page-level scroll path.
- Stops inline-thread expand/collapse toggle clicks from bubbling into blip focus/navigation handlers.
- Removes user-visible `root` timestamp suffixes and suppresses `Read.` selected-wave chrome even when debug overlay is enabled.
- Removes the inert per-blip overflow button and adds hover titles/tooltips to the wired blip action icons.

## Verification

- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py && git diff --check`
- `cd j2cl/lit && npm test -- --run` passed: 64 files, 820 tests.
- `sbt --batch "Test/testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellIntegrationTest" "Test/compile"` passed: 41 focused tests plus compile.

Note: `Test/testOnly org.waveprotocol.box.j2cl.read.J2clReadSurfaceDomRendererTest` is a J2CL browser-input test and the SBT JVM runner reports no runnable JVM tests for it; `Test/compile` compiled it.

Fixes part of #1161. Tracks #904.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tooltip titles to toolbar action buttons for improved discoverability.

* **Bug Fixes**
  * Removed the overflow ("More blip actions") button; toolbar shows Reply, Edit, Delete, Link only.
  * Root blip timestamps no longer show a "root" suffix.
  * Thread-toggle clicks no longer bubble into blip navigation.
  * Selected-wave content no longer creates a nested vertical scrollbar; shell/body height behavior improved.
  * Debug/read-state text suppressed from normal UI.

* **Tests**
  * Updated tests to reflect toolbar, timestamp, thread-toggle, and scroll behavior changes.

* **Chores**
  * Added changelog entry for this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->