### PR TITLE
Fix J2CL wave panel navigation parity

### DIFF
--- a/j2cl/lit/src/elements/shell-main-region.js
+++ b/j2cl/lit/src/elements/shell-main-region.js
@@ -6,6 +6,9 @@ export class ShellMainRegion extends LitElement {
       display: block;
       flex: 1;
       min-width: 0;
+      min-height: 0;
+      height: 100%;
+      overflow: hidden;
     }
 
     /* V-1 (#1099): wave panel sits flush against the rail / header
@@ -14,7 +17,9 @@ export class ShellMainRegion extends LitElement {
      * cards into a narrow centred column. */
     main {
       padding: 0;
-      min-height: 360px;
+      min-height: 0;
+      height: 100%;
+      overflow: hidden;
     }
   `;
 

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -89,9 +89,8 @@ export class WaveBlip extends LitElement {
     replyCount: { type: Number, attribute: "reply-count", reflect: true },
     livePulse: { type: Boolean, attribute: "live-pulse", reflect: true },
     // V-4 (#1102): blip depth distinguishes the root blip from reply
-    // blips so the avatar paints at the larger root size and the
-    // header timestamp picks up the ` · root` suffix that the mockup
-    // shows on the top-of-thread blip. Set by the Java renderer on
+    // blips so the avatar paints at the right size. It must not add
+    // visible "root" debug text to the header. Set by the Java renderer on
     // the host element directly — Lit reads it but does not reflect
     // back, otherwise the constructor's empty default would clobber
     // the renderer-set attribute on upgrade.
@@ -147,6 +146,8 @@ export class WaveBlip extends LitElement {
       line-height: 1.3;
     }
     .thread-chevron {
+      position: relative;
+      z-index: 2;
       flex: 0 0 auto;
       width: 16px;
       height: 20px;
@@ -179,6 +180,8 @@ export class WaveBlip extends LitElement {
       box-shadow: var(--wavy-focus-ring, 0 0 0 2px rgba(0, 119, 182, 0.16));
     }
     .avatar {
+      position: relative;
+      z-index: 1;
       flex: 0 0 auto;
       width: var(--wavy-avatar-size-reply, 28px);
       height: var(--wavy-avatar-size-reply, 28px);
@@ -546,11 +549,19 @@ export class WaveBlip extends LitElement {
 
   _onThreadChevronClick(event) {
     event.stopPropagation();
+    const detail = { blipId: this.blipId, waveId: this.waveId };
     this.dispatchEvent(
       new CustomEvent("wave-blip-drill-in-requested", {
         bubbles: true,
         composed: true,
-        detail: { blipId: this.blipId, waveId: this.waveId }
+        detail
+      })
+    );
+    this.dispatchEvent(
+      new CustomEvent("wavy-depth-drill-in", {
+        bubbles: true,
+        composed: true,
+        detail
       })
     );
   }
@@ -596,6 +607,7 @@ export class WaveBlip extends LitElement {
           class="thread-chevron"
           data-thread-chevron="true"
           aria-label=${`Drill into ${this.replyCount} ${replyNoun} under this blip`}
+          title=${`Drill into ${this.replyCount} ${replyNoun} under this blip`}
           @click=${this._onThreadChevronClick}
         >${this._chevronGlyph()}</button>`
       : html`<span class="thread-chevron" hidden></span>`;

