### PR TITLE
Fix J2CL inline reply thread toggle parity

### DIFF
--- a/j2cl/lit/src/design/wavy-thread-collapse.css
+++ b/j2cl/lit/src/design/wavy-thread-collapse.css
@@ -45,6 +45,21 @@
   opacity: 0;
 }
 
+/* GWT parity: the visible affordance for an inline reply thread is the
+ * parent blip chevron. Keep the generated legacy button in the DOM for
+ * keyboard/tests, but remove the stray per-thread +/- from layout. */
+.j2cl-read-thread-toggle {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .j2cl-read-thread,
   .j2cl-read-thread-collapsed {

--- a/j2cl/lit/src/design/wavy-thread-collapse.css
+++ b/j2cl/lit/src/design/wavy-thread-collapse.css
@@ -47,8 +47,11 @@
 
 /* GWT parity: the visible affordance for an inline reply thread is the
  * parent blip chevron. Keep the generated legacy button in the DOM for
- * keyboard/tests, but remove the stray per-thread +/- from layout. */
-.j2cl-read-thread-toggle {
+ * keyboard/tests, but remove the stray per-thread +/- from layout.
+ * Scope to [data-parent-blip-id] threads only: SSR-rendered inline threads
+ * lack this attribute and rely on the button as their sole toggle affordance
+ * (their parent is a div.blip, not a wave-blip, so no chevron event fires). */
+[data-parent-blip-id] > .j2cl-read-thread-toggle {
   position: absolute;
   width: 1px;
   height: 1px;

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -53,8 +53,8 @@ import "./wavy-task-affordance.js";
  *   handles the clipboard write itself before emitting.
  * - `wave-blip-profile-requested` — `{detail: {blipId, authorId}}`.
  *   Emitted from the avatar click for the L.1 profile overlay.
- * - `wave-blip-drill-in-requested` — `{detail: {blipId, waveId}}`.
- *   Emitted from the compact thread chevron for the R-3.7 G.1 drill-in.
+ * - `wave-blip-thread-toggle-requested` — `{detail: {blipId, waveId}}`.
+ *   Emitted from the compact thread chevron for inline reply collapse parity.
  */
 export class WaveBlip extends LitElement {
   static properties = {
@@ -549,19 +549,11 @@ export class WaveBlip extends LitElement {
 
   _onThreadChevronClick(event) {
     event.stopPropagation();
-    const detail = { blipId: this.blipId, waveId: this.waveId };
     this.dispatchEvent(
-      new CustomEvent("wave-blip-drill-in-requested", {
+      new CustomEvent("wave-blip-thread-toggle-requested", {
         bubbles: true,
         composed: true,
-        detail
-      })
-    );
-    this.dispatchEvent(
-      new CustomEvent("wavy-depth-drill-in", {
-        bubbles: true,
-        composed: true,
-        detail
+        detail: { blipId: this.blipId, waveId: this.waveId }
       })
     );
   }
@@ -601,13 +593,14 @@ export class WaveBlip extends LitElement {
     const hasReplies = this.replyCount > 0;
     const visuallyFocused = this._visuallyFocused();
     const replyNoun = this.replyCount === 1 ? "reply" : "replies";
+    const threadToggleVerb = this.threadCollapsed ? "Expand" : "Collapse";
     const chevron = hasReplies
       ? html`<button
           type="button"
           class="thread-chevron"
           data-thread-chevron="true"
-          aria-label=${`Drill into ${this.replyCount} ${replyNoun} under this blip`}
-          title=${`Drill into ${this.replyCount} ${replyNoun} under this blip`}
+          aria-label=${`${threadToggleVerb} ${this.replyCount} ${replyNoun} under this blip`}
+          title=${`${threadToggleVerb} ${this.replyCount} ${replyNoun} under this blip`}
           @click=${this._onThreadChevronClick}
         >${this._chevronGlyph()}</button>`
       : html`<span class="thread-chevron" hidden></span>`;

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -161,7 +161,7 @@ describe("<wave-blip>", () => {
     expect(el.renderRoot.querySelector("[data-inline-reply-chip='true']")).to.not.exist;
   });
 
-  it("compact thread chevron click emits wave-blip-drill-in-requested with blip context", async () => {
+  it("compact thread chevron click requests inline thread toggle with blip context", async () => {
     const el = await fixture(html`
       <wave-blip
         data-blip-id="b7"
@@ -175,14 +175,14 @@ describe("<wave-blip>", () => {
     await el.updateComplete;
     const chevron = el.renderRoot.querySelector("[data-thread-chevron='true']");
     expect(chevron).to.exist;
-    expect(chevron.getAttribute("aria-label")).to.equal("Drill into 2 replies under this blip");
+    expect(chevron.getAttribute("aria-label")).to.equal("Collapse 2 replies under this blip");
     setTimeout(() => chevron.click(), 0);
-    const ev = await oneEvent(el, "wave-blip-drill-in-requested");
+    const ev = await oneEvent(el, "wave-blip-thread-toggle-requested");
     expect(ev.detail.blipId).to.equal("b7");
     expect(ev.detail.waveId).to.equal("w7");
   });
 
-  it("compact thread chevron also emits the shell depth-navigation event", async () => {
+  it("compact thread chevron does not emit the shell depth-navigation event", async () => {
     const el = await fixture(html`
       <wave-blip
         data-blip-id="b7nav"
@@ -195,13 +195,11 @@ describe("<wave-blip>", () => {
     `);
     await el.updateComplete;
     const chevron = el.renderRoot.querySelector("[data-thread-chevron='true']");
-    expect(chevron.getAttribute("title")).to.equal("Drill into 2 replies under this blip");
-    setTimeout(() => chevron.click(), 0);
-    const ev = await oneEvent(el, "wavy-depth-drill-in");
-    expect(ev.detail.blipId).to.equal("b7nav");
-    expect(ev.detail.waveId).to.equal("w7");
-    expect(ev.bubbles).to.be.true;
-    expect(ev.composed).to.be.true;
+    expect(chevron.getAttribute("title")).to.equal("Collapse 2 replies under this blip");
+    let depthEventCount = 0;
+    el.addEventListener("wavy-depth-drill-in", () => depthEventCount++);
+    chevron.click();
+    expect(depthEventCount).to.equal(0);
   });
 
   it("uses singular grammar for a one-reply chevron aria-label", async () => {
@@ -212,7 +210,7 @@ describe("<wave-blip>", () => {
     `);
     await el.updateComplete;
     const chevron = el.renderRoot.querySelector("[data-thread-chevron='true']");
-    expect(chevron.getAttribute("aria-label")).to.equal("Drill into 1 reply under this blip");
+    expect(chevron.getAttribute("aria-label")).to.equal("Collapse 1 reply under this blip");
   });
 
   it("avatar click emits wave-blip-profile-requested with author id", async () => {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -723,6 +723,14 @@ public final class J2clReadSurfaceDomRenderer {
       evaluateDwellTimers();
       return true;
     }
+    if (appendTrailingWindowEntriesIfPossible(
+        effectiveEntries,
+        previouslyCollapsedThreadIds,
+        focusedBlipId,
+        scrollAnchorBlipId,
+        scrollAnchorTop)) {
+      return true;
+    }
 
     cancelAllDwellTimers();
     host.innerHTML = "";
@@ -912,6 +920,288 @@ public final class J2clReadSurfaceDomRenderer {
     pruneStaleInFlightOnRebuild();
     evaluateDwellTimers();
     return true;
+  }
+
+  private boolean appendTrailingWindowEntriesIfPossible(
+      List<J2clReadWindowEntry> effectiveEntries,
+      List<String> previouslyCollapsedThreadIds,
+      String focusedBlipId,
+      String scrollAnchorBlipId,
+      double scrollAnchorTop) {
+    if (renderedSurface == null
+        || renderedSurface.parentElement != host
+        || renderedWindowEntries.isEmpty()
+        || effectiveEntries.size() <= renderedWindowEntries.size()
+        || !isRenderedWindowPrefix(effectiveEntries)
+        || !renderedPrefixStillMatchesManifest(effectiveEntries)) {
+      return false;
+    }
+    HTMLElement rootThread = (HTMLElement) renderedSurface.querySelector("[data-thread-id='root']");
+    if (rootThread == null) {
+      return false;
+    }
+
+    Map<String, HTMLElement> winBlipHostsById = collectRenderedBlipHosts(renderedSurface);
+    Map<String, HTMLElement> winThreadHostsByKey = collectRenderedThreadHosts(renderedSurface);
+    Map<String, HTMLElement> winLastThreadHostByParent =
+        collectRenderedFallbackThreadAnchors(renderedSurface);
+    int blipIndex = renderedBlipCount(renderedSurface);
+    boolean hasPlaceholder = false;
+    for (int i = renderedWindowEntries.size(); i < effectiveEntries.size(); i++) {
+      J2clReadWindowEntry entry = effectiveEntries.get(i);
+      if (!entry.isLoaded()) {
+        hasPlaceholder = true;
+        HTMLElement placeholderEl = renderPlaceholder(entry);
+        String phParent = "";
+        String phThread = "";
+        if (!conversationManifest.isEmpty() && !entry.getBlipId().isEmpty()) {
+          SidecarConversationManifest.Entry phManifestEntry =
+              conversationManifest.findByBlipId(entry.getBlipId());
+          if (phManifestEntry != null) {
+            phParent =
+                phManifestEntry.getParentBlipId() == null ? "" : phManifestEntry.getParentBlipId();
+            phThread = phManifestEntry.getThreadId() == null ? "" : phManifestEntry.getThreadId();
+          }
+        }
+        HTMLElement placeholderTarget =
+            resolveWinThreadTarget(
+                phParent,
+                phThread,
+                rootThread,
+                winBlipHostsById,
+                winThreadHostsByKey,
+                winLastThreadHostByParent);
+        placeholderTarget.appendChild(placeholderEl);
+        if (!entry.getBlipId().isEmpty()) {
+          winBlipHostsById.put(entry.getBlipId(), placeholderEl);
+        }
+        continue;
+      }
+      String entryParent = entry.getParentBlipId();
+      String entryThread = entry.getThreadId();
+      if ((entryParent == null || entryParent.isEmpty())
+          && (entryThread == null || entryThread.isEmpty())
+          && !conversationManifest.isEmpty()) {
+        SidecarConversationManifest.Entry manifestEntry =
+            conversationManifest.findByBlipId(entry.getBlipId());
+        if (manifestEntry != null) {
+          entryParent = manifestEntry.getParentBlipId();
+          entryThread = manifestEntry.getThreadId();
+        }
+      }
+      J2clReadBlip blip =
+          new J2clReadBlip(
+              entry.getBlipId(),
+              entry.getText(),
+              entry.getAttachments(),
+              entry.getAuthorId(),
+              entry.getAuthorDisplayName(),
+              entry.getLastModifiedTimeMillis(),
+              entryParent,
+              entryThread,
+              entry.isUnread(),
+              entry.hasMention(),
+              /* deleted= */ false,
+              /* taskDone= */ entry.isTaskDone(),
+              entry.getTaskAssignee(),
+              entry.getTaskDueTimestamp(),
+              entry.getBodyItemCount(),
+              entry.isTask(),
+              entry.getInlineReplyAnchors());
+      HTMLElement blipElement = renderBlip(blip, blipIndex++);
+      String parentForDepth = blip.getParentBlipId();
+      boolean parentPresent =
+          parentForDepth != null && !parentForDepth.isEmpty() && winBlipHostsById.containsKey(parentForDepth);
+      blipElement.setAttribute("data-blip-depth", parentPresent ? "reply" : "root");
+      winBlipHostsById.put(blip.getBlipId(), blipElement);
+      HTMLElement blipTarget =
+          resolveWinThreadTarget(
+              blip.getParentBlipId() == null ? "" : blip.getParentBlipId(),
+              blip.getThreadId() == null ? "" : blip.getThreadId(),
+              rootThread,
+              winBlipHostsById,
+              winThreadHostsByKey,
+              winLastThreadHostByParent);
+      blipTarget.appendChild(blipElement);
+    }
+
+    updateRenderedReplyCounts(renderedSurface);
+    if (hasPlaceholder) {
+      renderedSurface.setAttribute("aria-live", "polite");
+      rootThread.setAttribute("aria-busy", "true");
+    }
+    renderedWindowEntries =
+        Collections.unmodifiableList(new ArrayList<J2clReadWindowEntry>(effectiveEntries));
+    renderedLiveBlips = Collections.<J2clReadBlip>emptyList();
+    renderedConversationManifest = conversationManifest;
+    enhanceSurface(renderedSurface);
+    restoreCollapsedThreads(previouslyCollapsedThreadIds);
+    restoreFocusedBlipById(focusedBlipId);
+    restoreScrollAnchor(scrollAnchorBlipId, scrollAnchorTop);
+    notifyReadSurfaceRendered();
+    if (!requestReachablePlaceholderAfterRender()) {
+      schedulePostLayoutPlaceholderCheckIfNeeded();
+    }
+    pruneStaleInFlightOnRebuild();
+    evaluateDwellTimers();
+    return true;
+  }
+
+  private boolean isRenderedWindowPrefix(List<J2clReadWindowEntry> entries) {
+    if (renderedWindowEntries.size() > entries.size()) {
+      return false;
+    }
+    for (int i = 0; i < renderedWindowEntries.size(); i++) {
+      if (!sameWindowEntry(renderedWindowEntries.get(i), entries.get(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean renderedPrefixStillMatchesManifest(List<J2clReadWindowEntry> entries) {
+    if (conversationManifest == renderedConversationManifest || conversationManifest.isEmpty()) {
+      return true;
+    }
+    for (int i = 0; i < renderedWindowEntries.size(); i++) {
+      J2clReadWindowEntry entry = entries.get(i);
+      if (entry == null || !entry.isLoaded() || entry.getBlipId().isEmpty()) {
+        continue;
+      }
+      String expectedParent = entry.getParentBlipId();
+      if ((expectedParent == null || expectedParent.isEmpty())
+          && (entry.getThreadId() == null || entry.getThreadId().isEmpty())) {
+        SidecarConversationManifest.Entry manifestEntry =
+            conversationManifest.findByBlipId(entry.getBlipId());
+        if (manifestEntry != null) {
+          expectedParent = manifestEntry.getParentBlipId();
+        }
+      }
+      if (!renderedBlipPlacementMatches(entry.getBlipId(), expectedParent)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean renderedBlipPlacementMatches(String blipId, String expectedParent) {
+    Element element = renderedSurface.querySelector("[data-blip-id=\"" + blipId + "\"]");
+    if (element == null) {
+      return false;
+    }
+    String parent = expectedParent == null ? "" : expectedParent;
+    Element thread =
+        element.parentElement == null || !element.parentElement.hasAttribute("data-parent-blip-id")
+            ? null
+            : element.parentElement;
+    if (parent.isEmpty()) {
+      return thread == null;
+    }
+    return thread != null && parent.equals(thread.getAttribute("data-parent-blip-id"));
+  }
+
+  private static Map<String, HTMLElement> collectRenderedBlipHosts(HTMLElement surface) {
+    Map<String, HTMLElement> hosts = new HashMap<String, HTMLElement>();
+    NodeList<Element> blips = surface.querySelectorAll("[data-blip-id], [data-placeholder-blip-id]");
+    for (int i = 0; i < blips.length; i++) {
+      Element element = blips.item(i);
+      if (!(element instanceof HTMLElement)) {
+        continue;
+      }
+      String id = element.getAttribute("data-blip-id");
+      if (id == null || id.isEmpty()) {
+        id = element.getAttribute("data-placeholder-blip-id");
+      }
+      if (id != null && !id.isEmpty() && !hosts.containsKey(id)) {
+        hosts.put(id, (HTMLElement) element);
+      }
+    }
+    return hosts;
+  }
+
+  private static Map<String, HTMLElement> collectRenderedThreadHosts(HTMLElement surface) {
+    Map<String, HTMLElement> hosts = new HashMap<String, HTMLElement>();
+    NodeList<Element> threads = surface.querySelectorAll(".inline-thread[data-parent-blip-id]");
+    for (int i = 0; i < threads.length; i++) {
+      Element element = threads.item(i);
+      if (!(element instanceof HTMLElement)) {
+        continue;
+      }
+      String parentId = element.getAttribute("data-parent-blip-id");
+      if (parentId == null || parentId.isEmpty()) {
+        continue;
+      }
+      hosts.put(parentId + "::" + rawThreadIdForHost(parentId, element), (HTMLElement) element);
+    }
+    return hosts;
+  }
+
+  private static Map<String, HTMLElement> collectRenderedFallbackThreadAnchors(HTMLElement surface) {
+    Map<String, HTMLElement> anchors = new HashMap<String, HTMLElement>();
+    NodeList<Element> threads = surface.querySelectorAll(".inline-thread[data-parent-blip-id]");
+    for (int i = 0; i < threads.length; i++) {
+      Element element = threads.item(i);
+      if (!(element instanceof HTMLElement)
+          || "inline".equals(element.getAttribute("data-inline-reply-anchor-placement"))) {
+        continue;
+      }
+      String parentId = element.getAttribute("data-parent-blip-id");
+      if (parentId != null && !parentId.isEmpty()) {
+        anchors.put(parentId, (HTMLElement) element);
+      }
+    }
+    return anchors;
+  }
+
+  private static String rawThreadIdForHost(String parentId, Element threadHost) {
+    String anchored = threadHost.getAttribute("data-inline-reply-anchor-thread-id");
+    if (anchored != null && !anchored.isEmpty()) {
+      return anchored;
+    }
+    String scoped = threadHost.getAttribute("data-thread-id");
+    if (scoped == null || scoped.isEmpty() || scoped.equals("inline-" + parentId)) {
+      return "";
+    }
+    String prefix = parentId + "::";
+    return scoped.startsWith(prefix) ? scoped.substring(prefix.length()) : scoped;
+  }
+
+  private static int renderedBlipCount(HTMLElement surface) {
+    return surface.querySelectorAll("[data-j2cl-read-blip='true']").length;
+  }
+
+  private static void updateRenderedReplyCounts(HTMLElement surface) {
+    NodeList<Element> blips = surface.querySelectorAll("[data-blip-id][reply-count]");
+    for (int i = 0; i < blips.length; i++) {
+      blips.item(i).removeAttribute("reply-count");
+    }
+    Map<String, Integer> counts = new HashMap<String, Integer>();
+    NodeList<Element> threads = surface.querySelectorAll(".inline-thread[data-parent-blip-id]");
+    for (int i = 0; i < threads.length; i++) {
+      Element thread = threads.item(i);
+      String parentId = thread.getAttribute("data-parent-blip-id");
+      if (parentId == null || parentId.isEmpty()) {
+        continue;
+      }
+      int direct = 0;
+      Element child = thread.firstElementChild;
+      while (child != null) {
+        if (child.hasAttribute("data-blip-id") || child.hasAttribute("data-placeholder-blip-id")) {
+          direct++;
+        }
+        child = child.nextElementSibling;
+      }
+      if (direct > 0) {
+        Integer prior = counts.get(parentId);
+        counts.put(parentId, (prior == null ? 0 : prior) + direct);
+      }
+    }
+    for (Map.Entry<String, Integer> entry : counts.entrySet()) {
+      Element parent = surface.querySelector("[data-blip-id=\"" + entry.getKey() + "\"]");
+      if (parent != null && entry.getValue() != null && entry.getValue() > 0) {
+        parent.setAttribute("reply-count", String.valueOf(entry.getValue()));
+      }
+    }
   }
 
   private List<J2clReadWindowEntry> orderWindowEntriesForRender(
@@ -2206,6 +2496,8 @@ public final class J2clReadSurfaceDomRenderer {
     HTMLElement button = (HTMLElement) DomGlobal.document.createElement("button");
     button.className = "j2cl-read-thread-toggle";
     button.setAttribute("type", "button");
+    button.setAttribute("tabindex", "-1");
+    button.setAttribute("aria-hidden", "true");
     button.setAttribute("aria-controls", thread.getAttribute("id"));
     button.setAttribute("aria-expanded", "true");
     button.setAttribute("aria-label", "Collapse " + label);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1073,27 +1073,31 @@ public final class J2clReadSurfaceDomRenderer {
         continue;
       }
       String expectedParent = entry.getParentBlipId();
+      String expectedThread = entry.getThreadId();
       if ((expectedParent == null || expectedParent.isEmpty())
-          && (entry.getThreadId() == null || entry.getThreadId().isEmpty())) {
+          && (expectedThread == null || expectedThread.isEmpty())) {
         SidecarConversationManifest.Entry manifestEntry =
             conversationManifest.findByBlipId(entry.getBlipId());
         if (manifestEntry != null) {
           expectedParent = manifestEntry.getParentBlipId();
+          expectedThread = manifestEntry.getThreadId();
         }
       }
-      if (!renderedBlipPlacementMatches(entry.getBlipId(), expectedParent)) {
+      if (!renderedBlipPlacementMatches(entry.getBlipId(), expectedParent, expectedThread)) {
         return false;
       }
     }
     return true;
   }
 
-  private boolean renderedBlipPlacementMatches(String blipId, String expectedParent) {
+  private boolean renderedBlipPlacementMatches(
+      String blipId, String expectedParent, String expectedThread) {
     Element element = renderedSurface.querySelector("[data-blip-id=\"" + blipId + "\"]");
     if (element == null) {
       return false;
     }
     String parent = expectedParent == null ? "" : expectedParent;
+    String threadId = expectedThread == null ? "" : expectedThread;
     Element thread =
         element.parentElement == null || !element.parentElement.hasAttribute("data-parent-blip-id")
             ? null
@@ -1101,7 +1105,9 @@ public final class J2clReadSurfaceDomRenderer {
     if (parent.isEmpty()) {
       return thread == null;
     }
-    return thread != null && parent.equals(thread.getAttribute("data-parent-blip-id"));
+    return thread != null
+        && parent.equals(thread.getAttribute("data-parent-blip-id"))
+        && threadId.equals(rawThreadIdForHost(parent, thread));
   }
 
   private static Map<String, HTMLElement> collectRenderedBlipHosts(HTMLElement surface) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -2139,6 +2139,11 @@ public final class J2clReadSurfaceDomRenderer {
     if (!surface.hasAttribute("aria-label")) {
       surface.setAttribute("aria-label", "Selected wave read surface");
     }
+    if (!surface.hasAttribute("data-j2cl-thread-toggle-bound")) {
+      surface.setAttribute("data-j2cl-thread-toggle-bound", "true");
+      surface.addEventListener(
+          "wave-blip-thread-toggle-requested", this::onBlipThreadToggleRequested);
+    }
     enhanceThreads(surface);
     enhanceBlips(surface);
     bindAttachmentTelemetry(surface);
@@ -2311,6 +2316,67 @@ public final class J2clReadSurfaceDomRenderer {
       // Telemetry is observational.
     }
     evaluateDwellTimers();
+  }
+
+  private void onBlipThreadToggleRequested(Event event) {
+    if (event == null) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    Object detail = ((CustomEvent<?>) event).detail;
+    if (detail == null) {
+      return;
+    }
+    JsPropertyMap<?> detailMap = Js.cast(detail);
+    Object rawBlipId = detailMap.get("blipId");
+    if (rawBlipId == null) {
+      return;
+    }
+    toggleInlineThreadsForParent(String.valueOf(rawBlipId));
+  }
+
+  private void toggleInlineThreadsForParent(String parentBlipId) {
+    if (parentBlipId == null || parentBlipId.isEmpty()) {
+      return;
+    }
+    List<HTMLElement> threads = inlineThreadsForParent(parentBlipId);
+    if (threads.isEmpty()) {
+      return;
+    }
+    boolean collapse = false;
+    for (HTMLElement thread : threads) {
+      if (!thread.classList.contains("j2cl-read-thread-collapsed")) {
+        collapse = true;
+        break;
+      }
+    }
+    for (HTMLElement thread : threads) {
+      HTMLElement button = (HTMLElement) thread.querySelector(".j2cl-read-thread-toggle");
+      if (button == null) {
+        continue;
+      }
+      boolean currentlyCollapsed = thread.classList.contains("j2cl-read-thread-collapsed");
+      if (currentlyCollapsed != collapse) {
+        toggleThread(thread, button);
+      }
+    }
+  }
+
+  private List<HTMLElement> inlineThreadsForParent(String parentBlipId) {
+    List<HTMLElement> matches = new ArrayList<>();
+    HTMLElement surface = renderedSurface != null ? renderedSurface : findExistingSurface();
+    if (surface == null) {
+      return matches;
+    }
+    NodeList<Element> threads = surface.querySelectorAll(".inline-thread[data-parent-blip-id]");
+    for (int index = 0; index < threads.length; index++) {
+      HTMLElement thread = (HTMLElement) threads.item(index);
+      if (thread != null && parentBlipId.equals(thread.getAttribute("data-parent-blip-id"))) {
+        matches.add(thread);
+      }
+    }
+    return matches;
   }
 
   private void onBlipFocus(Event event) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -2496,8 +2496,13 @@ public final class J2clReadSurfaceDomRenderer {
     HTMLElement button = (HTMLElement) DomGlobal.document.createElement("button");
     button.className = "j2cl-read-thread-toggle";
     button.setAttribute("type", "button");
-    button.setAttribute("tabindex", "-1");
-    button.setAttribute("aria-hidden", "true");
+    // SSR-rendered threads lack data-parent-blip-id; their parent is a legacy
+    // div.blip that does not emit wave-blip-thread-toggle-requested, so the
+    // button is the only toggle affordance and must remain visible/focusable.
+    if (thread.hasAttribute("data-parent-blip-id")) {
+      button.setAttribute("tabindex", "-1");
+      button.setAttribute("aria-hidden", "true");
+    }
     button.setAttribute("aria-controls", thread.getAttribute("id"));
     button.setAttribute("aria-expanded", "true");
     button.setAttribute("aria-label", "Collapse " + label);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1036,7 +1036,10 @@ public final class J2clReadSurfaceDomRenderer {
     renderedConversationManifest = conversationManifest;
     renderedBlips.clear();
     enhanceSurface(renderedSurface);
-    restoreCollapsedThreads(previouslyCollapsedThreadIds);
+    // Do NOT call restoreCollapsedThreads here: on the append path the
+    // existing DOM is reused, so threads retain their collapsed state
+    // through enhanceSurface. Calling toggleThread on already-collapsed
+    // threads would expand them.
     restoreFocusedBlipById(focusedBlipId);
     restoreScrollAnchor(scrollAnchorBlipId, scrollAnchorTop);
     notifyReadSurfaceRendered();

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1036,6 +1036,7 @@ public final class J2clReadSurfaceDomRenderer {
     renderedConversationManifest = conversationManifest;
     renderedBlips.clear();
     enhanceSurface(renderedSurface);
+    collapseAppendedThreadsForCollapsedParents(renderedSurface);
     // Do NOT call restoreCollapsedThreads here: on the append path the
     // existing DOM is reused, so threads retain their collapsed state
     // through enhanceSurface. Calling toggleThread on already-collapsed
@@ -1046,9 +1047,36 @@ public final class J2clReadSurfaceDomRenderer {
     if (!requestReachablePlaceholderAfterRender()) {
       schedulePostLayoutPlaceholderCheckIfNeeded();
     }
-    pruneStaleInFlightOnRebuild();
+    // The append path reuses existing blip nodes, so keep mark-read
+    // in-flight gates. Clearing them here would let evaluateDwellTimers
+    // send duplicate mark-read RPCs for already-visible unread blips.
     evaluateDwellTimers();
     return true;
+  }
+
+  private void collapseAppendedThreadsForCollapsedParents(HTMLElement surface) {
+    NodeList<Element> collapsedParents =
+        surface.querySelectorAll("[data-blip-id][data-thread-collapsed='true']");
+    for (int i = 0; i < collapsedParents.length; i++) {
+      Element parent = collapsedParents.item(i);
+      if (parent == null) {
+        continue;
+      }
+      String parentId = parent.getAttribute("data-blip-id");
+      if (parentId == null || parentId.isEmpty()) {
+        continue;
+      }
+      List<HTMLElement> threads = inlineThreadsForParent(parentId);
+      for (HTMLElement thread : threads) {
+        if (thread == null || thread.classList.contains("j2cl-read-thread-collapsed")) {
+          continue;
+        }
+        HTMLElement button = (HTMLElement) thread.querySelector(".j2cl-read-thread-toggle");
+        if (button != null) {
+          toggleThread(thread, button);
+        }
+      }
+    }
   }
 
   private boolean isRenderedWindowPrefix(List<J2clReadWindowEntry> entries) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1034,6 +1034,7 @@ public final class J2clReadSurfaceDomRenderer {
         Collections.unmodifiableList(new ArrayList<J2clReadWindowEntry>(effectiveEntries));
     renderedLiveBlips = Collections.<J2clReadBlip>emptyList();
     renderedConversationManifest = conversationManifest;
+    renderedBlips.clear();
     enhanceSurface(renderedSurface);
     restoreCollapsedThreads(previouslyCollapsedThreadIds);
     restoreFocusedBlipById(focusedBlipId);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -2319,6 +2319,32 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void appendingSubmittedReplyWindowEntryPreservesExistingBlipNode() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clReadWindowEntry root =
+        J2clReadWindowEntry.loaded("blip:b+root", 30L, 36L, "b+root", "Root text");
+    J2clReadWindowEntry reply =
+        J2clReadWindowEntry.loaded(
+            "blip:b+reply", 36L, 37L, "b+reply", "Submitted reply", "b+root", "t+reply");
+
+    Assert.assertTrue(renderer.renderWindow(Arrays.asList(root)));
+    HTMLElement rootNode = blip(host, "b+root");
+    rootNode.focus();
+
+    Assert.assertTrue(renderer.renderWindow(Arrays.asList(root, reply)));
+
+    Assert.assertSame(
+        "post-submit append must not rebuild already-rendered blips",
+        rootNode,
+        blip(host, "b+root"));
+    Assert.assertEquals(rootNode, DomGlobal.document.activeElement);
+    Assert.assertEquals("reply", blip(host, "b+reply").getAttribute("data-blip-depth"));
+    Assert.assertEquals("1", blip(host, "b+root").getAttribute("reply-count"));
+  }
+
+  @Test
   public void renderWindowPlaceholderUpgradeToLoadedAttachmentReplacesRenderedNodes() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -1004,6 +1004,32 @@ public class J2clReadSurfaceDomRendererTest {
     }
   }
 
+  private static void addMarkBlipReadInFlightForTest(
+      J2clReadSurfaceDomRenderer renderer, String blipId) {
+    try {
+      markBlipReadInFlightForTest(renderer).add(blipId);
+    } catch (Exception e) {
+      throw new AssertionError("failed to seed mark-read in-flight state", e);
+    }
+  }
+
+  private static boolean markBlipReadInFlightContainsForTest(
+      J2clReadSurfaceDomRenderer renderer, String blipId) {
+    try {
+      return markBlipReadInFlightForTest(renderer).contains(blipId);
+    } catch (Exception e) {
+      throw new AssertionError("failed to read mark-read in-flight state", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static java.util.Set<String> markBlipReadInFlightForTest(
+      J2clReadSurfaceDomRenderer renderer) throws Exception {
+    Field field = J2clReadSurfaceDomRenderer.class.getDeclaredField("markBlipReadInFlight");
+    field.setAccessible(true);
+    return (java.util.Set<String>) field.get(renderer);
+  }
+
   @Test
   public void collapsingWithoutFocusedBlipSanitizesHiddenTabStop() {
     assumeBrowserDom();
@@ -2354,6 +2380,89 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertEquals(rootNode, DomGlobal.document.activeElement);
     Assert.assertEquals("reply", blip(host, "b+reply").getAttribute("data-blip-depth"));
     Assert.assertEquals("1", blip(host, "b+root").getAttribute("reply-count"));
+  }
+
+  @Test
+  public void appendingSiblingThreadKeepsCollapsedParentState() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clReadWindowEntry root =
+        J2clReadWindowEntry.loaded("blip:b+root", 30L, 36L, "b+root", "Root text");
+    J2clReadWindowEntry firstReply =
+        J2clReadWindowEntry.loadedWithMetadata(
+            "blip:b+first",
+            36L,
+            37L,
+            "b+first",
+            "First reply",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            /* authorId= */ "",
+            /* authorDisplayName= */ "",
+            /* lastModifiedTimeMillis= */ 0L,
+            /* parentBlipId= */ "b+root",
+            /* threadId= */ "t+first",
+            /* unread= */ false,
+            /* hasMention= */ false);
+    J2clReadWindowEntry secondReply =
+        J2clReadWindowEntry.loadedWithMetadata(
+            "blip:b+second",
+            37L,
+            38L,
+            "b+second",
+            "Second reply",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            /* authorId= */ "",
+            /* authorDisplayName= */ "",
+            /* lastModifiedTimeMillis= */ 0L,
+            /* parentBlipId= */ "b+root",
+            /* threadId= */ "t+second",
+            /* unread= */ false,
+            /* hasMention= */ false);
+
+    Assert.assertTrue(renderer.renderWindow(Arrays.asList(root, firstReply)));
+    dispatchThreadToggle(blip(host, "b+root"), "b+root");
+    Assert.assertEquals("true", blip(host, "b+root").getAttribute("data-thread-collapsed"));
+
+    Assert.assertTrue(renderer.renderWindow(Arrays.asList(root, firstReply, secondReply)));
+
+    HTMLElement secondThread =
+        (HTMLElement) host.querySelector(".inline-thread[data-thread-id='b+root::t+second']");
+    Assert.assertNotNull(secondThread);
+    Assert.assertTrue(secondThread.classList.contains("j2cl-read-thread-collapsed"));
+    Assert.assertEquals("true", secondThread.getAttribute("data-j2cl-thread-collapsed"));
+    Assert.assertEquals("2", blip(host, "b+root").getAttribute("reply-count"));
+  }
+
+  @Test
+  public void appendingWindowEntryKeepsMarkReadInFlightGate() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clReadWindowEntry root =
+        J2clReadWindowEntry.loaded("blip:b+root", 30L, 36L, "b+root", "Root text");
+    J2clReadWindowEntry reply =
+        J2clReadWindowEntry.loadedWithMetadata(
+            "blip:b+reply",
+            36L,
+            37L,
+            "b+reply",
+            "Submitted reply",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            /* authorId= */ "",
+            /* authorDisplayName= */ "",
+            /* lastModifiedTimeMillis= */ 0L,
+            /* parentBlipId= */ "b+root",
+            /* threadId= */ "t+reply",
+            /* unread= */ false,
+            /* hasMention= */ false);
+
+    Assert.assertTrue(renderer.renderWindow(Arrays.asList(root)));
+    addMarkBlipReadInFlightForTest(renderer, "b+root");
+
+    Assert.assertTrue(renderer.renderWindow(Arrays.asList(root, reply)));
+
+    Assert.assertTrue(markBlipReadInFlightContainsForTest(renderer, "b+root"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -1087,6 +1087,34 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void blipChevronEventTogglesInlineRepliesInPlace() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    host.innerHTML =
+        "<div class=\"wave-content\">"
+            + "<div class=\"thread\" data-thread-id=\"t+root\">"
+            + "<wave-blip data-blip-id=\"b+root\" reply-count=\"1\">Root</wave-blip>"
+            + "<div class=\"inline-thread\" data-thread-id=\"t+inline\" data-parent-blip-id=\"b+root\">"
+            + "<wave-blip data-blip-id=\"b+reply\">Reply</wave-blip>"
+            + "</div>"
+            + "</div></div>";
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+
+    Assert.assertTrue(renderer.enhanceExistingSurface());
+    HTMLElement root = blip(host, "b+root");
+    HTMLElement thread =
+        (HTMLElement) host.querySelector(".inline-thread[data-thread-id='t+inline']");
+
+    dispatchThreadToggle(root, "b+root");
+    Assert.assertTrue(thread.classList.contains("j2cl-read-thread-collapsed"));
+    Assert.assertEquals("true", root.getAttribute("data-thread-collapsed"));
+
+    dispatchThreadToggle(root, "b+root");
+    Assert.assertFalse(thread.classList.contains("j2cl-read-thread-collapsed"));
+    Assert.assertFalse(root.hasAttribute("data-thread-collapsed"));
+  }
+
+  @Test
   public void collapsingFocusedThreadMovesToNearestFollowingVisibleBlip() {
     assumeBrowserDom();
     HTMLDivElement host = createThreadedHost();
@@ -3221,6 +3249,17 @@ public class J2clReadSurfaceDomRendererTest {
     KeyboardEventInit init = KeyboardEventInit.create();
     init.setKey(key);
     target.dispatchEvent(new KeyboardEvent("keydown", init));
+  }
+
+  private static void dispatchThreadToggle(HTMLElement target, String blipId) {
+    jsinterop.base.JsPropertyMap<Object> detail = jsinterop.base.JsPropertyMap.of();
+    detail.set("blipId", blipId);
+    elemental2.dom.CustomEventInit<Object> init = elemental2.dom.CustomEventInit.create();
+    init.setBubbles(true);
+    init.setComposed(true);
+    init.setDetail(detail);
+    target.dispatchEvent(
+        new elemental2.dom.CustomEvent<Object>("wave-blip-thread-toggle-requested", init));
   }
 
   // ----------------------------------------------------------------------

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -2326,8 +2326,20 @@ public class J2clReadSurfaceDomRendererTest {
     J2clReadWindowEntry root =
         J2clReadWindowEntry.loaded("blip:b+root", 30L, 36L, "b+root", "Root text");
     J2clReadWindowEntry reply =
-        J2clReadWindowEntry.loaded(
-            "blip:b+reply", 36L, 37L, "b+reply", "Submitted reply", "b+root", "t+reply");
+        J2clReadWindowEntry.loadedWithMetadata(
+            "blip:b+reply",
+            36L,
+            37L,
+            "b+reply",
+            "Submitted reply",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            /* authorId= */ "",
+            /* authorDisplayName= */ "",
+            /* lastModifiedTimeMillis= */ 0L,
+            /* parentBlipId= */ "b+root",
+            /* threadId= */ "t+reply",
+            /* unread= */ false,
+            /* hasMention= */ false);
 
     Assert.assertTrue(renderer.renderWindow(Arrays.asList(root)));
     HTMLElement rootNode = blip(host, "b+root");

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
@@ -182,6 +182,10 @@ public class J2clRichContentDeltaFactoryTest {
     Assert.assertTrue(
         "reply blip must appear once in manifest and once as the new document",
         countOccurrences(deltaJson, "b+seedA") >= 2);
+    Assert.assertEquals(
+        "manifest append should retain existing trailing blips exactly once",
+        1,
+        countOccurrences(deltaJson, "{\"5\":2}"));
   }
 
   @Test

--- a/wave/config/changelog.d/2026-05-04-j2cl-inline-thread-chevron-parity.json
+++ b/wave/config/changelog.d/2026-05-04-j2cl-inline-thread-chevron-parity.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-05-04-j2cl-inline-thread-chevron-parity",
+  "version": "J2CL parity",
+  "date": "2026-05-04",
+  "title": "J2CL inline reply chevrons match GWT",
+  "summary": "Inline reply controls in the J2CL wave view now expand and collapse replies in place instead of navigating away or showing stray per-thread plus controls.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Changes the compact reply chevron to request inline thread expand/collapse instead of shell depth navigation.",
+        "Hides the generated per-thread plus/minus button from layout so the visible reply affordance lives on the parent blip like the GWT view.",
+        "Adds regression coverage for inline-thread toggle dispatch and rich reply manifest trailing-retain placement."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes #1200.

This narrows the J2CL inline reply thread behavior to match the GWT wave view more closely:

- the parent blip reply chevron now requests inline expand/collapse instead of shell depth navigation;
- the read renderer handles that event by toggling the inline threads for the parent blip in place;
- the generated per-thread `+/-` collapse button stays in the DOM for keyboard/test compatibility but is visually hidden so it no longer appears as a stray inert plus beside each blip/thread;
- regression coverage locks the Lit event contract, renderer in-place toggle behavior, and rich reply manifest trailing retain count.

## Verification

- `git diff --check`
- `cd j2cl/lit && npm test -- --files test/wave-blip.test.js` — 38 passed
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py`
- `sbt --batch "testOnly org.waveprotocol.box.j2cl.read.J2clReadSurfaceDomRendererTest org.waveprotocol.box.j2cl.richtext.J2clRichContentDeltaFactoryTest"` — compiled main/test Java; root JUnit discovered no J2CL browser tests
- `sbt --batch j2clLitTest j2clLitBuild` — 823 Lit tests passed and Lit build completed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inline reply chevrons now request expand/collapse in place (no navigation) and use “Expand”/“Collapse” ARIA/tooltip text.
  * Legacy per-thread plus/minus controls are hidden for renderer-managed threads (SSR-injected controls remain focusable).

* **Performance**
  * Surface rendering appends trailing replies when possible, preserving existing blip nodes and focus.

* **Tests**
  * Added regression tests for inline-thread toggle behavior and preserved rendering when appending replies.

* **Documentation**
  * Changelog entry added describing the chevron parity fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->