### PR TITLE
Fix J2CL inline reply target and URL parity

### DIFF
--- a/docs/superpowers/plans/2026-05-04-j2cl-inline-reply-url-parity.md
+++ b/docs/superpowers/plans/2026-05-04-j2cl-inline-reply-url-parity.md
@@ -1,0 +1,80 @@
+# J2CL Inline Reply And URL Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Make J2CL reply submissions target the same blip/thread the user clicked, preserve existing inline-blip rendering behavior, and emit GWT-compatible wave hash URLs while keeping the current J2CL query route.
+
+**Architecture:** Keep the renderer's existing inline anchor support intact. Fix the submit boundary by carrying target-specific manifest insertion offsets in `J2clSidecarWriteSession`, then pass the inline composer's `reply-target-blip-id` to the controller so the delta factory inserts replies under the correct manifest blip. Keep J2CL's query params for route state, but append the GWT-style encoded WaveRef hash so copied URLs resemble GWT and remain hash-deeplink compatible.
+
+**Tech Stack:** Java J2CL, Lit custom elements, SBT J2CL tasks, GitHub Issues workflow.
+
+---
+
+## Root Cause Summary
+
+- `J2clComposeSurfaceView.openInlineComposer(...)` mounts `<wavy-composer>` on the clicked `wave-blip`, but `reply-submit` calls only `listener.onReplySubmitted(...)` or `listener.onReplySubmittedWithComponents(...)`.
+- `J2clComposeSurfaceController.submitReply()` snapshots the global `writeSession`, so every inline composer submits to the default reply target, usually `b+root`, instead of the blip that opened the composer.
+- `J2clSelectedWaveProjector.buildWriteSession(...)` currently stores only one manifest insert position: the default reply target's position. Even if the view passes a per-blip target, the controller needs target-specific insert offsets to create a valid conversation-manifest insertion.
+- J2CL already parses GWT hash WaveRefs as legacy input, but `J2clSidecarRouteCodec.toUrl(...)` emits only query params, so visible URLs do not match GWT's hash-based WaveRef representation.
+
+## Files
+
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarWriteSession.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java`
+- Modify: `j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java`
+- Test: `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java`
+- Test: `j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java`
+- Test: `j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodecTest.java`
+- Create: `wave/config/changelog.d/2026-05-04-j2cl-inline-reply-url-parity.json`
+
+## Task 1: Add Target-Specific Write Session Coverage
+
+- [x] Add a failing test in `J2clSelectedWaveProjectorTest` proving a write session built from a manifest with root and child entries can produce a child-targeted session whose `replyTargetBlipId` and `replyManifestInsertPosition` match the child entry.
+- [x] Expected red result: `J2clSidecarWriteSession` has no target-specific retargeting API.
+- [x] Implement `J2clSidecarWriteSession` support for immutable per-blip reply insert positions and item count.
+- [x] Add `forReplyTarget(String replyTargetBlipId)` that returns the same session when the target is blank/current, or a copied session with the target's manifest insert position when known.
+- [x] Populate the per-blip insert-position map in `J2clSelectedWaveProjector.buildWriteSession(...)` whenever the update carries a fresh coupled manifest.
+- [x] Preserve previous behavior for legacy constructors and live blip-only updates without a fresh manifest.
+
+## Task 2: Submit Inline Replies To The Actual Composer Target
+
+- [x] Add failing controller coverage using a capturing delta factory: with default write session target `b+root`, call a new target-aware reply submit for `b+child` and assert the captured session uses `b+child`.
+- [x] Add the same red-path coverage for component-rich submissions so formatting and target selection are both preserved.
+- [x] Extend `J2clComposeSurfaceController.Listener` with default target-aware overloads for plain and component reply submissions.
+- [x] Update `J2clComposeSurfaceController.start()` to forward the target-aware overloads to controller methods.
+- [x] Add controller methods that normalize the target id, retarget the current `writeSession` via `forReplyTarget(...)`, and submit using that session only for this request.
+- [x] Update `J2clComposeSurfaceView.openInlineComposer(...)` so `reply-submit` passes the composer's `reply-target-blip-id` to the listener.
+- [x] Keep the empty/root composer path using the existing default write session target.
+
+## Task 3: Preserve Inline Blip Rendering Semantics
+
+- [x] Run or inspect existing renderer tests that cover `<reply id="..."></reply>` anchors and slotted inline threads.
+- [x] Add no production renderer change unless a test shows the renderer no longer mounts matching thread ids into `slot="blip-extension"` under the parent blip.
+- [x] If renderer coverage fails, fix only the anchor/thread matching logic; do not change fallback thread rendering.
+
+## Task 4: Emit GWT-Compatible Wave Hash URLs
+
+- [x] Add failing route codec tests showing a selected wave URL includes both the existing J2CL query route and a GWT-style hash: `?q=...&wave=...#example.com/w+abc123`.
+- [x] Add depth coverage so `depth=b+leaf` appends hash metadata compatible with `ThreadNavigationHistory`: `#example.com/w+abc123&focus=b%2Bleaf&slide-nav=1`.
+- [x] Update `J2clSidecarRouteCodec.toUrl(...)` to append the hash only when `selectedWaveId` is present.
+- [x] Keep `parse(...)` query precedence over hash unchanged, so existing J2CL links and legacy GWT hash links still load safely.
+- [x] Update route-controller expectations that assert pushed/replaced URLs.
+
+## Task 5: Changelog, Verification, And PR
+
+- [x] Add a changelog fragment describing J2CL inline reply target and URL parity.
+- [x] Run `python3 scripts/assemble-changelog.py`.
+- [x] Run `python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`.
+- [x] Run `git diff --check`.
+- [x] Run `sbt --batch j2clSearchBuild`.
+- [x] Run `sbt --batch j2clLitTest j2clLitBuild`.
+- [x] Self-review the diff against the user-reported screenshots: reply under clicked blip, no top insertion from wrong target, existing inline anchor rendering preserved, GWT-style hash visible in URL.
+- [ ] Commit, push, create PR, update the GitHub issue with worktree, plan, verification, commit, and PR URL, then monitor PR review/CI until merged.
+
+## Self-Review
+
+- Spec coverage: The plan covers reply target correctness, inline-blip rendering evidence, and URL representation parity. It does not attempt unrelated UI chrome fixes in this lane.
+- Placeholder scan: No task depends on TBD behavior; all file targets and verification commands are explicit.
+- Type consistency: The proposed target-aware listener overloads and `forReplyTarget(String)` API are named consistently across view, controller, and write-session tasks.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -95,6 +95,10 @@ public final class J2clComposeSurfaceController {
 
     void onReplySubmitted(String draft);
 
+    default void onReplySubmitted(String draft, String replyTargetBlipId) {
+      onReplySubmitted(draft);
+    }
+
     /**
      * J-UI-5 (#1083, R-5.1 + R-5.7): the user submitted a reply from the
      * inline rich-text composer. {@code components} carries the
@@ -120,6 +124,19 @@ public final class J2clComposeSurfaceController {
         }
       }
       onReplySubmitted(builder.toString());
+    }
+
+    default void onReplySubmittedWithComponents(
+        List<SubmittedComponent> components, String replyTargetBlipId) {
+      StringBuilder builder = new StringBuilder();
+      if (components != null) {
+        for (SubmittedComponent component : components) {
+          if (component != null && component.getText() != null) {
+            builder.append(component.getText());
+          }
+        }
+      }
+      onReplySubmitted(builder.toString(), replyTargetBlipId);
     }
 
     void onAttachmentFilesSelected(List<AttachmentFileSelection> selections);
@@ -784,8 +801,20 @@ public final class J2clComposeSurfaceController {
           }
 
           @Override
+          public void onReplySubmitted(String draft, String replyTargetBlipId) {
+            J2clComposeSurfaceController.this.onReplySubmitted(draft, replyTargetBlipId);
+          }
+
+          @Override
           public void onReplySubmittedWithComponents(List<SubmittedComponent> components) {
             J2clComposeSurfaceController.this.onReplySubmittedWithComponents(components);
+          }
+
+          @Override
+          public void onReplySubmittedWithComponents(
+              List<SubmittedComponent> components, String replyTargetBlipId) {
+            J2clComposeSurfaceController.this.onReplySubmittedWithComponents(
+                components, replyTargetBlipId);
           }
 
           @Override
@@ -1016,9 +1045,13 @@ public final class J2clComposeSurfaceController {
   }
 
   public void onReplySubmitted(String draft) {
+    onReplySubmitted(draft, null);
+  }
+
+  public void onReplySubmitted(String draft, String replyTargetBlipId) {
     replyDraft = normalizeDraft(draft);
     pendingSubmittedComponents = null;
-    submitReply();
+    submitReply(replyTargetBlipId);
   }
 
   /**
@@ -1030,9 +1063,14 @@ public final class J2clComposeSurfaceController {
    * the whole draft to a single annotation.
    */
   public void onReplySubmittedWithComponents(List<SubmittedComponent> components) {
+    onReplySubmittedWithComponents(components, null);
+  }
+
+  public void onReplySubmittedWithComponents(
+      List<SubmittedComponent> components, String replyTargetBlipId) {
     if (components == null) {
       pendingSubmittedComponents = null;
-      onReplySubmitted("");
+      onReplySubmitted("", replyTargetBlipId);
       return;
     }
     StringBuilder plainBuilder = new StringBuilder();
@@ -1043,7 +1081,7 @@ public final class J2clComposeSurfaceController {
     }
     replyDraft = normalizeDraft(plainBuilder.toString());
     pendingSubmittedComponents = new ArrayList<SubmittedComponent>(components);
-    submitReply();
+    submitReply(replyTargetBlipId);
   }
 
   public boolean onToolbarAction(J2clDailyToolbarAction action) {
@@ -2113,11 +2151,16 @@ public final class J2clComposeSurfaceController {
   }
 
   private void submitReply() {
+    submitReply(null);
+  }
+
+  private void submitReply(String replyTargetBlipId) {
     if (signedOut || replySubmitting) {
       render();
       return;
     }
-    if (writeSession == null || isEmpty(writeSession.getSelectedWaveId())) {
+    J2clSidecarWriteSession submitSession = sessionForReplyTarget(replyTargetBlipId);
+    if (submitSession == null || isEmpty(submitSession.getSelectedWaveId())) {
       replyStatusText = "";
       replyErrorText =
           hasSelectedWaveContext()
@@ -2146,7 +2189,7 @@ public final class J2clComposeSurfaceController {
     final String submittedDraft = replyDraft;
     final String submittedAnnotationCommandId = annotationCommandId;
     final int generation = ++replyGeneration;
-    final J2clSidecarWriteSession submitSession = writeSession;
+    final J2clSidecarWriteSession capturedSubmitSession = submitSession;
     render();
     gateway.fetchRootSessionBootstrap(
         bootstrap -> {
@@ -2159,7 +2202,7 @@ public final class J2clComposeSurfaceController {
             request =
                 deltaFactory.createReplyRequest(
                     bootstrap.getAddress(),
-                    submitSession,
+                    capturedSubmitSession,
                     submittedDraft,
                     buildDocument(submittedDraft, true, submittedAnnotationCommandId, true));
           } catch (RuntimeException e) {
@@ -2171,10 +2214,18 @@ public final class J2clComposeSurfaceController {
           gateway.submit(
               bootstrap,
               request,
-              response -> handleReplyResponse(generation, submitSession, request, response),
+              response -> handleReplyResponse(generation, capturedSubmitSession, request, response),
               error -> handleReplyFailure(generation, error));
         },
         error -> handleReplyFailure(generation, error));
+  }
+
+  private J2clSidecarWriteSession sessionForReplyTarget(String replyTargetBlipId) {
+    if (writeSession == null) {
+      return null;
+    }
+    String normalizedTarget = replyTargetBlipId == null ? "" : replyTargetBlipId.trim();
+    return normalizedTarget.isEmpty() ? writeSession : writeSession.forReplyTarget(normalizedTarget);
   }
 
   private void handleReplyResponse(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -517,9 +517,9 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           List<J2clComposeSurfaceController.SubmittedComponent> components =
               decodeSubmittedComponents(event);
           if (components.isEmpty()) {
-            listener.onReplySubmitted(propertyString(composer, "draft"));
+            listener.onReplySubmitted(propertyString(composer, "draft"), key);
           } else {
-            listener.onReplySubmittedWithComponents(components);
+            listener.onReplySubmittedWithComponents(components, key);
           }
         });
     composer.addEventListener(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -415,6 +415,8 @@ public final class J2clSelectedWaveProjector {
     }
     int replyManifestInsertPosition = -1;
     int replyManifestItemCount = -1;
+    Map<String, Integer> replyManifestInsertPositionsByBlipId =
+        Collections.<String, Integer>emptyMap();
     // Rendering may reuse a cached manifest on live blip-only updates, but submit offsets must
     // only come from a manifest coupled to the same base version/hash as the write session.
     SidecarConversationManifest writeManifest =
@@ -422,16 +424,19 @@ public final class J2clSelectedWaveProjector {
             ? manifestFromUpdate
             : SidecarConversationManifest.empty();
     if (!writeManifest.isEmpty()) {
+      replyManifestInsertPositionsByBlipId = replyManifestInsertPositionsByBlipId(writeManifest);
       SidecarConversationManifest.Entry replyTarget = writeManifest.findByBlipId(replyTargetBlipId);
       if (replyTarget != null) {
         replyManifestInsertPosition = replyTarget.getReplyInsertPosition();
         replyManifestItemCount = writeManifest.getItemCount();
       }
-    } else if (!updateHasCoupledPair
-        && previousWriteSession != null
-        && replyTargetBlipId.equals(previousWriteSession.getReplyTargetBlipId())) {
-      replyManifestInsertPosition = previousWriteSession.getReplyManifestInsertPosition();
-      replyManifestItemCount = previousWriteSession.getReplyManifestItemCount();
+    } else if (!updateHasCoupledPair && previousWriteSession != null) {
+      J2clSidecarWriteSession previousForTarget =
+          previousWriteSession.forReplyTarget(replyTargetBlipId);
+      replyManifestInsertPosition = previousForTarget.getReplyManifestInsertPosition();
+      replyManifestItemCount = previousForTarget.getReplyManifestItemCount();
+      replyManifestInsertPositionsByBlipId =
+          previousWriteSession.getReplyManifestInsertPositionsByBlipId();
     }
     return new J2clSidecarWriteSession(
         selectedWaveId,
@@ -441,7 +446,23 @@ public final class J2clSelectedWaveProjector {
         replyTargetBlipId,
         participantIds,
         replyManifestInsertPosition,
-        replyManifestItemCount);
+        replyManifestItemCount,
+        replyManifestInsertPositionsByBlipId);
+  }
+
+  private static Map<String, Integer> replyManifestInsertPositionsByBlipId(
+      SidecarConversationManifest manifest) {
+    if (manifest == null || manifest.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    Map<String, Integer> positions = new LinkedHashMap<String, Integer>();
+    for (SidecarConversationManifest.Entry entry : manifest.getOrderedEntries()) {
+      if (entry == null || entry.getBlipId().isEmpty() || entry.getReplyInsertPosition() < 0) {
+        continue;
+      }
+      positions.put(entry.getBlipId(), Integer.valueOf(entry.getReplyInsertPosition()));
+    }
+    return positions.isEmpty() ? Collections.<String, Integer>emptyMap() : positions;
   }
 
   private static J2clSelectedWaveViewportState projectViewportState(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodec.java
@@ -16,11 +16,22 @@ public final class J2clSidecarRouteCodec {
   }
 
   public static J2clSidecarRouteState parse(String search, String hash) {
+    String effectiveSearch = search;
+    String effectiveHash = hash;
+    if (effectiveSearch != null) {
+      int hashStart = effectiveSearch.indexOf('#');
+      if (hashStart >= 0) {
+        if (effectiveHash == null || effectiveHash.isEmpty()) {
+          effectiveHash = effectiveSearch.substring(hashStart);
+        }
+        effectiveSearch = effectiveSearch.substring(0, hashStart);
+      }
+    }
     String query = null;
     String selectedWaveId = null;
     String depthBlipId = null;
-    if (search != null && !search.isEmpty()) {
-      String trimmed = search.charAt(0) == '?' ? search.substring(1) : search;
+    if (effectiveSearch != null && !effectiveSearch.isEmpty()) {
+      String trimmed = effectiveSearch.charAt(0) == '?' ? effectiveSearch.substring(1) : effectiveSearch;
       if (!trimmed.isEmpty()) {
         String[] parts = trimmed.split("&");
         for (String part : parts) {
@@ -38,7 +49,7 @@ public final class J2clSidecarRouteCodec {
       }
     }
     if (selectedWaveId == null) {
-      selectedWaveId = decodeLegacyHashWaveValue(hash);
+      selectedWaveId = decodeLegacyHashWaveValue(effectiveHash);
     }
     return new J2clSidecarRouteState(query, selectedWaveId, depthBlipId);
   }
@@ -63,7 +74,19 @@ public final class J2clSidecarRouteCodec {
     if (state.getDepthBlipId() != null) {
       url.append("&depth=").append(encodeUriComponentSafe(state.getDepthBlipId()));
     }
+    appendGwtCompatibleHash(url, state);
     return url.toString();
+  }
+
+  private static void appendGwtCompatibleHash(StringBuilder url, J2clSidecarRouteState state) {
+    if (state == null || state.getSelectedWaveId() == null || state.getSelectedWaveId().isEmpty()) {
+      return;
+    }
+    url.append('#').append(state.getSelectedWaveId());
+    if (state.getDepthBlipId() != null && !state.getDepthBlipId().isEmpty()) {
+      url.append("&focus=").append(encodeUriComponentSafe(state.getDepthBlipId()));
+      url.append("&slide-nav=1");
+    }
   }
 
   private static String decodeQueryValue(String value) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarWriteSession.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarWriteSession.java
@@ -2,7 +2,9 @@ package org.waveprotocol.box.j2cl.search;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 public final class J2clSidecarWriteSession {
   private final String selectedWaveId;
@@ -13,6 +15,7 @@ public final class J2clSidecarWriteSession {
   private final List<String> participantIds;
   private final int replyManifestInsertPosition;
   private final int replyManifestItemCount;
+  private final Map<String, Integer> replyManifestInsertPositionsByBlipId;
 
   public J2clSidecarWriteSession(
       String selectedWaveId,
@@ -106,6 +109,28 @@ public final class J2clSidecarWriteSession {
       List<String> participantIds,
       int replyManifestInsertPosition,
       int replyManifestItemCount) {
+    this(
+        selectedWaveId,
+        channelId,
+        baseVersion,
+        historyHash,
+        replyTargetBlipId,
+        participantIds,
+        replyManifestInsertPosition,
+        replyManifestItemCount,
+        singletonReplyPosition(replyTargetBlipId, replyManifestInsertPosition));
+  }
+
+  public J2clSidecarWriteSession(
+      String selectedWaveId,
+      String channelId,
+      long baseVersion,
+      String historyHash,
+      String replyTargetBlipId,
+      List<String> participantIds,
+      int replyManifestInsertPosition,
+      int replyManifestItemCount,
+      Map<String, Integer> replyManifestInsertPositionsByBlipId) {
     this.selectedWaveId = selectedWaveId;
     this.channelId = channelId;
     this.baseVersion = baseVersion;
@@ -117,6 +142,11 @@ public final class J2clSidecarWriteSession {
             : Collections.unmodifiableList(new ArrayList<String>(participantIds));
     this.replyManifestInsertPosition = Math.max(-1, replyManifestInsertPosition);
     this.replyManifestItemCount = Math.max(-1, replyManifestItemCount);
+    this.replyManifestInsertPositionsByBlipId =
+        immutableReplyPositions(
+            replyManifestInsertPositionsByBlipId,
+            this.replyTargetBlipId,
+            this.replyManifestInsertPosition);
   }
 
   public String getSelectedWaveId() {
@@ -149,5 +179,61 @@ public final class J2clSidecarWriteSession {
 
   public int getReplyManifestItemCount() {
     return replyManifestItemCount;
+  }
+
+  public J2clSidecarWriteSession forReplyTarget(String replyTargetBlipId) {
+    String target = replyTargetBlipId == null ? "" : replyTargetBlipId.trim();
+    if (target.isEmpty() || target.equals(this.replyTargetBlipId)) {
+      return this;
+    }
+    Integer insertPosition = replyManifestInsertPositionsByBlipId.get(target);
+    int normalizedInsertPosition = insertPosition == null ? -1 : Math.max(-1, insertPosition.intValue());
+    int normalizedItemCount = normalizedInsertPosition >= 0 ? replyManifestItemCount : -1;
+    return new J2clSidecarWriteSession(
+        selectedWaveId,
+        channelId,
+        baseVersion,
+        historyHash,
+        target,
+        participantIds,
+        normalizedInsertPosition,
+        normalizedItemCount,
+        replyManifestInsertPositionsByBlipId);
+  }
+
+  Map<String, Integer> getReplyManifestInsertPositionsByBlipId() {
+    return replyManifestInsertPositionsByBlipId;
+  }
+
+  private static Map<String, Integer> singletonReplyPosition(String blipId, int insertPosition) {
+    if (blipId == null || blipId.isEmpty() || insertPosition < 0) {
+      return Collections.emptyMap();
+    }
+    Map<String, Integer> positions = new LinkedHashMap<String, Integer>();
+    positions.put(blipId, Integer.valueOf(insertPosition));
+    return positions;
+  }
+
+  private static Map<String, Integer> immutableReplyPositions(
+      Map<String, Integer> positions, String currentBlipId, int currentInsertPosition) {
+    Map<String, Integer> copy = new LinkedHashMap<String, Integer>();
+    if (positions != null) {
+      for (Map.Entry<String, Integer> entry : positions.entrySet()) {
+        if (entry == null || entry.getKey() == null || entry.getKey().isEmpty()) {
+          continue;
+        }
+        Integer value = entry.getValue();
+        if (value == null || value.intValue() < 0) {
+          continue;
+        }
+        copy.put(entry.getKey(), Integer.valueOf(value.intValue()));
+      }
+    }
+    if (currentBlipId != null && !currentBlipId.isEmpty() && currentInsertPosition >= 0) {
+      copy.put(currentBlipId, Integer.valueOf(currentInsertPosition));
+    }
+    return copy.isEmpty()
+        ? Collections.<String, Integer>emptyMap()
+        : Collections.unmodifiableMap(copy);
   }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -55,6 +55,60 @@ public class J2clComposeSurfaceControllerTest {
   }
 
   @Test
+  public void targetAwareReplySubmitUsesRequestedBlipSession() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    CapturingDeltaFactory factory = new CapturingDeltaFactory();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            factory,
+            waveId -> { },
+            waveId -> { });
+
+    controller.start();
+    controller.onWriteSessionChanged(writeSessionWithReplyTargets());
+    controller.onReplySubmitted("aa under 555", "b+child");
+
+    Assert.assertNotNull(factory.lastReplySession);
+    Assert.assertEquals("b+child", factory.lastReplySession.getReplyTargetBlipId());
+    Assert.assertEquals(6, factory.lastReplySession.getReplyManifestInsertPosition());
+    Assert.assertEquals(12, factory.lastReplySession.getReplyManifestItemCount());
+    Assert.assertEquals("aa under 555", factory.lastDraftText);
+  }
+
+  @Test
+  public void targetAwareComponentReplySubmitKeepsRequestedBlipSession() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    CapturingDeltaFactory factory = new CapturingDeltaFactory();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            factory,
+            waveId -> { },
+            waveId -> { });
+
+    controller.start();
+    controller.onWriteSessionChanged(writeSessionWithReplyTargets());
+    controller.onReplySubmittedWithComponents(
+        Arrays.asList(
+            J2clComposeSurfaceController.SubmittedComponent.text("plain "),
+            J2clComposeSurfaceController.SubmittedComponent.annotated(
+                "bold", "fontWeight", "bold")),
+        "b+child");
+
+    Assert.assertNotNull(factory.lastReplySession);
+    Assert.assertEquals("b+child", factory.lastReplySession.getReplyTargetBlipId());
+    Assert.assertEquals(6, factory.lastReplySession.getReplyManifestInsertPosition());
+    Assert.assertEquals(12, factory.lastReplySession.getReplyManifestItemCount());
+    Assert.assertEquals("plain bold", factory.lastDraftText);
+    Assert.assertEquals(2, factory.lastDocumentComponentCount);
+  }
+
+  @Test
   public void selectedWaveParticipantsRenderBeforeWriteSessionReady() {
     FakeGateway gateway = new FakeGateway();
     FakeView view = new FakeView();
@@ -4339,6 +4393,27 @@ public class J2clComposeSurfaceControllerTest {
         new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
   }
 
+  private static J2clSidecarWriteSession writeSessionWithReplyTargets() {
+    return new J2clSidecarWriteSession(
+        "example.com/w+1",
+        "chan-1",
+        44L,
+        "ABCD",
+        "b+root",
+        Arrays.asList("user@example.com"),
+        9,
+        12,
+        replyPositions("b+root", 9, "b+child", 6));
+  }
+
+  private static java.util.Map<String, Integer> replyPositions(
+      String firstBlipId, int firstPosition, String secondBlipId, int secondPosition) {
+    java.util.Map<String, Integer> positions = new java.util.LinkedHashMap<String, Integer>();
+    positions.put(firstBlipId, Integer.valueOf(firstPosition));
+    positions.put(secondBlipId, Integer.valueOf(secondPosition));
+    return positions;
+  }
+
   private static J2clComposeSurfaceController.AttachmentControllerFactory
       testAttachmentControllerFactory(FakeAttachmentTransport transport) {
     return (waveRef, domain, insertionCallback, stateChangeCallback) ->
@@ -4764,6 +4839,7 @@ public class J2clComposeSurfaceControllerTest {
     private List<String> lastAdditionalParticipants = Collections.emptyList();
     private String lastDraftText = null;
     private int lastDocumentComponentCount = -1;
+    private J2clSidecarWriteSession lastReplySession = null;
 
     @Override
     public J2clComposeSurfaceController.CreateWaveRequest createWaveRequest(
@@ -4792,7 +4868,11 @@ public class J2clComposeSurfaceControllerTest {
         J2clSidecarWriteSession session,
         String draftText,
         org.waveprotocol.box.j2cl.richtext.J2clComposerDocument document) {
-      throw new UnsupportedOperationException("Not needed by this test.");
+      lastReplySession = session;
+      lastDraftText = draftText;
+      lastDocumentComponentCount = componentCount(document);
+      return new SidecarSubmitRequest(
+          session.getSelectedWaveId() + "/~/conv+root", "{\"reply\":true}", session.getChannelId());
     }
 
     private static int componentCount(org.waveprotocol.box.j2cl.richtext.J2clComposerDocument document) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -2807,6 +2807,43 @@ public class J2clSelectedWaveProjectorTest {
   }
 
   @Test
+  public void writeSessionCanRetargetManifestInsertPositionToChildBlip() {
+    SidecarConversationManifest manifest =
+        SidecarConversationManifest.of(
+            Arrays.asList(
+                new SidecarConversationManifest.Entry("b+root", "", "root", 0, 0, 9),
+                new SidecarConversationManifest.Entry("b+child", "b+root", "t+child", 1, 0, 6)),
+            12);
+    SidecarSelectedWaveUpdate update =
+        new SidecarSelectedWaveUpdate(
+            1,
+            WAVELET_NAME,
+            true,
+            CHANNEL_ID,
+            44L,
+            "ABCD",
+            Arrays.asList("user@example.com"),
+            Arrays.asList(
+                new SidecarSelectedWaveDocument(
+                    "b+root", "user@example.com", 33L, 44L, "root content"),
+                new SidecarSelectedWaveDocument(
+                    "b+child", "user@example.com", 33L, 44L, "child content")),
+            null,
+            manifest);
+
+    J2clSidecarWriteSession writeSession =
+        J2clSelectedWaveProjector.project(WAVE_ID, null, update, null, 0).getWriteSession();
+    J2clSidecarWriteSession childSession = writeSession.forReplyTarget("b+child");
+
+    Assert.assertNotNull(writeSession);
+    Assert.assertEquals("b+root", writeSession.getReplyTargetBlipId());
+    Assert.assertEquals(9, writeSession.getReplyManifestInsertPosition());
+    Assert.assertEquals("b+child", childSession.getReplyTargetBlipId());
+    Assert.assertEquals(6, childSession.getReplyManifestInsertPosition());
+    Assert.assertEquals(12, childSession.getReplyManifestItemCount());
+  }
+
+  @Test
   public void writeSessionDoesNotReusePreviousManifestOffsetsWithFreshBasis() {
     SidecarConversationManifest previousManifest =
         SidecarConversationManifest.of(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteCodecTest.java
@@ -38,7 +38,7 @@ public class J2clSidecarRouteCodecTest {
     Assert.assertEquals("with:@", state.getQuery());
     Assert.assertEquals("example.com/w+abc123", state.getSelectedWaveId());
     Assert.assertEquals(
-        "?q=with%3A%40&wave=example.com%2Fw%2Babc123",
+        "?q=with%3A%40&wave=example.com%2Fw%2Babc123#example.com/w+abc123",
         J2clSidecarRouteCodec.toUrl(state));
   }
 
@@ -124,7 +124,9 @@ public class J2clSidecarRouteCodecTest {
         new J2clSidecarRouteState("with:@", "example.com/w+abc123", "b+leaf-blip");
     String url = J2clSidecarRouteCodec.toUrl(state);
     Assert.assertEquals(
-        "?q=with%3A%40&wave=example.com%2Fw%2Babc123&depth=b%2Bleaf-blip", url);
+        "?q=with%3A%40&wave=example.com%2Fw%2Babc123&depth=b%2Bleaf-blip"
+            + "#example.com/w+abc123&focus=b%2Bleaf-blip&slide-nav=1",
+        url);
   }
 
   @Test
@@ -145,7 +147,7 @@ public class J2clSidecarRouteCodecTest {
         new J2clSidecarRouteState("with:@", "example.com/w+abc123");
     String url = J2clSidecarRouteCodec.toUrl(state);
     Assert.assertEquals(
-        "?q=with%3A%40&wave=example.com%2Fw%2Babc123", url);
+        "?q=with%3A%40&wave=example.com%2Fw%2Babc123#example.com/w+abc123", url);
   }
 
   // --- J-UI-2 (#1080, R-4.5): folder + chip composition round-trips ---

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSidecarRouteControllerTest.java
@@ -21,7 +21,7 @@ public class J2clSidecarRouteControllerTest {
     controller.start();
 
     Assert.assertEquals(
-        Arrays.asList("?q=with%3A%40&wave=example.com%2Fw%2B1"),
+        Arrays.asList("?q=with%3A%40&wave=example.com%2Fw%2B1#example.com/w+1"),
         history.replacedUrls);
     Assert.assertEquals(
         Arrays.asList("start:with:@:example.com/w+1"),
@@ -62,7 +62,7 @@ public class J2clSidecarRouteControllerTest {
         new J2clSidecarRouteState("with:@", "example.com/w+1"), digest("example.com/w+1"), true);
 
     Assert.assertEquals(
-        Arrays.asList("?q=with%3A%40&wave=example.com%2Fw%2B1"),
+        Arrays.asList("?q=with%3A%40&wave=example.com%2Fw%2B1#example.com/w+1"),
         history.pushedUrls);
     Assert.assertEquals(
         Arrays.asList("example.com/w+1:example.com/w+1"),
@@ -118,7 +118,7 @@ public class J2clSidecarRouteControllerTest {
     controller.selectWave("example.com/w+2");
 
     Assert.assertEquals(
-        Arrays.asList("?q=with%3A%40&wave=example.com%2Fw%2B2"),
+        Arrays.asList("?q=with%3A%40&wave=example.com%2Fw%2B2#example.com/w+2"),
         history.pushedUrls);
     Assert.assertEquals(
         Arrays.asList("sync:example.com/w+2"),
@@ -141,7 +141,7 @@ public class J2clSidecarRouteControllerTest {
     controller.start();
 
     Assert.assertEquals(
-        Arrays.asList("?view=j2cl-root&q=with%3A%40&wave=example.com%2Fw%2B1"),
+        Arrays.asList("?view=j2cl-root&q=with%3A%40&wave=example.com%2Fw%2B1#example.com/w+1"),
         history.replacedUrls);
     Assert.assertEquals(
         Arrays.asList("start:with:@:example.com/w+1"),
@@ -164,7 +164,7 @@ public class J2clSidecarRouteControllerTest {
     controller.selectWave("example.com/w+2");
 
     Assert.assertEquals(
-        Arrays.asList("?view=j2cl-root&q=with%3A%40&wave=example.com%2Fw%2B2"),
+        Arrays.asList("?view=j2cl-root&q=with%3A%40&wave=example.com%2Fw%2B2#example.com/w+2"),
         history.pushedUrls);
     Assert.assertEquals(
         Arrays.asList("sync:example.com/w+2"),
@@ -217,8 +217,8 @@ public class J2clSidecarRouteControllerTest {
 
     Assert.assertEquals(
         Arrays.asList(
-            "?view=j2cl-root&q=with%3A%40&wave=example.com%2Fw%2B1",
-            "?view=j2cl-root&q=with%3A%40&wave=example.com%2Fw%2B2",
+            "?view=j2cl-root&q=with%3A%40&wave=example.com%2Fw%2B1#example.com/w+1",
+            "?view=j2cl-root&q=with%3A%40&wave=example.com%2Fw%2B2#example.com/w+2",
             "?view=j2cl-root&q=in%3Ainbox"),
         routeUrlObserver.urls);
   }
@@ -235,7 +235,7 @@ public class J2clSidecarRouteControllerTest {
     controller.start();
 
     Assert.assertEquals(
-        Arrays.asList("?view=j2cl-root&q=in%3Ainbox&wave=example.com%2Fw%2B1"),
+        Arrays.asList("?view=j2cl-root&q=in%3Ainbox&wave=example.com%2Fw%2B1#example.com/w+1"),
         history.replacedUrls);
     Assert.assertEquals(
         Arrays.asList("start:in:inbox:example.com/w+1"),

--- a/wave/config/changelog.d/2026-05-04-j2cl-inline-reply-url-parity.json
+++ b/wave/config/changelog.d/2026-05-04-j2cl-inline-reply-url-parity.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-05-04-j2cl-inline-reply-url-parity",
+  "version": "J2CL parity",
+  "date": "2026-05-04",
+  "title": "J2CL inline replies target the clicked blip",
+  "summary": "Inline reply submissions in the J2CL wave view now use the blip that opened the composer and J2CL wave URLs include a GWT-compatible WaveRef hash.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Passes the inline composer's target blip through the reply submit path so replies are inserted under the clicked blip instead of the default root target.",
+        "Carries per-blip conversation-manifest insert positions in the write session so target-specific replies keep the correct thread ordering.",
+        "Adds a GWT-compatible hash WaveRef to J2CL route URLs while preserving the existing query route and legacy hash parsing."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Fixes inline reply submissions so the clicked blip target is passed from the mounted J2CL composer through the controller and into the write session.
- Carries per-blip conversation-manifest insert positions so replies can be inserted under the correct blip/thread instead of falling back to the root/default target.
- Appends a GWT-compatible WaveRef hash to J2CL URLs while preserving the existing query route and legacy hash parsing.

Closes #1202.
Updates #904.

## Verification
- Red proof: `sbt --batch j2clSearchTest` initially failed on missing `forReplyTarget`, target-aware reply submit overloads, and target-aware write-session constructor.
- `sbt --batch j2clSearchTest`
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`
- `git diff --check`
- `sbt --batch j2clSearchBuild`
- `sbt --batch j2clLitTest` (823 passed, 0 failed)
- `sbt --batch j2clLitBuild`

Note: no Claude Code review used per current instruction; relying on self-review and PR review comments.