### PR TITLE
Suppress J2CL wave shortcuts while editing blips

### DIFF
--- a/j2cl/lit/src/elements/wavy-wave-nav-row.js
+++ b/j2cl/lit/src/elements/wavy-wave-nav-row.js
@@ -1,5 +1,6 @@
 import { LitElement, css, html } from "lit";
 import { getWaveActionIcon } from "../icons/wave-action-bar-icons.js";
+import { isEditableTarget } from "../shortcuts/keybindings.js";
 
 /**
  * <wavy-wave-nav-row> — F-2 (#1037, R-3.4; slice 2 #1046) wave-level nav
@@ -220,16 +221,8 @@ export class WavyWaveNavRow extends LitElement {
     if (event.ctrlKey || event.metaKey || event.altKey) {
       return;
     }
-    const target = event.target;
-    if (target && target.nodeType === 1) {
-      const tag = target.tagName;
-      if (
-        tag === "INPUT" ||
-        tag === "TEXTAREA" ||
-        target.isContentEditable === true
-      ) {
-        return;
-      }
+    if (isEditableTarget(event)) {
+      return;
     }
     event.preventDefault();
     this._emit("wave-nav-version-history-requested", { keyboard: true });

--- a/j2cl/lit/src/elements/wavy-wave-nav-row.js
+++ b/j2cl/lit/src/elements/wavy-wave-nav-row.js
@@ -215,7 +215,11 @@ export class WavyWaveNavRow extends LitElement {
   }
 
   _onKeyDown(event) {
-    if (!event || (event.key !== "H" && event.key !== "h")) {
+    if (
+      !event ||
+      event.defaultPrevented ||
+      (event.key !== "H" && event.key !== "h")
+    ) {
       return;
     }
     if (event.ctrlKey || event.metaKey || event.altKey) {

--- a/j2cl/lit/test/wavy-wave-nav-row.test.js
+++ b/j2cl/lit/test/wavy-wave-nav-row.test.js
@@ -354,6 +354,29 @@ describe("<wavy-wave-nav-row>", () => {
     expect(event.defaultPrevented).to.be.false;
   });
 
+  it("H keyboard ignored when an inner handler already prevented default", async () => {
+    const card = await fixture(
+      html`<section data-j2cl-selected-wave-host>
+        <wavy-wave-nav-row></wavy-wave-nav-row>
+      </section>`
+    );
+    const el = card.querySelector("wavy-wave-nav-row");
+    await el.updateComplete;
+    let fired = false;
+    el.addEventListener("wave-nav-version-history-requested", () => {
+      fired = true;
+    });
+    const event = new KeyboardEvent("keydown", {
+      key: "H",
+      bubbles: true,
+      cancelable: true
+    });
+    event.preventDefault();
+    card.dispatchEvent(event);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(fired).to.be.false;
+  });
+
   it("H keyboard ignored when modifier (cmd/ctrl/alt) is held", async () => {
     const card = await fixture(
       html`<section data-j2cl-selected-wave-host>

--- a/j2cl/lit/test/wavy-wave-nav-row.test.js
+++ b/j2cl/lit/test/wavy-wave-nav-row.test.js
@@ -315,6 +315,45 @@ describe("<wavy-wave-nav-row>", () => {
     expect(fired).to.be.false;
   });
 
+  it("H keyboard ignored when composed path starts inside a contenteditable editor", async () => {
+    const card = await fixture(
+      html`<section data-j2cl-selected-wave-host>
+        <div id="editor-host"></div>
+        <wavy-wave-nav-row></wavy-wave-nav-row>
+      </section>`
+    );
+    const el = card.querySelector("wavy-wave-nav-row");
+    await el.updateComplete;
+    let fired = false;
+    el.addEventListener("wave-nav-version-history-requested", () => {
+      fired = true;
+    });
+    const editor = document.createElement("div");
+    editor.setAttribute("contenteditable", "true");
+    const event = new KeyboardEvent("keydown", {
+      key: "H",
+      bubbles: true,
+      composed: true,
+      cancelable: true
+    });
+    Object.defineProperty(event, "composedPath", {
+      configurable: true,
+      value: () => [
+        editor,
+        card.querySelector("#editor-host"),
+        card,
+        document.body,
+        document.documentElement,
+        document,
+        window
+      ]
+    });
+    card.dispatchEvent(event);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(fired).to.be.false;
+    expect(event.defaultPrevented).to.be.false;
+  });
+
   it("H keyboard ignored when modifier (cmd/ctrl/alt) is held", async () => {
     const card = await fixture(
       html`<section data-j2cl-selected-wave-host>

--- a/wave/config/changelog.d/2026-05-04-j2cl-editor-shortcut-guard.json
+++ b/wave/config/changelog.d/2026-05-04-j2cl-editor-shortcut-guard.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-04-j2cl-editor-shortcut-guard",
+  "version": "J2CL parity",
+  "date": "2026-05-04",
+  "title": "J2CL editor shortcuts stay scoped while composing",
+  "summary": "Wave-level keyboard shortcuts no longer open version history while editing a blip in the J2CL wave view.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Suppresses the J2CL wave navigation version-history shortcut when the key event originates from a composed-path editor target, including Lit shadow-DOM composer events."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #1198

## Summary
- Reuses the shared J2CL shortcut editable-target guard for the wave nav row version-history shortcut.
- Adds a regression test for key events retargeted from a contenteditable editor through a Lit/shadow-DOM composed path.
- Adds a J2CL parity changelog fragment.

## Verification
- `cd j2cl/lit && npm test -- --files test/wavy-wave-nav-row.test.js` -> 27 passed, 0 failed
- `cd j2cl/lit && npm run build` -> passed
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py` -> passed
- `git diff --check` -> passed
- `sbt --batch j2clLitTest j2clLitBuild` -> 64 test files, 822 passed, 0 failed; build completed

## Self Review
- Scope is limited to the row-owned version-history shortcut; toolbar click behavior is unchanged.
- Existing host-level `H` shortcut coverage remains, and the new test covers the missing composed-path editor case.
- The guard now matches shell shortcut behavior for inputs, selects, textareas, contenteditable nodes, and shadow-DOM paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Keyboard shortcuts for version history no longer trigger while composing or editing content in the wave view.

* **Tests**
  * Added a keyboard-handling test to ensure the version-history shortcut is suppressed when the event originates from an editable/composed-path target.

* **Documentation**
  * Added a changelog entry documenting the scoped-shortcut behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->