### PR TITLE
Fix J2CL inline thread placeholder growth after layout

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -48,6 +48,12 @@ public final class J2clComposeSurfaceController {
     void focusReplyComposer();
 
     /**
+     * Close the active inline reply composer after the controller has confirmed
+     * the submit succeeded. Default no-op preserves legacy view doubles.
+     */
+    default void closeActiveReplyComposer() {}
+
+    /**
      * J-UI-3 (#1081, R-5.1): focus the title input on the create form so
      * the rail's New Wave button gives the user an immediate place to type.
      * Default no-op so existing test doubles compile unchanged.
@@ -2208,6 +2214,7 @@ public final class J2clComposeSurfaceController {
     replyErrorText = "";
     replyStaleBasis = false;
     replyStaleWaveId = null;
+    view.closeActiveReplyComposer();
     render();
     if (replySuccessHandler != null
         && submitSession != null

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -226,6 +226,9 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
       DomGlobal.document.body.addEventListener(
           "wavy-composer-cancelled",
           event -> closeInlineComposer(eventDetailString(event, "replyTargetBlipId")));
+      DomGlobal.document.body.addEventListener(
+          "wavy-read-surface-rendered",
+          event -> ensureActiveInlineComposerMounted(activeInlineComposer()));
     }
 
     // F-3.S2 (#1038): mention popover + per-blip task affordance events.
@@ -413,6 +416,7 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     // composers display and submit against the wrong target.
     HTMLElement composer = activeInlineComposer();
     if (composer != null) {
+      ensureActiveInlineComposerMounted(composer);
       mirrorComposerState(composer, model);
     }
   }
@@ -569,6 +573,31 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
 
   private HTMLElement activeInlineComposer() {
     return inlineComposers.get(activeInlineComposerKey);
+  }
+
+  @Override
+  public void closeActiveReplyComposer() {
+    closeInlineComposer(activeInlineComposerKey);
+  }
+
+  private void ensureActiveInlineComposerMounted(HTMLElement composer) {
+    if (composer == null || composer.isConnected) {
+      return;
+    }
+    HTMLElement mountPoint = locateInlineMountPoint(activeInlineComposerKey);
+    if (mountPoint != null) {
+      mountPoint.appendChild(composer);
+      composer.dispatchEvent(new Event("composer-focus-request"));
+      return;
+    }
+    if (activeInlineComposerKey != null && !activeInlineComposerKey.isEmpty()) {
+      closeInlineComposer(activeInlineComposerKey);
+      return;
+    }
+    if (replyElement.parentNode != null) {
+      replyElement.parentNode.appendChild(composer);
+      composer.dispatchEvent(new Event("composer-focus-request"));
+    }
   }
 
   private HTMLElement locateInlineMountPoint(String blipId) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -2609,10 +2609,14 @@ public final class J2clReadSurfaceDomRenderer {
       return;
     }
     postLayoutPlaceholderCheckPending = true;
+    final HTMLElement scheduledSurface = renderedSurface;
     dwellTimerScheduler.schedule(
         0,
         () -> {
           postLayoutPlaceholderCheckPending = false;
+          if (renderedSurface != scheduledSurface) {
+            return;
+          }
           requestVisiblePlaceholderIfAny();
         });
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -154,6 +154,7 @@ public final class J2clReadSurfaceDomRenderer {
   private DwellTimerScheduler dwellTimerScheduler = defaultDwellTimerScheduler();
   private final Map<String, Object> dwellTimers = new HashMap<String, Object>();
   private final Set<String> markBlipReadInFlight = new HashSet<String>();
+  private boolean postLayoutPlaceholderCheckPending;
   // F-3.S3 (#1038, R-5.5): per-blip reaction summaries injected by the
   // view layer (J2clSelectedWaveView). Null binder means "no reactions
   // wiring yet" — the row is still mounted as an empty add-only state.
@@ -649,6 +650,7 @@ public final class J2clReadSurfaceDomRenderer {
     enhanceSurface(surface);
     restoreCollapsedThreads(previouslyCollapsedThreadIds);
     restoreFocusedBlipById(focusedBlipId);
+    notifyReadSurfaceRendered();
     pruneStaleInFlightOnRebuild();
     evaluateDwellTimers();
     return true;
@@ -865,7 +867,10 @@ public final class J2clReadSurfaceDomRenderer {
     restoreCollapsedThreads(previouslyCollapsedThreadIds);
     restoreFocusedBlipById(focusedBlipId);
     restoreScrollAnchor(scrollAnchorBlipId, scrollAnchorTop);
-    requestReachablePlaceholderAfterRender();
+    notifyReadSurfaceRendered();
+    if (!requestReachablePlaceholderAfterRender()) {
+      schedulePostLayoutPlaceholderCheckIfNeeded();
+    }
     pruneStaleInFlightOnRebuild();
     evaluateDwellTimers();
     return true;
@@ -2559,40 +2564,66 @@ public final class J2clReadSurfaceDomRenderer {
     return Math.max(documentHeight, bodyHeight);
   }
 
-  private void requestReachablePlaceholderAfterRender() {
+  private boolean requestReachablePlaceholderAfterRender() {
     if (viewportEdgeListener == null || renderedWindowEntries.isEmpty()) {
-      return;
+      return false;
     }
     if (lastScrollDirection != null && isNearEdge(lastScrollDirection)) {
       String pendingDirection = lastScrollDirection;
       lastScrollDirection = null;
       if (requestEdgeIfPlaceholder(pendingDirection)) {
-        return;
+        return true;
       }
     }
     if (edgePlaceholder(J2clViewportGrowthDirection.FORWARD) != null
         && isNearEdge(J2clViewportGrowthDirection.FORWARD)) {
       if (requestEdgeIfPlaceholder(J2clViewportGrowthDirection.FORWARD)) {
-        return;
+        return true;
       }
     }
     if (edgePlaceholder(J2clViewportGrowthDirection.BACKWARD) != null
         && isNearEdge(J2clViewportGrowthDirection.BACKWARD)
         && requestEdgeIfPlaceholder(J2clViewportGrowthDirection.BACKWARD)) {
-      return;
+      return true;
     }
-    requestVisiblePlaceholderIfAny();
+    return requestVisiblePlaceholderIfAny();
   }
 
-  private void requestVisiblePlaceholderIfAny() {
+  private boolean requestVisiblePlaceholderIfAny() {
     if (viewportEdgeListener == null) {
-      return;
+      return false;
     }
     J2clReadWindowEntry placeholder = visiblePlaceholder();
     if (placeholder != null) {
       viewportEdgeListener.onViewportEdge(
           placeholder.getBlipId(), visiblePlaceholderDirection(placeholder));
+      return true;
     }
+    return false;
+  }
+
+  private void schedulePostLayoutPlaceholderCheckIfNeeded() {
+    if (viewportEdgeListener == null
+        || postLayoutPlaceholderCheckPending
+        || host.querySelector("[data-j2cl-viewport-placeholder='true']") == null) {
+      return;
+    }
+    postLayoutPlaceholderCheckPending = true;
+    dwellTimerScheduler.schedule(
+        0,
+        () -> {
+          postLayoutPlaceholderCheckPending = false;
+          requestVisiblePlaceholderIfAny();
+        });
+  }
+
+  private void notifyReadSurfaceRendered() {
+    if (renderedSurface == null) {
+      return;
+    }
+    CustomEventInit<Object> init = CustomEventInit.create();
+    init.setBubbles(true);
+    renderedSurface.dispatchEvent(new CustomEvent<Object>("wavy-read-surface-rendered", init));
   }
 
   private J2clReadWindowEntry visiblePlaceholder() {
@@ -2606,7 +2637,7 @@ public final class J2clReadSurfaceDomRenderer {
         host.querySelectorAll("[data-j2cl-viewport-placeholder='true']");
     for (int i = 0; i < placeholders.length; i++) {
       HTMLElement placeholderEl = (HTMLElement) placeholders.item(i);
-      if (placeholderEl == null || !isElementInViewport(placeholderEl, effectiveHostBounds)) {
+      if (placeholderEl == null || !isPlaceholderInViewport(placeholderEl, effectiveHostBounds)) {
         continue;
       }
       String blipId = placeholderEl.getAttribute("data-placeholder-blip-id");
@@ -2619,6 +2650,21 @@ public final class J2clReadSurfaceDomRenderer {
       }
     }
     return null;
+  }
+
+  private static boolean isPlaceholderInViewport(HTMLElement placeholder, double[] hostBounds) {
+    DOMRect rect = placeholder.getBoundingClientRect();
+    if (rect.height <= 0 || rect.width <= 0) {
+      return false;
+    }
+    double intersectTop = Math.max(rect.top, hostBounds[1]);
+    double intersectBottom = Math.min(rect.bottom, hostBounds[3]);
+    if (intersectBottom <= intersectTop) {
+      return false;
+    }
+    double intersectLeft = Math.max(rect.left, hostBounds[0]);
+    double intersectRight = Math.min(rect.right, hostBounds[2]);
+    return intersectRight > intersectLeft;
   }
 
   private String visiblePlaceholderDirection(J2clReadWindowEntry placeholder) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -59,7 +59,8 @@ public class J2clComposeSurfaceControllerTest {
     FakeGateway gateway = new FakeGateway();
     FakeView view = new FakeView();
     J2clComposeSurfaceController controller =
-        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+        newController(
+            gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
 
     controller.start();
     controller.onSelectedWaveComposeContextChanged(
@@ -2076,6 +2077,46 @@ public class J2clComposeSurfaceControllerTest {
     Assert.assertEquals(3, gateway.submitCalls);
     Assert.assertFalse(gateway.lastSubmitRequest.getDeltaJson().contains("fontWeight"));
     assertContains(gateway.lastSubmitRequest.getDeltaJson(), "\"2\":\"Plain after retry\"");
+  }
+
+  @Test
+  public void replySubmitClosesActiveComposerOnlyAfterSuccess() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+
+    controller.onReplySubmitted("Reply");
+
+    Assert.assertEquals(1, gateway.submitCalls);
+    Assert.assertEquals(1, view.closeActiveReplyComposerCalls);
+    Assert.assertEquals("", view.model.getReplyDraft());
+    Assert.assertEquals("", view.model.getReplyErrorText());
+  }
+
+  @Test
+  public void replySubmitFailureKeepsActiveComposerOpenForRetry() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.submitResponse = new SidecarSubmitResponse(0, "server rejected", 0L);
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(
+            gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+
+    controller.onReplySubmitted("Retry me");
+
+    Assert.assertEquals(1, gateway.submitCalls);
+    Assert.assertEquals(0, view.closeActiveReplyComposerCalls);
+    Assert.assertEquals("Retry me", view.model.getReplyDraft());
+    Assert.assertEquals("server rejected", view.model.getReplyErrorText());
   }
 
   @Test
@@ -4662,6 +4703,7 @@ public class J2clComposeSurfaceControllerTest {
     private int focusReplyComposerCalls;
     private int focusCreateSurfaceCalls;
     private int focusCreateComposerCalls;
+    private int closeActiveReplyComposerCalls;
 
     @Override
     public void bind(J2clComposeSurfaceController.Listener listener) {
@@ -4680,6 +4722,11 @@ public class J2clComposeSurfaceControllerTest {
     @Override
     public void focusReplyComposer() {
       focusReplyComposerCalls++;
+    }
+
+    @Override
+    public void closeActiveReplyComposer() {
+      closeActiveReplyComposerCalls++;
     }
 
     @Override

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -2717,6 +2717,76 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void renderWindowRequestsGrowthForPartiallyVisibleTrailingPlaceholder() {
+    assumeBrowserDom();
+    currentStyle = (HTMLElement) DomGlobal.document.createElement("style");
+    currentStyle.textContent =
+        ".j2cl-read-blip{display:block;height:90px;}"
+            + ".j2cl-read-viewport-placeholder{display:block;height:100px;}";
+    DomGlobal.document.head.appendChild(currentStyle);
+    HTMLDivElement host = createHost();
+    host.setAttribute("style", "height: 100px; overflow-y: auto;");
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    final String[] requested = new String[2];
+    renderer.setViewportEdgeListener(
+        (anchorBlipId, direction) -> {
+          requested[0] = anchorBlipId;
+          requested[1] = direction;
+        });
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded(
+                    "blip:b+root", 30L, 36L, "b+root", "Root text"),
+                J2clReadWindowEntry.placeholder(
+                    "blip:b+missing", 36L, 40L, "b+missing"))));
+
+    Assert.assertEquals("b+missing", requested[0]);
+    Assert.assertEquals(J2clViewportGrowthDirection.FORWARD, requested[1]);
+  }
+
+  @Test
+  public void renderWindowRechecksVisiblePlaceholdersAfterLayoutSettles() {
+    assumeBrowserDom();
+    currentStyle = (HTMLElement) DomGlobal.document.createElement("style");
+    currentStyle.textContent =
+        ".j2cl-read-blip{display:block;height:300px;}"
+            + ".j2cl-read-viewport-placeholder{display:block;height:0;}";
+    DomGlobal.document.head.appendChild(currentStyle);
+    HTMLDivElement host = createHost();
+    host.setAttribute("style", "height: 100px; overflow-y: auto;");
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    FakeScheduler scheduler = new FakeScheduler();
+    renderer.setDwellTimerSchedulerForTesting(scheduler);
+    final String[] requested = new String[2];
+    renderer.setViewportEdgeListener(
+        (anchorBlipId, direction) -> {
+          requested[0] = anchorBlipId;
+          requested[1] = direction;
+        });
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded(
+                    "blip:b+root", 30L, 36L, "b+root", "Root text"),
+                J2clReadWindowEntry.placeholder(
+                    "blip:b+missing", 36L, 40L, "b+missing"))));
+    Assert.assertNull(requested[0]);
+    Assert.assertEquals(1, scheduler.scheduled.size());
+
+    currentStyle.textContent =
+        ".j2cl-read-blip{display:block;height:300px;}"
+            + ".j2cl-read-viewport-placeholder{display:block;height:100px;}";
+    host.scrollTop = 250;
+    scheduler.fireNext();
+
+    Assert.assertEquals("b+missing", requested[0]);
+    Assert.assertEquals(J2clViewportGrowthDirection.FORWARD, requested[1]);
+  }
+
+  @Test
   public void renderWindowSkipsPendingGrowthReplayWhenListenerIsCleared() throws Exception {
     assumeBrowserDom();
     HTMLDivElement host = createHost();
@@ -3405,5 +3475,26 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertTrue(
         "expand should re-dispatch focus-changed when focus is visible",
         focusChangedCount[0] > afterCollapse);
+  }
+
+  private static final class FakeScheduler
+      implements J2clReadSurfaceDomRenderer.DwellTimerScheduler {
+    final List<Runnable> scheduled = new ArrayList<Runnable>();
+
+    @Override
+    public Object schedule(int delayMs, Runnable action) {
+      scheduled.add(action);
+      return action;
+    }
+
+    @Override
+    public void cancel(Object handle) {
+      scheduled.remove(handle);
+    }
+
+    void fireNext() {
+      Assert.assertFalse(scheduled.isEmpty());
+      scheduled.remove(0).run();
+    }
   }
 }

--- a/wave/config/changelog.d/2026-05-04-j2cl-partial-placeholder-growth.json
+++ b/wave/config/changelog.d/2026-05-04-j2cl-partial-placeholder-growth.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-04-j2cl-partial-placeholder-growth",
+  "version": "J2CL parity",
+  "date": "2026-05-04",
+  "title": "J2CL inline thread lazy-load parity",
+  "summary": "Fixes J2CL inline-thread lazy loading when the next loading sentinel is only partially visible, matching the GWT expectation that visible inline replies continue loading without manual page-bottom scrolling.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Triggers viewport fragment growth for any visibly intersecting loading placeholder while preserving the stricter visibility threshold used for marking real blips read.",
+        "Keeps the active inline composer mounted when viewport fragment growth rebuilds the target blip, so mention typing and reply drafting survive lazy-loaded inline thread updates."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Grow J2CL read windows when an inline-thread placeholder is even partially visible, matching the GWT-style inline thread reveal behavior instead of leaving placeholders stranded.
- Recheck visible placeholders after the read surface settles so post-render layout/custom-element sizing cannot hide a needed growth request.
- Keep an active inline reply composer mounted across read-surface fragment growth, then close it after successful submit so stale inline composers do not remain visible.

## Linked issues
- Closes #1161
- Part of #904

## Verification
- `sbt --batch Test/compile` ✅
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json` ✅
- `git diff --check` ✅
- `PORT=9941 bash scripts/wave-smoke.sh check` ✅
- `cd wave/src/e2e/j2cl-gwt-parity && WAVE_E2E_BASE_URL=http://127.0.0.1:9941 npx playwright test --workers=1 --retries=0` ✅ 21/21
- Focused precheck: `WAVE_E2E_BASE_URL=http://127.0.0.1:9941 npx playwright test tests/visual-parity.spec.ts:740 tests/wave-actions-parity.spec.ts:119 tests/wave-actions-parity.spec.ts:278 tests/wave-reading-parity.spec.ts:110 --workers=1 --retries=0` ✅ 4/4

## Notes
- The first root-level `npx playwright test` attempt was invalid for this repo because it mixed Node test files with browser Playwright specs; the parity harness was then run from `wave/src/e2e/j2cl-gwt-parity`, where 21/21 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trigger viewport-driven fragment growth when loading placeholders are partially visible.
  * Keep inline reply composer mounted across lazy-load rebuilds so draft/typing are preserved; ensure composers close only after a successful submit.
  * Improve placeholder visibility detection and schedule post-layout rechecks for reliable read-surface rendering.

* **Tests**
  * Added tests for partial-placeholder growth, post-layout rechecks, and reply-submit composer-close behavior.

* **Documentation**
  * Added changelog describing the inline-thread lazy-load parity fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->