--- a/j2cl/lit/src/elements/wavy-task-affordance.js
+++ b/j2cl/lit/src/elements/wavy-task-affordance.js
@@ -226,6 +226,7 @@ export class WavyTaskAffordance extends LitElement {
         role="checkbox"
         aria-checked=${this.completed ? "true" : "false"}
         aria-label=${this.completed ? this.labelAriaUncheck : this.labelAriaCheck}
+        title=${this.completed ? this.labelAriaUncheck : this.labelAriaCheck}
         @click=${this._toggle}
       >
         ${this.completed ? this.labelToggleDone : this.labelToggleOpen}
@@ -234,6 +235,7 @@ export class WavyTaskAffordance extends LitElement {
         type="button"
         data-task-details-trigger="true"
         aria-label=${this.labelDetails}
+        title=${this.labelDetails}
         aria-haspopup="dialog"
         aria-expanded=${this._popoverOpen ? "true" : "false"}
         @click=${this._openDetails}

--- a/j2cl/lit/src/shortcuts/blip-focus.js
+++ b/j2cl/lit/src/shortcuts/blip-focus.js
@@ -172,12 +172,13 @@ export function dispatchFocusedBlipDepth(direction, root = document) {
   if (!surface) return false;
   if (direction === "in") {
     const blipId = focused ? focused.getAttribute("data-blip-id") || "" : "";
+    const waveId = focused ? focused.getAttribute("data-wave-id") || "" : "";
     if (!blipId) return false;
     surface.dispatchEvent(
       new CustomEvent("wavy-depth-drill-in", {
         bubbles: true,
         composed: true,
-        detail: { blipId }
+        detail: { blipId, waveId }
       })
     );
     return true;

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -21,6 +21,7 @@ body.j2cl-root-shell-page {
   margin: 0;
   height: 100%;
   min-height: 100vh;
+  overflow: hidden;
   background: #ffffff;
   color: var(--shell-color-text-primary);
   font-family: var(--shell-font-ui);
@@ -38,7 +39,9 @@ shell-root,
 shell-root-signed-out {
   position: relative;
   display: grid;
+  height: 100vh;
   min-height: 100vh;
+  overflow: hidden;
   gap: 0;
   box-sizing: border-box;
   width: 100%;
@@ -91,6 +94,8 @@ shell-root-signed-out > [slot="header"] {
 
 shell-root > [slot="nav"] {
   grid-area: nav;
+  min-height: 0;
+  overflow: hidden;
 }
 
 shell-root > [slot="splitter"] {
@@ -100,6 +105,8 @@ shell-root > [slot="splitter"] {
 shell-root > [slot="main"],
 shell-root-signed-out > [slot="main"] {
   grid-area: main;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .j2cl-shell-splitter {
@@ -263,6 +270,8 @@ shell-nav-rail > a:focus-visible {
 shell-nav-rail {
   display: block;
   align-self: stretch;
+  min-height: 0;
+  overflow: hidden;
   padding: 0;
   border-radius: 0;
   background: #ffffff;
@@ -290,6 +299,9 @@ shell-nav-rail > a:first-child {
 shell-main-region {
   display: block;
   min-width: 0;
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
   padding: 0;
   border-radius: 0;
   background: #ffffff;
@@ -304,7 +316,9 @@ shell-root-signed-out > [slot="main"] {
 }
 
 #j2cl-root-shell-workflow {
-  min-height: 360px;
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
 }
 
 #j2cl-root-shell-workflow > [data-j2cl-fallback="true"] {

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -17,6 +17,13 @@
   --shell-font-ui: Arial, Helvetica, sans-serif;
 }
 
+html.j2cl-root-shell-page,
+html:has(body.j2cl-root-shell-page) {
+  height: 100%;
+  min-height: 100vh;
+  overflow: hidden;
+}
+
 body.j2cl-root-shell-page {
   margin: 0;
   height: 100%;

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -271,7 +271,7 @@ shell-nav-rail {
   display: block;
   align-self: stretch;
   min-height: 0;
-  overflow: hidden;
+  overflow-y: auto;
   padding: 0;
   border-radius: 0;
   background: #ffffff;

--- a/j2cl/lit/test/shortcuts/blip-focus.test.js
+++ b/j2cl/lit/test/shortcuts/blip-focus.test.js
@@ -220,7 +220,7 @@ describe("dispatchFocusedBlipDepth", () => {
   it("dispatches drill-in for the focused blip", async () => {
     const root = await fixture(html`
       <div data-j2cl-read-surface="true">
-        <wave-blip data-blip-id="b1"></wave-blip>
+        <wave-blip data-blip-id="b1" data-wave-id="w1"></wave-blip>
       </div>
     `);
     const blip = root.querySelector("wave-blip");
@@ -230,7 +230,7 @@ describe("dispatchFocusedBlipDepth", () => {
       detail = event.detail;
     });
     expect(dispatchFocusedBlipDepth("in", root)).to.equal(true);
-    expect(detail).to.deep.equal({ blipId: "b1" });
+    expect(detail).to.deep.equal({ blipId: "b1", waveId: "w1" });
   });
 
   it("dispatches depth-up with the parent depth id from the host", async () => {

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -182,6 +182,28 @@ describe("<wave-blip>", () => {
     expect(ev.detail.waveId).to.equal("w7");
   });
 
+  it("compact thread chevron also emits the shell depth-navigation event", async () => {
+    const el = await fixture(html`
+      <wave-blip
+        data-blip-id="b7nav"
+        data-wave-id="w7"
+        author-name="A"
+        reply-count="2"
+      >
+        body
+      </wave-blip>
+    `);
+    await el.updateComplete;
+    const chevron = el.renderRoot.querySelector("[data-thread-chevron='true']");
+    expect(chevron.getAttribute("title")).to.equal("Drill into 2 replies under this blip");
+    setTimeout(() => chevron.click(), 0);
+    const ev = await oneEvent(el, "wavy-depth-drill-in");
+    expect(ev.detail.blipId).to.equal("b7nav");
+    expect(ev.detail.waveId).to.equal("w7");
+    expect(ev.bubbles).to.be.true;
+    expect(ev.composed).to.be.true;
+  });
+
   it("uses singular grammar for a one-reply chevron aria-label", async () => {
     const el = await fixture(html`
       <wave-blip data-blip-id="b7a" data-wave-id="w7" author-name="A" reply-count="1">

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -405,6 +405,44 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   /**
+   * Credits a user-directed focus/navigation action as an explicit read.
+   *
+   * <p>The dwell timer remains the passive scroll-through guard. Toolbar
+   * navigation, keyboard focus, and direct blip clicks are stronger signals:
+   * they intentionally target one blip, matching GWT's focused-blip read
+   * semantics and keeping the search digest unread badge responsive.
+   */
+  public boolean markFocusedBlipReadNow(HTMLElement blip) {
+    if (markBlipReadListener == null || blip == null || !blip.hasAttribute("unread")) {
+      return false;
+    }
+    String blipId = blip.getAttribute("data-blip-id");
+    if (blipId == null || blipId.isEmpty() || !markBlipReadInFlight.add(blipId)) {
+      return false;
+    }
+    Object handle = dwellTimers.remove(blipId);
+    if (handle != null) {
+      dwellTimerScheduler.cancel(handle);
+    }
+    blip.removeAttribute("unread");
+    Runnable restoreOnError =
+        () -> {
+          markBlipReadInFlight.remove(blipId);
+          if (renderedBlipById(blipId) == blip) {
+            blip.setAttribute("unread", "");
+            evaluateDwellTimers();
+          }
+        };
+    try {
+      markBlipReadListener.markBlipRead(blipId, restoreOnError);
+      return true;
+    } catch (Throwable t) {
+      restoreOnError.run();
+      return false;
+    }
+  }
+
+  /**
    * Visibility predicate used by {@link #evaluateDwellTimers}. A blip is
    * considered visible when the intersection rectangle covers ≥ 50 % of the
    * blip OR (for blips taller than the viewport) ≥ 50 % of the viewport height.
@@ -800,8 +838,8 @@ public final class J2clReadSurfaceDomRenderer {
               /* isTask= */ entry.isTask(),
               entry.getInlineReplyAnchors());
       HTMLElement blipElement = renderBlip(blip, blipIndex++);
-      // V-4 (#1102): mark blip depth so the larger root avatar paints
-      // and the timestamp picks up the ` · root` suffix. Check parent
+      // V-4 (#1102): mark blip depth so root/reply avatar sizing paints
+      // correctly without exposing implementation labels. Check parent
       // presence in winBlipHostsById to match the fallback in
       // resolveWinThreadTarget — a blip whose parent hasn't been inserted
       // yet will be placed at the root thread, so treat it as root.
@@ -2809,12 +2847,14 @@ public final class J2clReadSurfaceDomRenderer {
       return;
     }
     if (focusedBlip == next) {
+      markFocusedBlipReadNow(next);
       return;
     }
     clearFocusedBlip();
     focusedBlip = next;
     setFocusMarkers(focusedBlip);
     focusedBlip.setAttribute("tabindex", "0");
+    markFocusedBlipReadNow(focusedBlip);
     dispatchFocusChanged(focusedBlip, key);
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -33,6 +33,16 @@ import org.waveprotocol.box.j2cl.transport.SidecarViewportHints;
 import org.waveprotocol.box.j2cl.viewport.J2clViewportGrowthDirection;
 
 public final class J2clSelectedWaveView implements J2clSelectedWaveController.View {
+  /**
+   * Initial selected-wave viewport size for normal client-side opens.
+   *
+   * <p>The server default is intentionally conservative for fragment growth, but it is too small
+   * for the desktop wave panel: compact reply-chain waves can visibly fit more than five blips,
+   * leaving a reachable placeholder in a small wave until the user scrolls. Request one screen plus
+   * a short prefetch buffer so small/medium waves feel GWT-complete while large waves remain
+   * viewport-bounded and continue to grow lazily at the edges.
+   */
+  private static final int INITIAL_VIEWPORT_BLIP_LIMIT = 12;
   // Keep in sync with j2cl/lit/src/controllers/wave-action-bar-controller.js.
   // Java stamps model-published folder state; Lit also reconciles this marker
   // while handling source-wave-id reuse before Java publishes for a wave.
@@ -595,6 +605,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     FocusOptionsType focusOptions = FocusOptionsType.create();
     focusOptions.setPreventScroll(true);
     target.focus(focusOptions);
+    readSurface.markFocusedBlipReadNow(target);
     ScrollIntoViewOptions scrollOptions = ScrollIntoViewOptions.create();
     scrollOptions.setBlock("center");
     scrollOptions.setInline("nearest");
@@ -697,7 +708,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     title.textContent = model.getTitleText();
     String unreadText = effectiveUnreadText(model);
     unread.textContent = unreadText;
-    unread.hidden = unreadText.isEmpty();
+    unread.hidden = true;
     unread.className =
         model.isReadStateStale()
             ? "sidecar-selected-unread sidecar-selected-unread-stale"
@@ -1122,7 +1133,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
         && !anchor.isEmpty()) {
       return new SidecarViewportHints(anchor, J2clViewportGrowthDirection.FORWARD, null);
     }
-    return SidecarViewportHints.defaultLimit();
+    return new SidecarViewportHints(null, null, Integer.valueOf(INITIAL_VIEWPORT_BLIP_LIMIT));
   }
 
   private String serverFirstBlipAnchor() {
@@ -1144,7 +1155,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   private void renderPreservedServerFirstState(J2clSelectedWaveModel model) {
     String unreadText = effectiveUnreadText(model);
     unread.textContent = unreadText;
-    unread.hidden = unreadText.isEmpty();
+    unread.hidden = true;
     unread.className =
         model.isReadStateStale()
             ? "sidecar-selected-unread sidecar-selected-unread-stale"

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -143,6 +143,9 @@ body.j2cl-root-shell-page:not(.j2cl-debug-overlay-on) [data-j2cl-debug-only] {
 
 .sidecar-search-shell {
   width: 100%;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .sidecar-split-layout {
@@ -150,6 +153,9 @@ body.j2cl-root-shell-page:not(.j2cl-debug-overlay-on) [data-j2cl-debug-only] {
   gap: 0;
   grid-template-columns: minmax(320px, 420px) minmax(0, 1fr);
   align-items: start;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
 }
 
 /* V-1 (#1099): on the J2CL root server-first workflow the legacy search
@@ -172,7 +178,10 @@ body.j2cl-root-shell-page:not(.j2cl-debug-overlay-on) [data-j2cl-debug-only] {
 
 .sidecar-selected-host {
   box-sizing: border-box;
+  height: 100%;
+  min-height: 0;
   min-width: 0;
+  overflow: hidden;
   width: 100%;
 }
 
@@ -182,6 +191,11 @@ body.j2cl-root-shell-page:not(.j2cl-debug-overlay-on) [data-j2cl-debug-only] {
   border-radius: 4px;
   box-sizing: border-box;
   box-shadow: none;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
   padding: 12px;
   width: 100%;
 }
@@ -280,8 +294,12 @@ shell-root[data-wave-controls-compact="true"] wavy-wave-nav-row {
 
 .sidecar-selected-content {
   display: grid;
+  flex: 1 1 auto;
   gap: 0;
   margin-top: 0;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
   padding-right: 0;
 }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererMarkReadTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererMarkReadTest.java
@@ -115,6 +115,35 @@ public class J2clReadSurfaceDomRendererMarkReadTest {
   }
 
   @Test
+  public void explicitFocusMarksUnreadBlipReadImmediately() {
+    HTMLDivElement host = createHost();
+    installViewport(host, 200);
+    installBlipLayout();
+    FakeScheduler scheduler = new FakeScheduler();
+    RecordingListener listener = new RecordingListener();
+
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    renderer.setDwellTimerSchedulerForTesting(scheduler);
+    renderer.setMarkBlipReadListener(listener);
+
+    List<J2clReadBlip> blips = new ArrayList<J2clReadBlip>();
+    blips.add(unreadBlip("b+focused", "focused"));
+    renderer.render(blips, java.util.Collections.<String>emptyList());
+    HTMLElement blip = (HTMLElement) host.querySelector("wave-blip[data-blip-id='b+focused']");
+    Assert.assertNotNull(blip);
+
+    Assert.assertTrue(renderer.markFocusedBlipReadNow(blip));
+
+    Assert.assertEquals(
+        "explicit navigation/focus should credit read state without waiting for the dwell timer",
+        java.util.Arrays.asList("b+focused"),
+        listener.fired);
+    Assert.assertFalse(
+        "optimistic local read state should clear the visual unread marker immediately",
+        blip.hasAttribute("unread"));
+  }
+
+  @Test
   public void blipFiringTwiceForSameIdIsBlockedByInFlightSet() {
     HTMLDivElement host = createHost();
     installViewport(host, 200);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -4,6 +4,7 @@ import com.google.j2cl.junit.apt.J2clTestInput;
 import elemental2.core.JsArray;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.HTMLElement;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -132,6 +133,21 @@ public class J2clSelectedWaveViewChromeTest {
         "Nav-row receives the model's unread count via the unread-count attribute",
         "5",
         row.getAttribute("unread-count"));
+  }
+
+  @Test
+  public void renderKeepsTopReadStateTextHiddenInWaveChrome() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+
+    view.render(selectedModel("example.com/w+read-text"));
+
+    HTMLElement readState = (HTMLElement) host.querySelector(".sidecar-selected-unread");
+    Assert.assertNotNull(readState);
+    Assert.assertTrue(
+        "Top wave chrome must not show text like 'Read.'; per-blip read state is visual.",
+        readState.hidden);
   }
 
   @Test
@@ -705,6 +721,28 @@ public class J2clSelectedWaveViewChromeTest {
     Assert.assertEquals(
         host.querySelector("wave-blip[data-blip-id='b+3']"),
         DomGlobal.document.activeElement);
+  }
+
+  @Test
+  public void navRowNextUnreadMarksFocusedUnreadBlipReadImmediately() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+    final List<String> markedRead = new ArrayList<String>();
+    view.setMarkBlipReadHandler((blipId, onError) -> markedRead.add(blipId));
+    view.render(navigationModel());
+
+    dispatchNavEvent(view.getCardElement(), "wave-nav-next-unread-requested");
+
+    HTMLElement unreadBlip = (HTMLElement) host.querySelector("wave-blip[data-blip-id='b+2']");
+    Assert.assertEquals(unreadBlip, DomGlobal.document.activeElement);
+    Assert.assertEquals(
+        "Toolbar navigation to an unread blip should update read state immediately",
+        Collections.singletonList("b+2"),
+        markedRead);
+    Assert.assertFalse(
+        "Optimistic local read state should clear the unread marker before the server echo",
+        unreadBlip.hasAttribute("unread"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewServerFirstLogicTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewServerFirstLogicTest.java
@@ -129,7 +129,7 @@ public class J2clSelectedWaveViewServerFirstLogicTest {
 
     Assert.assertNull(hints.getStartBlipId());
     Assert.assertNull(hints.getDirection());
-    Assert.assertEquals(Integer.valueOf(0), hints.getLimit());
+    Assert.assertEquals(Integer.valueOf(12), hints.getLimit());
   }
 
   @Test
@@ -140,7 +140,7 @@ public class J2clSelectedWaveViewServerFirstLogicTest {
 
     Assert.assertNull(hints.getStartBlipId());
     Assert.assertNull(hints.getDirection());
-    Assert.assertEquals(Integer.valueOf(0), hints.getLimit());
+    Assert.assertEquals(Integer.valueOf(12), hints.getLimit());
   }
 
   @Test

--- a/wave/config/changelog.d/2026-05-04-j2cl-wave-navigation-readstate-scroll.json
+++ b/wave/config/changelog.d/2026-05-04-j2cl-wave-navigation-readstate-scroll.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-05-04-j2cl-wave-navigation-readstate-scroll",
+  "version": "J2CL parity",
+  "date": "2026-05-04",
+  "title": "J2CL wave navigation and read-state parity",
+  "summary": "Fixes remaining J2CL wave-panel parity gaps around single-scroll layout, explicit blip navigation, and read-state chrome.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Constrains the J2CL root shell to the viewport and makes the selected wave content the single vertical scroll owner.",
+        "Marks unread blips read immediately when the user focuses them via wave navigation or direct blip focus.",
+        "Hides text-only top read-state labels from the wave chrome while preserving unread counts in the navigation controls."
+      ]
+    }
+  ]
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -531,6 +531,13 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
   public void testRootShellOwnsViewportHeightWithoutBodyScrollbar() {
     String css = readSourceFile("j2cl/lit/src/tokens/shell-tokens.css");
     assertTrue(
+        "J2CL root html element must hide document scrolling in standards-mode browsers.",
+        java.util.regex.Pattern.compile(
+                "html\\.j2cl-root-shell-page,\\s*html:has\\(body\\.j2cl-root-shell-page\\)"
+                    + "\\s*\\{[^}]*\\boverflow\\s*:\\s*hidden\\s*;")
+            .matcher(css)
+            .find());
+    assertTrue(
         "J2CL root body must hide document scrolling so the wave panel has one scroll owner.",
         java.util.regex.Pattern.compile(
                 "body\\.j2cl-root-shell-page\\s*\\{[^}]*\\boverflow\\s*:\\s*hidden\\s*;")

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -503,25 +503,41 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
             "element.setAttribute(\"posted-at\", blipLabel(blip.getBlipId()));"));
   }
 
-  public void testSelectedWaveContentDoesNotOwnNestedVerticalScrollbar() {
+  public void testSelectedWaveContentOwnsOnlyWavePanelScrollbar() {
     String css = readSourceFile("j2cl/src/main/webapp/assets/sidecar.css");
     java.util.regex.Pattern rulePattern =
         java.util.regex.Pattern.compile("[^{]*sidecar-selected-content[^{]*\\{([^}]*)\\}");
     java.util.regex.Matcher matcher = rulePattern.matcher(css);
     assertTrue("sidecar.css must define .sidecar-selected-content", matcher.find());
     boolean anyOverflowY = false;
-    boolean anyMaxHeight = false;
+    boolean anyMinHeightZero = false;
     do {
       String block = matcher.group(1);
       if (block.contains("overflow-y")) anyOverflowY = true;
-      if (block.contains("max-height")) anyMaxHeight = true;
+      if (block.contains("min-height: 0")) anyMinHeightZero = true;
     } while (matcher.find());
-    assertFalse(
-        "Selected wave content must not own an inner vertical scrollbar; the root page scrolls once.",
+    assertTrue(
+        "Selected wave content should be the single wave-panel vertical scroll owner.",
         anyOverflowY);
-    assertFalse(
-        "Selected wave content must not clamp to viewport height; that creates a second wave-panel scrollbar.",
-        anyMaxHeight);
+    assertTrue(
+        "Selected wave content must be allowed to shrink inside the shell grid before it scrolls.",
+        anyMinHeightZero);
+  }
+
+  public void testRootShellOwnsViewportHeightWithoutBodyScrollbar() {
+    String css = readSourceFile("j2cl/lit/src/tokens/shell-tokens.css");
+    assertTrue(
+        "J2CL root body must hide document scrolling so the wave panel has one scroll owner.",
+        java.util.regex.Pattern.compile(
+                "body\\.j2cl-root-shell-page\\s*\\{[^}]*\\boverflow\\s*:\\s*hidden\\s*;")
+            .matcher(css)
+            .find());
+    assertTrue(
+        "Root shell must be constrained to the viewport height, not only min-height.",
+        java.util.regex.Pattern.compile(
+                "shell-root,\\s*shell-root-signed-out\\s*\\{[^}]*\\bheight\\s*:\\s*100vh\\s*;")
+            .matcher(css)
+            .find());
   }
 
   public void testReadSurfaceRendererUsesActiveScrollContainerForViewportLoading() {

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -509,16 +509,20 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         java.util.regex.Pattern.compile("[^{]*sidecar-selected-content[^{]*\\{([^}]*)\\}");
     java.util.regex.Matcher matcher = rulePattern.matcher(css);
     assertTrue("sidecar.css must define .sidecar-selected-content", matcher.find());
-    boolean anyOverflowY = false;
+    boolean anyOverflowYAuto = false;
     boolean anyMinHeightZero = false;
     do {
       String block = matcher.group(1);
-      if (block.contains("overflow-y")) anyOverflowY = true;
+      if (java.util.regex.Pattern.compile("overflow-y\\s*:\\s*auto\\s*;")
+          .matcher(block)
+          .find()) {
+        anyOverflowYAuto = true;
+      }
       if (block.contains("min-height: 0")) anyMinHeightZero = true;
     } while (matcher.find());
     assertTrue(
         "Selected wave content should be the single wave-panel vertical scroll owner.",
-        anyOverflowY);
+        anyOverflowYAuto);
     assertTrue(
         "Selected wave content must be allowed to shrink inside the shell grid before it scrolls.",
         anyMinHeightZero);


### PR DESCRIPTION
## Summary
- Remove the nested page/body scrollbar from the J2CL root wave shell so the selected wave content owns the single wave-panel scroll surface.
- Hide the visible top read-state text, mark explicitly focused/navigation-targeted unread blips read immediately, and keep unread/read state represented by blip/search chrome instead of debug text.
- Wire the compact thread chevron to depth navigation, fix its hit target, add missing tooltips, and raise the normal initial viewport hint to keep small waves complete while preserving large-wave lazy loading.

Fixes #1196

## Verification
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`
- `git diff --check`
- `cd j2cl/lit && npm test -- --files test/wave-blip.test.js test/wavy-task-affordance.test.js test/shell-main-region.test.js test/shell-root.test.js`
- `cd j2cl/lit && npm run build`
- `sbt --batch Test/compile`
- `sbt --batch 'testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellIntegrationTest'`
- `sbt --batch j2clLitTest`
- `bash scripts/worktree-boot.sh --port 9942`
- `PORT=9942 bash scripts/wave-smoke.sh check`
- `WAVE_E2E_BASE_URL=http://127.0.0.1:9942 npx playwright test tests/smoke.spec.ts tests/wave-reading-parity.spec.ts tests/inline-reply-parity.spec.ts tests/wave-actions-parity.spec.ts --workers=1 --retries=0`
- Browser audit on local J2CL root: body/html not scrollable, only `.sidecar-selected-content` scrolls; top read-state copy hidden; small wave rendered 6 blips with 0 placeholders; compact thread chevron changed the depth URL with 0 scroll delta.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Constrained shell/sidecar layouts to prevent viewport overflow; selected content is now the sole vertical scroller. Top text-only read-state is hidden; focused unread items are marked read immediately.

* **New Features**
  * Added tooltips to interactive controls and emit an additional drill-in event carrying wave + blip identifiers.

* **Tests**
  * Added/updated tests covering immediate mark-as-read, drill-in events, and the new scroll/viewport behavior.

* **Documentation**
  * Added changelog entry describing these fixes and behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->