### PR TITLE
Fix J2CL wave blip click and reply parity

### DIFF
--- a/docs/superpowers/plans/2026-05-07-issue-1205-wave-blip-ui.md
+++ b/docs/superpowers/plans/2026-05-07-issue-1205-wave-blip-ui.md
@@ -1,0 +1,28 @@
+# Issue 1205: J2CL Wave Blip UI Parity
+
+## Goal
+
+Fix the J2CL read surface regressions reported on 2026-05-07:
+
+- Clicking a blip should focus it and mark it read without making the page jump.
+- Unread blips should be visually distinguishable in the blip body, not only by nav-row counts.
+- Missing author metadata should not render avatar initials as `?`.
+- Inline-thread controls should only be visible when they are the real toggle affordance, with clear labels/tooltips.
+- Replies at the inline-depth limit should become regular sibling replies instead of failing server validation.
+
+## Plan
+
+1. Add focused regression coverage around click-to-read, thread toggle labels/visibility, and reply depth fallback.
+2. Change the read renderer click path to focus with `preventScroll` and keep immediate mark-read behavior.
+3. Update thread toggle rendering to hide parent-owned duplicate buttons and use chevron glyphs plus matching `title`/`aria-label` on visible controls.
+4. Update `<wave-blip>` styling so unread blips receive a stronger body highlight, and replace `?` avatar fallback with a stable unknown-user label.
+5. Extend conversation-manifest parsing and write-session metadata with a post-blip sibling insert position/depth, then use it to emit regular replies when the target blip is already at the inline reply limit.
+6. Add a changelog fragment and run narrow J2CL tests plus local sanity before PR.
+
+## Acceptance
+
+- Clicking an unread rendered blip removes the unread marker and fires mark-read immediately.
+- Visible inline-thread buttons show `▾`/`▸`, expose tooltips, and do not bubble into blip navigation.
+- Parent-owned inline-thread duplicate buttons are hidden from view and accessibility.
+- Missing-author avatars no longer show `?`.
+- At depth 5 and above, reply deltas insert a sibling `<blip>` after the target blip rather than a nested `<thread>`.

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -276,19 +276,19 @@ export class WaveBlip extends LitElement {
       border-color: #90cdf4;
       background: #ffffff;
     }
-    :host([focused]) .body,
-    :host([tabindex="0"]) .body {
-      border-color: #d9e2ec;
-      background: #ffffff;
-      color: var(--wavy-signal-cyan, #0077b6);
-      font-weight: 600;
-    }
     :host([unread]) .body {
       border-color: var(--wavy-unread-border);
       background: var(--wavy-unread-bg);
       color: var(--wavy-unread-fg);
       font-weight: 600;
       box-shadow: inset 3px 0 0 var(--wavy-signal-cyan, #0077b6);
+    }
+    :host([focused]) .body,
+    :host([tabindex="0"]) .body {
+      border-color: #d9e2ec;
+      background: #ffffff;
+      color: var(--wavy-signal-cyan, #0077b6);
+      font-weight: 600;
     }
     :host([unread]) .author {
       color: var(--wavy-unread-author-fg);

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -118,6 +118,10 @@ export class WaveBlip extends LitElement {
   static styles = css`
     :host {
       display: block;
+      --wavy-unread-border: rgba(0, 119, 182, 0.5);
+      --wavy-unread-bg: rgba(0, 180, 216, 0.1);
+      --wavy-unread-fg: #0f3f5f;
+      --wavy-unread-author-fg: #075985;
       /* The visual envelope lives on the inner <wavy-blip-card>; this
        * host is a transparent wrapper so the F-0 recipe styling owns
        * focus / unread / pulse visuals. */
@@ -280,14 +284,14 @@ export class WaveBlip extends LitElement {
       font-weight: 600;
     }
     :host([unread]) .body {
-      border-color: rgba(0, 119, 182, 0.5);
-      background: rgba(0, 180, 216, 0.1);
-      color: #0f3f5f;
+      border-color: var(--wavy-unread-border);
+      background: var(--wavy-unread-bg);
+      color: var(--wavy-unread-fg);
       font-weight: 600;
       box-shadow: inset 3px 0 0 var(--wavy-signal-cyan, #0077b6);
     }
     :host([unread]) .author {
-      color: #075985;
+      color: var(--wavy-unread-author-fg);
       font-weight: 700;
     }
     .task-affordance-slot {

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -279,6 +279,17 @@ export class WaveBlip extends LitElement {
       color: var(--wavy-signal-cyan, #0077b6);
       font-weight: 600;
     }
+    :host([unread]) .body {
+      border-color: rgba(0, 119, 182, 0.5);
+      background: rgba(0, 180, 216, 0.1);
+      color: #0f3f5f;
+      font-weight: 600;
+      box-shadow: inset 3px 0 0 var(--wavy-signal-cyan, #0077b6);
+    }
+    :host([unread]) .author {
+      color: #075985;
+      font-weight: 700;
+    }
     .task-affordance-slot {
       display: inline-flex;
       align-items: center;
@@ -420,13 +431,17 @@ export class WaveBlip extends LitElement {
   }
 
   _initials() {
-    const name = (this.authorName || this.authorId || "?").trim();
-    if (!name) return "?";
+    const name = this._authorLabel();
     const parts = name.split(/\s+/);
     if (parts.length >= 2) {
       return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
     }
     return name.substring(0, 2).toUpperCase();
+  }
+
+  _authorLabel() {
+    const label = (this.authorName || this.authorId || "").trim();
+    return label || "Unknown user";
   }
 
   /**
@@ -594,6 +609,7 @@ export class WaveBlip extends LitElement {
     const visuallyFocused = this._visuallyFocused();
     const replyNoun = this.replyCount === 1 ? "reply" : "replies";
     const threadToggleVerb = this.threadCollapsed ? "Expand" : "Collapse";
+    const authorLabel = this._authorLabel();
     const chevron = hasReplies
       ? html`<button
           type="button"
@@ -623,12 +639,12 @@ export class WaveBlip extends LitElement {
             class="avatar"
             data-blip-avatar="true"
             data-palette=${String(palette)}
-            aria-label=${`Open ${this.authorName || this.authorId || "user"} profile`}
+            aria-label=${`Open ${authorLabel} profile`}
             @click=${this._onAvatarClick}
           >
             ${this._initials()}
           </button>
-          <span class="author">${this.authorName || this.authorId || ""}</span>
+          <span class="author">${this.authorName || this.authorId || authorLabel}</span>
           <time
             class="posted"
             title=${tooltip}

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -440,8 +440,9 @@ export class WaveBlip extends LitElement {
   }
 
   _authorLabel() {
-    const label = (this.authorName || this.authorId || "").trim();
-    return label || "Unknown user";
+    const name = typeof this.authorName === "string" ? this.authorName.trim() : "";
+    const id = typeof this.authorId === "string" ? this.authorId.trim() : "";
+    return name || id || "Unknown user";
   }
 
   /**
@@ -625,7 +626,7 @@ export class WaveBlip extends LitElement {
       <wavy-blip-card
         data-blip-id=${this.blipId}
         data-wave-id=${this.waveId}
-        author-name=${this.authorName}
+        author-name=${authorLabel}
         posted-at=${this.postedAt}
         ?is-author=${this.isAuthor}
         ?focused=${visuallyFocused}
@@ -644,7 +645,7 @@ export class WaveBlip extends LitElement {
           >
             ${this._initials()}
           </button>
-          <span class="author">${this.authorName || this.authorId || authorLabel}</span>
+          <span class="author">${authorLabel}</span>
           <time
             class="posted"
             title=${tooltip}

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -104,8 +104,17 @@ describe("<wave-blip>", () => {
     await el.updateComplete;
     const body = el.renderRoot.querySelector(".body");
     const style = getComputedStyle(body);
+    const token =
+      getComputedStyle(document.documentElement)
+        .getPropertyValue("--wavy-signal-cyan")
+        .trim() || "#0077b6";
+    const probe = document.createElement("span");
+    probe.style.color = token;
+    document.body.appendChild(probe);
+    const expectedCyan = getComputedStyle(probe).color;
+    probe.remove();
     expect(style.backgroundColor).to.equal("rgb(255, 255, 255)");
-    expect(style.color).to.equal("rgb(0, 119, 182)");
+    expect(style.color).to.equal(expectedCyan);
     expect(style.boxShadow).to.contain("inset");
   });
 

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -95,6 +95,20 @@ describe("<wave-blip>", () => {
     expect(style.fontWeight).to.not.equal("normal");
   });
 
+  it("keeps focused unread blip bodies visibly focused while read status syncs", async () => {
+    const el = await fixture(html`
+      <wave-blip data-blip-id="b2f" data-wave-id="w2" author-name="Bob" focused unread>
+        body
+      </wave-blip>
+    `);
+    await el.updateComplete;
+    const body = el.renderRoot.querySelector(".body");
+    const style = getComputedStyle(body);
+    expect(style.backgroundColor).to.equal("rgb(255, 255, 255)");
+    expect(style.color).to.equal("rgb(0, 119, 182)");
+    expect(style.boxShadow).to.contain("inset");
+  });
+
   it("renders the per-blip toolbar in the metadata slot", async () => {
     const el = await fixture(html`
       <wave-blip data-blip-id="b3" data-wave-id="w3" author-name="Carol">

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -92,6 +92,7 @@ describe("<wave-blip>", () => {
     const style = getComputedStyle(body);
     expect(style.boxShadow).to.contain("inset");
     expect(style.fontWeight).to.not.equal("400");
+    expect(style.fontWeight).to.not.equal("normal");
   });
 
   it("renders the per-blip toolbar in the metadata slot", async () => {
@@ -593,6 +594,22 @@ describe("<wave-blip>", () => {
       expect(avatar.textContent.trim()).to.equal("UU");
       expect(avatar.getAttribute("aria-label")).to.equal("Open Unknown user profile");
       expect(author.textContent.trim()).to.equal("Unknown user");
+    });
+
+    it("whitespace author name falls back to trimmed author id", async () => {
+      const el = await fixture(html`
+        <wave-blip
+          data-blip-id="b41trim"
+          author-name="   "
+          author-id="  alice@example.com  "
+        ></wave-blip>
+      `);
+      await el.updateComplete;
+      const avatar = el.renderRoot.querySelector(".avatar");
+      const author = el.renderRoot.querySelector(".author");
+      expect(avatar.textContent.trim()).to.equal("AL");
+      expect(avatar.getAttribute("aria-label")).to.equal("Open alice@example.com profile");
+      expect(author.textContent.trim()).to.equal("alice@example.com");
     });
 
     it("renders the thread chevron only when reply-count > 0", async () => {

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -81,6 +81,19 @@ describe("<wave-blip>", () => {
     expect(card.hasAttribute("unread")).to.be.true;
   });
 
+  it("highlights unread blip bodies beyond the small card unread dot", async () => {
+    const el = await fixture(html`
+      <wave-blip data-blip-id="b2u" data-wave-id="w2" author-name="Bob" unread>
+        body
+      </wave-blip>
+    `);
+    await el.updateComplete;
+    const body = el.renderRoot.querySelector(".body");
+    const style = getComputedStyle(body);
+    expect(style.boxShadow).to.contain("inset");
+    expect(style.fontWeight).to.not.equal("400");
+  });
+
   it("renders the per-blip toolbar in the metadata slot", async () => {
     const el = await fixture(html`
       <wave-blip data-blip-id="b3" data-wave-id="w3" author-name="Carol">
@@ -568,6 +581,18 @@ describe("<wave-blip>", () => {
         palettes.add(el.renderRoot.querySelector(".avatar").getAttribute("data-palette"));
       }
       expect(palettes.size).to.be.greaterThan(1);
+    });
+
+    it("missing author metadata uses a stable unknown-user avatar instead of a question mark", async () => {
+      const el = await fixture(html`
+        <wave-blip data-blip-id="b41unknown"></wave-blip>
+      `);
+      await el.updateComplete;
+      const avatar = el.renderRoot.querySelector(".avatar");
+      const author = el.renderRoot.querySelector(".author");
+      expect(avatar.textContent.trim()).to.equal("UU");
+      expect(avatar.getAttribute("aria-label")).to.equal("Open Unknown user profile");
+      expect(author.textContent.trim()).to.equal("Unknown user");
     });
 
     it("renders the thread chevron only when reply-count > 0", async () => {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -3262,7 +3262,7 @@ public final class J2clReadSurfaceDomRenderer {
       FocusOptionsType options = FocusOptionsType.create();
       options.setPreventScroll(true);
       element.focus(options);
-    } catch (Throwable ignored) {
+    } catch (RuntimeException ignored) {
       element.focus();
     }
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -2531,14 +2531,6 @@ public final class J2clReadSurfaceDomRenderer {
     HTMLElement button = (HTMLElement) DomGlobal.document.createElement("button");
     button.className = "j2cl-read-thread-toggle";
     button.setAttribute("type", "button");
-    // SSR-rendered threads lack data-parent-blip-id; their parent is a legacy
-    // div.blip that does not emit wave-blip-thread-toggle-requested, so the
-    // button is the only toggle affordance and must remain visible/focusable.
-    if (thread.hasAttribute("data-parent-blip-id")) {
-      button.setAttribute("tabindex", "-1");
-      button.setAttribute("aria-hidden", "true");
-      button.setAttribute("hidden", "");
-    }
     button.setAttribute("aria-controls", thread.getAttribute("id"));
     updateThreadToggleButton(
         thread, button, thread.classList.contains("j2cl-read-thread-collapsed"));

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -3226,7 +3226,11 @@ public final class J2clReadSurfaceDomRenderer {
     int boundedIndex = Math.max(0, Math.min(index, visibleBlips.size() - 1));
     HTMLElement next = visibleBlips.get(boundedIndex);
     focusBlip(next, key);
-    focusWithoutScrolling(next);
+    if (key == null || key.isEmpty()) {
+      focusWithoutScrolling(next);
+    } else {
+      next.focus();
+    }
   }
 
   private void focusBlip(HTMLElement next) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -5,6 +5,7 @@ import elemental2.dom.CustomEventInit;
 import elemental2.dom.DOMRect;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.Element;
+import elemental2.dom.Element.FocusOptionsType;
 import elemental2.dom.Event;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
@@ -2521,12 +2522,8 @@ public final class J2clReadSurfaceDomRenderer {
     if (thread.hasAttribute("data-j2cl-collapse-ready")) {
       HTMLElement existingButton = (HTMLElement) thread.querySelector(".j2cl-read-thread-toggle");
       if (existingButton != null) {
-        existingButton.setAttribute(
-            "aria-label",
-            (thread.classList.contains("j2cl-read-thread-collapsed") ? "Expand " : "Collapse ")
-                + label);
-        existingButton.textContent =
-            thread.classList.contains("j2cl-read-thread-collapsed") ? "+" : "\u2212";
+        updateThreadToggleButton(
+            thread, existingButton, thread.classList.contains("j2cl-read-thread-collapsed"));
       }
       return;
     }
@@ -2540,11 +2537,10 @@ public final class J2clReadSurfaceDomRenderer {
     if (thread.hasAttribute("data-parent-blip-id")) {
       button.setAttribute("tabindex", "-1");
       button.setAttribute("aria-hidden", "true");
+      button.setAttribute("hidden", "");
     }
     button.setAttribute("aria-controls", thread.getAttribute("id"));
-    button.setAttribute("aria-expanded", "true");
-    button.setAttribute("aria-label", "Collapse " + label);
-    button.textContent = "\u2212";
+    updateThreadToggleButton(thread, button, false);
     button.addEventListener(
         "click",
         event -> {
@@ -2598,16 +2594,11 @@ public final class J2clReadSurfaceDomRenderer {
     if (collapsed) {
       thread.classList.add("j2cl-read-thread-collapsed");
       thread.setAttribute("data-j2cl-thread-collapsed", "true");
-      button.setAttribute("aria-expanded", "false");
-      button.setAttribute("aria-label", "Expand " + threadLabel(thread));
-      button.textContent = "+";
     } else {
       thread.classList.remove("j2cl-read-thread-collapsed");
       thread.removeAttribute("data-j2cl-thread-collapsed");
-      button.setAttribute("aria-expanded", "true");
-      button.setAttribute("aria-label", "Collapse " + threadLabel(thread));
-      button.textContent = "\u2212";
     }
+    updateThreadToggleButton(thread, button, collapsed);
     // V-4 (#1102): mirror collapse state onto the parent wave-blip so
     // the chevron glyph (triangle-down/right) reflects the actual
     // thread state. Use the rendered-blip lookup helper rather than
@@ -2730,7 +2721,7 @@ public final class J2clReadSurfaceDomRenderer {
     }
     HTMLElement blip = (HTMLElement) event.currentTarget;
     focusBlip(blip);
-    blip.focus();
+    focusWithoutScrolling(blip);
   }
 
   private static boolean isInteractiveClick(Event event) {
@@ -3235,7 +3226,7 @@ public final class J2clReadSurfaceDomRenderer {
     int boundedIndex = Math.max(0, Math.min(index, visibleBlips.size() - 1));
     HTMLElement next = visibleBlips.get(boundedIndex);
     focusBlip(next, key);
-    next.focus();
+    focusWithoutScrolling(next);
   }
 
   private void focusBlip(HTMLElement next) {
@@ -3257,6 +3248,31 @@ public final class J2clReadSurfaceDomRenderer {
     focusedBlip.setAttribute("tabindex", "0");
     markFocusedBlipReadNow(focusedBlip);
     dispatchFocusChanged(focusedBlip, key);
+  }
+
+  private static void focusWithoutScrolling(HTMLElement element) {
+    if (element == null) {
+      return;
+    }
+    try {
+      FocusOptionsType options = FocusOptionsType.create();
+      options.setPreventScroll(true);
+      element.focus(options);
+    } catch (Throwable ignored) {
+      element.focus();
+    }
+  }
+
+  private static void updateThreadToggleButton(
+      HTMLElement thread, HTMLElement button, boolean collapsed) {
+    if (button == null) {
+      return;
+    }
+    String label = (collapsed ? "Expand " : "Collapse ") + threadLabel(thread);
+    button.setAttribute("aria-expanded", collapsed ? "false" : "true");
+    button.setAttribute("aria-label", label);
+    button.setAttribute("title", label);
+    button.textContent = collapsed ? "\u25b8" : "\u25be";
   }
 
   private void setFocusMarkers(HTMLElement blip) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -2540,7 +2540,8 @@ public final class J2clReadSurfaceDomRenderer {
       button.setAttribute("hidden", "");
     }
     button.setAttribute("aria-controls", thread.getAttribute("id"));
-    updateThreadToggleButton(thread, button, false);
+    updateThreadToggleButton(
+        thread, button, thread.classList.contains("j2cl-read-thread-collapsed"));
     button.addEventListener(
         "click",
         event -> {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -37,6 +37,8 @@ public final class J2clRichContentDeltaFactory {
 
   private static final char[] WEB64_ALPHABET =
       "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_".toCharArray();
+  // Mirrors ClientFlagsBase.maxReplyDepth's default and the local/prod server depth gate.
+  private static final int DEFAULT_MAX_INLINE_REPLY_DEPTH = 5;
 
   private final String sessionSeed;
   private int counter;
@@ -874,7 +876,15 @@ public final class J2clRichContentDeltaFactory {
     }
     String replyBlipId = nextToken("b+");
     String operationsJson = buildDocumentOperation(replyBlipId, document);
-    if (session.getReplyManifestInsertPosition() >= 0) {
+    if (shouldCreateRegularReply(session)) {
+      operationsJson =
+          buildConversationRegularReplyOperation(
+                  session.getReplyManifestSiblingInsertPosition(),
+                  session.getReplyManifestItemCount(),
+                  replyBlipId)
+              + ","
+              + operationsJson;
+    } else if (session.getReplyManifestInsertPosition() >= 0) {
       String replyThreadId = nextToken("t+");
       operationsJson =
           buildConversationReplyThreadOperation(
@@ -905,6 +915,32 @@ public final class J2clRichContentDeltaFactory {
     appendComponentSeparator(components);
     appendElementEnd(components);
     return buildRawDocumentOperation("conversation", components.toString());
+  }
+
+  private String buildConversationRegularReplyOperation(
+      int insertPosition, int manifestItemCount, String replyBlipId) {
+    if (insertPosition < 0) {
+      throw new IllegalArgumentException("Invalid manifest sibling reply insert position.");
+    }
+    StringBuilder components = new StringBuilder();
+    if (insertPosition > 0) {
+      appendRetain(components, insertPosition);
+      appendComponentSeparator(components);
+    }
+    appendElementStartWithAttr(components, "blip", "id", replyBlipId);
+    appendComponentSeparator(components);
+    appendElementEnd(components);
+    int trailingRetain = manifestItemCount < 0 ? 0 : manifestItemCount - insertPosition;
+    if (trailingRetain > 0) {
+      appendComponentSeparator(components);
+      appendRetain(components, trailingRetain);
+    }
+    return buildRawDocumentOperation("conversation", components.toString());
+  }
+
+  private static boolean shouldCreateRegularReply(J2clSidecarWriteSession session) {
+    return session.getReplyTargetDepth() >= DEFAULT_MAX_INLINE_REPLY_DEPTH
+        && session.getReplyManifestSiblingInsertPosition() >= 0;
   }
 
   private String buildConversationReplyThreadOperation(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactory.java
@@ -23,6 +23,8 @@ public class J2clPlainTextDeltaFactory {
 
   private static final char[] WEB64_ALPHABET =
       "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_".toCharArray();
+  // Mirrors ClientFlagsBase.maxReplyDepth's default and the local/prod server depth gate.
+  private static final int DEFAULT_MAX_INLINE_REPLY_DEPTH = 5;
 
   private final String sessionSeed;
   private int counter;
@@ -64,7 +66,15 @@ public class J2clPlainTextDeltaFactory {
             + "\",\"2\":{\"1\":[{\"2\":\""
             + escapeJson(text)
             + "\"}]}}}";
-    if (session.getReplyManifestInsertPosition() >= 0) {
+    if (shouldCreateRegularReply(session)) {
+      operationsJson =
+          buildConversationRegularReplyOperation(
+                  session.getReplyManifestSiblingInsertPosition(),
+                  session.getReplyManifestItemCount(),
+                  replyBlipId)
+              + ","
+              + operationsJson;
+    } else if (session.getReplyManifestInsertPosition() >= 0) {
       String replyThreadId = nextToken("t+");
       operationsJson =
           buildConversationReplyThreadOperation(
@@ -113,6 +123,26 @@ public class J2clPlainTextDeltaFactory {
             + "\"}]}},{\"4\":true},{\"4\":true}"
             + (trailingRetain > 0 ? ",{\"5\":" + trailingRetain + "}" : "");
     return buildRawDocumentOperation("conversation", componentsJson);
+  }
+
+  private static String buildConversationRegularReplyOperation(
+      int insertPosition, int manifestItemCount, String replyBlipId) {
+    if (insertPosition < 0) {
+      throw new IllegalArgumentException("Invalid manifest sibling reply insert position.");
+    }
+    int trailingRetain = manifestItemCount < 0 ? 0 : manifestItemCount - insertPosition;
+    String componentsJson =
+        (insertPosition > 0 ? "{\"5\":" + insertPosition + "}," : "")
+            + "{\"3\":{\"1\":\"blip\",\"2\":[{\"1\":\"id\",\"2\":\""
+            + escapeJson(replyBlipId)
+            + "\"}]}},{\"4\":true}"
+            + (trailingRetain > 0 ? ",{\"5\":" + trailingRetain + "}" : "");
+    return buildRawDocumentOperation("conversation", componentsJson);
+  }
+
+  private static boolean shouldCreateRegularReply(J2clSidecarWriteSession session) {
+    return session.getReplyTargetDepth() >= DEFAULT_MAX_INLINE_REPLY_DEPTH
+        && session.getReplyManifestSiblingInsertPosition() >= 0;
   }
 
   private static String buildRawDocumentOperation(String documentId, String componentsJson) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -415,7 +415,13 @@ public final class J2clSelectedWaveProjector {
     }
     int replyManifestInsertPosition = -1;
     int replyManifestItemCount = -1;
+    int replyManifestSiblingInsertPosition = -1;
+    int replyTargetDepth = -1;
     Map<String, Integer> replyManifestInsertPositionsByBlipId =
+        Collections.<String, Integer>emptyMap();
+    Map<String, Integer> replyManifestSiblingInsertPositionsByBlipId =
+        Collections.<String, Integer>emptyMap();
+    Map<String, Integer> replyTargetDepthsByBlipId =
         Collections.<String, Integer>emptyMap();
     // Rendering may reuse a cached manifest on live blip-only updates, but submit offsets must
     // only come from a manifest coupled to the same base version/hash as the write session.
@@ -425,9 +431,14 @@ public final class J2clSelectedWaveProjector {
             : SidecarConversationManifest.empty();
     if (!writeManifest.isEmpty()) {
       replyManifestInsertPositionsByBlipId = replyManifestInsertPositionsByBlipId(writeManifest);
+      replyManifestSiblingInsertPositionsByBlipId =
+          replyManifestSiblingInsertPositionsByBlipId(writeManifest);
+      replyTargetDepthsByBlipId = replyTargetDepthsByBlipId(writeManifest);
       SidecarConversationManifest.Entry replyTarget = writeManifest.findByBlipId(replyTargetBlipId);
       if (replyTarget != null) {
         replyManifestInsertPosition = replyTarget.getReplyInsertPosition();
+        replyManifestSiblingInsertPosition = replyTarget.getSiblingReplyInsertPosition();
+        replyTargetDepth = replyTarget.getDepth();
         replyManifestItemCount = writeManifest.getItemCount();
       }
     } else if (!updateHasCoupledPair && previousWriteSession != null) {
@@ -435,8 +446,15 @@ public final class J2clSelectedWaveProjector {
           previousWriteSession.forReplyTarget(replyTargetBlipId);
       replyManifestInsertPosition = previousForTarget.getReplyManifestInsertPosition();
       replyManifestItemCount = previousForTarget.getReplyManifestItemCount();
+      replyManifestSiblingInsertPosition =
+          previousForTarget.getReplyManifestSiblingInsertPosition();
+      replyTargetDepth = previousForTarget.getReplyTargetDepth();
       replyManifestInsertPositionsByBlipId =
           previousWriteSession.getReplyManifestInsertPositionsByBlipId();
+      replyManifestSiblingInsertPositionsByBlipId =
+          previousWriteSession.getReplyManifestSiblingInsertPositionsByBlipId();
+      replyTargetDepthsByBlipId =
+          previousWriteSession.getReplyTargetDepthsByBlipId();
     }
     return new J2clSidecarWriteSession(
         selectedWaveId,
@@ -447,7 +465,11 @@ public final class J2clSelectedWaveProjector {
         participantIds,
         replyManifestInsertPosition,
         replyManifestItemCount,
-        replyManifestInsertPositionsByBlipId);
+        replyManifestSiblingInsertPosition,
+        replyTargetDepth,
+        replyManifestInsertPositionsByBlipId,
+        replyManifestSiblingInsertPositionsByBlipId,
+        replyTargetDepthsByBlipId);
   }
 
   private static Map<String, Integer> replyManifestInsertPositionsByBlipId(
@@ -463,6 +485,38 @@ public final class J2clSelectedWaveProjector {
       positions.put(entry.getBlipId(), Integer.valueOf(entry.getReplyInsertPosition()));
     }
     return positions.isEmpty() ? Collections.<String, Integer>emptyMap() : positions;
+  }
+
+  private static Map<String, Integer> replyManifestSiblingInsertPositionsByBlipId(
+      SidecarConversationManifest manifest) {
+    if (manifest == null || manifest.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    Map<String, Integer> positions = new LinkedHashMap<String, Integer>();
+    for (SidecarConversationManifest.Entry entry : manifest.getOrderedEntries()) {
+      if (entry == null
+          || entry.getBlipId().isEmpty()
+          || entry.getSiblingReplyInsertPosition() < 0) {
+        continue;
+      }
+      positions.put(entry.getBlipId(), Integer.valueOf(entry.getSiblingReplyInsertPosition()));
+    }
+    return positions.isEmpty() ? Collections.<String, Integer>emptyMap() : positions;
+  }
+
+  private static Map<String, Integer> replyTargetDepthsByBlipId(
+      SidecarConversationManifest manifest) {
+    if (manifest == null || manifest.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    Map<String, Integer> depths = new LinkedHashMap<String, Integer>();
+    for (SidecarConversationManifest.Entry entry : manifest.getOrderedEntries()) {
+      if (entry == null || entry.getBlipId().isEmpty() || entry.getDepth() < 0) {
+        continue;
+      }
+      depths.put(entry.getBlipId(), Integer.valueOf(entry.getDepth()));
+    }
+    return depths.isEmpty() ? Collections.<String, Integer>emptyMap() : depths;
   }
 
   private static J2clSelectedWaveViewportState projectViewportState(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarWriteSession.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarWriteSession.java
@@ -251,7 +251,10 @@ public final class J2clSidecarWriteSession {
         siblingInsertPosition == null ? -1 : Math.max(-1, siblingInsertPosition.intValue());
     Integer targetDepth = replyTargetDepthsByBlipId.get(target);
     int normalizedTargetDepth = targetDepth == null ? -1 : Math.max(-1, targetDepth.intValue());
-    int normalizedItemCount = normalizedInsertPosition >= 0 ? replyManifestItemCount : -1;
+    int normalizedItemCount =
+        normalizedInsertPosition >= 0 || normalizedSiblingInsertPosition >= 0
+            ? replyManifestItemCount
+            : -1;
     return new J2clSidecarWriteSession(
         selectedWaveId,
         channelId,

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarWriteSession.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarWriteSession.java
@@ -15,7 +15,11 @@ public final class J2clSidecarWriteSession {
   private final List<String> participantIds;
   private final int replyManifestInsertPosition;
   private final int replyManifestItemCount;
+  private final int replyManifestSiblingInsertPosition;
+  private final int replyTargetDepth;
   private final Map<String, Integer> replyManifestInsertPositionsByBlipId;
+  private final Map<String, Integer> replyManifestSiblingInsertPositionsByBlipId;
+  private final Map<String, Integer> replyTargetDepthsByBlipId;
 
   public J2clSidecarWriteSession(
       String selectedWaveId,
@@ -118,7 +122,11 @@ public final class J2clSidecarWriteSession {
         participantIds,
         replyManifestInsertPosition,
         replyManifestItemCount,
-        singletonReplyPosition(replyTargetBlipId, replyManifestInsertPosition));
+        -1,
+        -1,
+        singletonReplyPosition(replyTargetBlipId, replyManifestInsertPosition),
+        Collections.<String, Integer>emptyMap(),
+        Collections.<String, Integer>emptyMap());
   }
 
   public J2clSidecarWriteSession(
@@ -131,6 +139,36 @@ public final class J2clSidecarWriteSession {
       int replyManifestInsertPosition,
       int replyManifestItemCount,
       Map<String, Integer> replyManifestInsertPositionsByBlipId) {
+    this(
+        selectedWaveId,
+        channelId,
+        baseVersion,
+        historyHash,
+        replyTargetBlipId,
+        participantIds,
+        replyManifestInsertPosition,
+        replyManifestItemCount,
+        -1,
+        -1,
+        replyManifestInsertPositionsByBlipId,
+        Collections.<String, Integer>emptyMap(),
+        Collections.<String, Integer>emptyMap());
+  }
+
+  public J2clSidecarWriteSession(
+      String selectedWaveId,
+      String channelId,
+      long baseVersion,
+      String historyHash,
+      String replyTargetBlipId,
+      List<String> participantIds,
+      int replyManifestInsertPosition,
+      int replyManifestItemCount,
+      int replyManifestSiblingInsertPosition,
+      int replyTargetDepth,
+      Map<String, Integer> replyManifestInsertPositionsByBlipId,
+      Map<String, Integer> replyManifestSiblingInsertPositionsByBlipId,
+      Map<String, Integer> replyTargetDepthsByBlipId) {
     this.selectedWaveId = selectedWaveId;
     this.channelId = channelId;
     this.baseVersion = baseVersion;
@@ -142,11 +180,23 @@ public final class J2clSidecarWriteSession {
             : Collections.unmodifiableList(new ArrayList<String>(participantIds));
     this.replyManifestInsertPosition = Math.max(-1, replyManifestInsertPosition);
     this.replyManifestItemCount = Math.max(-1, replyManifestItemCount);
+    this.replyManifestSiblingInsertPosition = Math.max(-1, replyManifestSiblingInsertPosition);
+    this.replyTargetDepth = Math.max(-1, replyTargetDepth);
     this.replyManifestInsertPositionsByBlipId =
         immutableReplyPositions(
             replyManifestInsertPositionsByBlipId,
             this.replyTargetBlipId,
             this.replyManifestInsertPosition);
+    this.replyManifestSiblingInsertPositionsByBlipId =
+        immutableReplyPositions(
+            replyManifestSiblingInsertPositionsByBlipId,
+            this.replyTargetBlipId,
+            this.replyManifestSiblingInsertPosition);
+    this.replyTargetDepthsByBlipId =
+        immutableReplyPositions(
+            replyTargetDepthsByBlipId,
+            this.replyTargetBlipId,
+            this.replyTargetDepth);
   }
 
   public String getSelectedWaveId() {
@@ -181,6 +231,14 @@ public final class J2clSidecarWriteSession {
     return replyManifestItemCount;
   }
 
+  public int getReplyManifestSiblingInsertPosition() {
+    return replyManifestSiblingInsertPosition;
+  }
+
+  public int getReplyTargetDepth() {
+    return replyTargetDepth;
+  }
+
   public J2clSidecarWriteSession forReplyTarget(String replyTargetBlipId) {
     String target = replyTargetBlipId == null ? "" : replyTargetBlipId.trim();
     if (target.isEmpty() || target.equals(this.replyTargetBlipId)) {
@@ -188,6 +246,11 @@ public final class J2clSidecarWriteSession {
     }
     Integer insertPosition = replyManifestInsertPositionsByBlipId.get(target);
     int normalizedInsertPosition = insertPosition == null ? -1 : Math.max(-1, insertPosition.intValue());
+    Integer siblingInsertPosition = replyManifestSiblingInsertPositionsByBlipId.get(target);
+    int normalizedSiblingInsertPosition =
+        siblingInsertPosition == null ? -1 : Math.max(-1, siblingInsertPosition.intValue());
+    Integer targetDepth = replyTargetDepthsByBlipId.get(target);
+    int normalizedTargetDepth = targetDepth == null ? -1 : Math.max(-1, targetDepth.intValue());
     int normalizedItemCount = normalizedInsertPosition >= 0 ? replyManifestItemCount : -1;
     return new J2clSidecarWriteSession(
         selectedWaveId,
@@ -198,11 +261,23 @@ public final class J2clSidecarWriteSession {
         participantIds,
         normalizedInsertPosition,
         normalizedItemCount,
-        replyManifestInsertPositionsByBlipId);
+        normalizedSiblingInsertPosition,
+        normalizedTargetDepth,
+        replyManifestInsertPositionsByBlipId,
+        replyManifestSiblingInsertPositionsByBlipId,
+        replyTargetDepthsByBlipId);
   }
 
   Map<String, Integer> getReplyManifestInsertPositionsByBlipId() {
     return replyManifestInsertPositionsByBlipId;
+  }
+
+  Map<String, Integer> getReplyManifestSiblingInsertPositionsByBlipId() {
+    return replyManifestSiblingInsertPositionsByBlipId;
+  }
+
+  Map<String, Integer> getReplyTargetDepthsByBlipId() {
+    return replyTargetDepthsByBlipId;
   }
 
   private static Map<String, Integer> singletonReplyPosition(String blipId, int insertPosition) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarConversationManifest.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarConversationManifest.java
@@ -35,6 +35,7 @@ public final class SidecarConversationManifest {
     private final int depth;
     private final int siblingIndex;
     private final int replyInsertPosition;
+    private final int siblingReplyInsertPosition;
 
     public Entry(String blipId, String parentBlipId, String threadId, int depth, int siblingIndex) {
       this(blipId, parentBlipId, threadId, depth, siblingIndex, -1);
@@ -47,12 +48,24 @@ public final class SidecarConversationManifest {
         int depth,
         int siblingIndex,
         int replyInsertPosition) {
+      this(blipId, parentBlipId, threadId, depth, siblingIndex, replyInsertPosition, -1);
+    }
+
+    public Entry(
+        String blipId,
+        String parentBlipId,
+        String threadId,
+        int depth,
+        int siblingIndex,
+        int replyInsertPosition,
+        int siblingReplyInsertPosition) {
       this.blipId = blipId == null ? "" : blipId;
       this.parentBlipId = parentBlipId == null ? "" : parentBlipId;
       this.threadId = threadId == null ? "" : threadId;
       this.depth = depth;
       this.siblingIndex = siblingIndex;
       this.replyInsertPosition = Math.max(-1, replyInsertPosition);
+      this.siblingReplyInsertPosition = Math.max(-1, siblingReplyInsertPosition);
     }
 
     public String getBlipId() {
@@ -86,6 +99,15 @@ public final class SidecarConversationManifest {
      */
     public int getReplyInsertPosition() {
       return replyInsertPosition;
+    }
+
+    /**
+     * Item position immediately after this blip's closing element in the
+     * conversation manifest. Depth-limit fallback reply deltas retain to this
+     * position and insert a sibling {@code <blip/>} in the current thread.
+     */
+    public int getSiblingReplyInsertPosition() {
+      return siblingReplyInsertPosition;
     }
   }
 
@@ -238,6 +260,7 @@ public final class SidecarConversationManifest {
             Integer entryIndex = removeLast(openBlipEntryIndexStack);
             if (entryIndex != null && entryIndex.intValue() >= 0) {
               setReplyInsertPosition(entries, entryIndex.intValue(), itemPosition);
+              setSiblingReplyInsertPosition(entries, entryIndex.intValue(), itemPosition + 1);
             }
             itemPosition++;
           }
@@ -302,6 +325,7 @@ public final class SidecarConversationManifest {
                 siblingIndex));
         if (selfClosing) {
           setReplyInsertPosition(entries, entryIndex, itemPosition);
+          setSiblingReplyInsertPosition(entries, entryIndex, itemPosition + 1);
           itemPosition++;
         } else {
           openBlipStack.add(blipId);
@@ -457,6 +481,7 @@ public final class SidecarConversationManifest {
     for (Entry entry : entries) {
       if (entry != null) {
         inferredMin = Math.max(inferredMin, entry.getReplyInsertPosition() + 1);
+        inferredMin = Math.max(inferredMin, entry.getSiblingReplyInsertPosition());
       }
     }
     if (explicitItemCount >= 0) {
@@ -478,6 +503,24 @@ public final class SidecarConversationManifest {
             entry.getThreadId(),
             entry.getDepth(),
             entry.getSiblingIndex(),
+            position,
+            entry.getSiblingReplyInsertPosition()));
+  }
+
+  private static void setSiblingReplyInsertPosition(List<Entry> entries, int index, int position) {
+    if (entries == null || index < 0 || index >= entries.size()) {
+      return;
+    }
+    Entry entry = entries.get(index);
+    entries.set(
+        index,
+        new Entry(
+            entry.getBlipId(),
+            entry.getParentBlipId(),
+            entry.getThreadId(),
+            entry.getDepth(),
+            entry.getSiblingIndex(),
+            entry.getReplyInsertPosition(),
             position));
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarConversationManifest.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarConversationManifest.java
@@ -516,6 +516,9 @@ public final class SidecarConversationManifest {
       return;
     }
     Entry entry = entries.get(index);
+    if (entry == null) {
+      return;
+    }
     entries.set(
         index,
         new Entry(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarConversationManifest.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarConversationManifest.java
@@ -102,9 +102,10 @@ public final class SidecarConversationManifest {
     }
 
     /**
-     * Item position immediately after this blip's closing element in the
-     * conversation manifest. Depth-limit fallback reply deltas retain to this
-     * position and insert a sibling {@code <blip/>} in the current thread.
+     * Item position in the conversation manifest immediately after this blip's
+     * closing element. Depth-limit fallback reply deltas retain document items
+     * up to this position and insert a sibling {@code <blip/>} in the current
+     * thread.
      */
     public int getSiblingReplyInsertPosition() {
       return siblingReplyInsertPosition;
@@ -495,6 +496,9 @@ public final class SidecarConversationManifest {
       return;
     }
     Entry entry = entries.get(index);
+    if (entry == null) {
+      return;
+    }
     entries.set(
         index,
         new Entry(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererMarkReadTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererMarkReadTest.java
@@ -144,6 +144,32 @@ public class J2clReadSurfaceDomRendererMarkReadTest {
   }
 
   @Test
+  public void clickingUnreadBlipMarksReadImmediately() {
+    HTMLDivElement host = createHost();
+    installViewport(host, 200);
+    installBlipLayout();
+    FakeScheduler scheduler = new FakeScheduler();
+    RecordingListener listener = new RecordingListener();
+
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    renderer.setDwellTimerSchedulerForTesting(scheduler);
+    renderer.setMarkBlipReadListener(listener);
+
+    List<J2clReadBlip> blips = new ArrayList<J2clReadBlip>();
+    blips.add(unreadBlip("b+clicked", "clicked"));
+    renderer.render(blips, java.util.Collections.<String>emptyList());
+    HTMLElement blip = (HTMLElement) host.querySelector("wave-blip[data-blip-id='b+clicked']");
+    Assert.assertNotNull(blip);
+
+    blip.click();
+
+    Assert.assertEquals(java.util.Arrays.asList("b+clicked"), listener.fired);
+    Assert.assertFalse(blip.hasAttribute("unread"));
+    Assert.assertEquals("0", blip.getAttribute("tabindex"));
+    Assert.assertEquals("true", blip.getAttribute("aria-current"));
+  }
+
+  @Test
   public void blipFiringTwiceForSameIdIsBlockedByInFlightSet() {
     HTMLDivElement host = createHost();
     installViewport(host, 200);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -94,6 +94,28 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void enhanceExistingSurfaceInitializesCollapsedThreadToggleState() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    host.innerHTML =
+        "<div class=\"wave-content\">"
+            + "<div class=\"inline-thread j2cl-read-thread-collapsed\""
+            + " data-thread-id=\"t+inline\" data-j2cl-thread-collapsed=\"true\">"
+            + "<div class=\"blip\" data-blip-id=\"b+reply\">Reply</div>"
+            + "</div></div>";
+
+    Assert.assertTrue(new J2clReadSurfaceDomRenderer(host).enhanceExistingSurface());
+
+    HTMLButtonElement toggle =
+        (HTMLButtonElement) host.querySelector(".j2cl-read-thread-toggle");
+    Assert.assertNotNull(toggle);
+    Assert.assertEquals("false", toggle.getAttribute("aria-expanded"));
+    Assert.assertEquals("Expand inline reply thread 1 (inline)", toggle.getAttribute("aria-label"));
+    Assert.assertEquals("Expand inline reply thread 1 (inline)", toggle.getAttribute("title"));
+    Assert.assertEquals("▸", toggle.textContent);
+  }
+
+  @Test
   public void parentOwnedInlineThreadToggleIsHiddenBecauseParentChevronOwnsAction() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -130,7 +130,17 @@ public class J2clReadSurfaceDomRendererTest {
         renderer.render(
             Arrays.asList(
                 new J2clReadBlip("b+root", "Root"),
-                new J2clReadBlip("b+reply", "Reply")),
+                new J2clReadBlip(
+                    "b+reply",
+                    "Reply",
+                    Collections.<J2clAttachmentRenderModel>emptyList(),
+                    "",
+                    "",
+                    0L,
+                    "b+root",
+                    "t+inline",
+                    false,
+                    false)),
             Collections.<String>emptyList()));
 
     HTMLButtonElement toggle =

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -148,6 +148,9 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertNotNull(toggle);
     Assert.assertFalse(toggle.hasAttribute("hidden"));
     Assert.assertNull(toggle.getAttribute("aria-hidden"));
+    Assert.assertEquals("true", toggle.getAttribute("aria-expanded"));
+    Assert.assertEquals(
+        "Collapse inline reply thread 2 (b+root::t+inline)", toggle.getAttribute("aria-label"));
     Assert.assertEquals(
         "Collapse inline reply thread 2 (b+root::t+inline)", toggle.getAttribute("title"));
     Assert.assertEquals("▾", toggle.textContent);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -116,7 +116,7 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
-  public void parentOwnedInlineThreadToggleIsHiddenBecauseParentChevronOwnsAction() {
+  public void parentOwnedInlineThreadToggleIsVisibleAndDescribed() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();
     J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
@@ -136,9 +136,11 @@ public class J2clReadSurfaceDomRendererTest {
     HTMLButtonElement toggle =
         (HTMLButtonElement) host.querySelector(".inline-thread .j2cl-read-thread-toggle");
     Assert.assertNotNull(toggle);
-    Assert.assertTrue(toggle.hasAttribute("hidden"));
-    Assert.assertEquals("true", toggle.getAttribute("aria-hidden"));
-    Assert.assertEquals("-1", toggle.getAttribute("tabindex"));
+    Assert.assertFalse(toggle.hasAttribute("hidden"));
+    Assert.assertNull(toggle.getAttribute("aria-hidden"));
+    Assert.assertEquals(
+        "Collapse inline reply thread 2 (b+root::t+inline)", toggle.getAttribute("title"));
+    Assert.assertEquals("▾", toggle.textContent);
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -70,7 +70,9 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertEquals("true", toggle.getAttribute("aria-expanded"));
     Assert.assertEquals(
         "Collapse inline reply thread 1 (inline)", toggle.getAttribute("aria-label"));
-    Assert.assertEquals("−", toggle.textContent);
+    Assert.assertEquals(
+        "Collapse inline reply thread 1 (inline)", toggle.getAttribute("title"));
+    Assert.assertEquals("▾", toggle.textContent);
 
     HTMLElement inlineThread =
         (HTMLElement) host.querySelector(".inline-thread[data-thread-id='t+inline']");
@@ -87,7 +89,34 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertEquals("true", inlineThread.getAttribute("data-j2cl-thread-collapsed"));
     Assert.assertEquals("false", toggle.getAttribute("aria-expanded"));
     Assert.assertEquals("Expand inline reply thread 1 (inline)", toggle.getAttribute("aria-label"));
-    Assert.assertEquals("+", toggle.textContent);
+    Assert.assertEquals("Expand inline reply thread 1 (inline)", toggle.getAttribute("title"));
+    Assert.assertEquals("▸", toggle.textContent);
+  }
+
+  @Test
+  public void parentOwnedInlineThreadToggleIsHiddenBecauseParentChevronOwnsAction() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    renderer.setConversationManifest(
+        SidecarConversationManifest.of(
+            Arrays.asList(
+                new SidecarConversationManifest.Entry("b+root", "", "t+root", 0, 0),
+                new SidecarConversationManifest.Entry("b+reply", "b+root", "t+inline", 1, 0))));
+
+    Assert.assertTrue(
+        renderer.render(
+            Arrays.asList(
+                new J2clReadBlip("b+root", "Root"),
+                new J2clReadBlip("b+reply", "Reply")),
+            Collections.<String>emptyList()));
+
+    HTMLButtonElement toggle =
+        (HTMLButtonElement) host.querySelector(".inline-thread .j2cl-read-thread-toggle");
+    Assert.assertNotNull(toggle);
+    Assert.assertTrue(toggle.hasAttribute("hidden"));
+    Assert.assertEquals("true", toggle.getAttribute("aria-hidden"));
+    Assert.assertEquals("-1", toggle.getAttribute("tabindex"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
@@ -189,6 +189,42 @@ public class J2clRichContentDeltaFactoryTest {
   }
 
   @Test
+  public void replyRequestAtInlineDepthLimitFallsBackToRegularSiblingReply() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession(
+            "example.com/w+reply",
+            "chan-7",
+            44L,
+            "ABCD",
+            "b+deep",
+            Collections.<String>emptyList(),
+            6,
+            10,
+            7,
+            5,
+            Collections.singletonMap("b+deep", Integer.valueOf(6)),
+            Collections.singletonMap("b+deep", Integer.valueOf(7)),
+            Collections.singletonMap("b+deep", Integer.valueOf(5)));
+    J2clComposerDocument document =
+        J2clComposerDocument.builder().text("Depth-limited reply").build();
+
+    SidecarSubmitRequest request = factory.createReplyRequest("user@example.com", session, document);
+    String deltaJson = request.getDeltaJson();
+
+    Assert.assertEquals("b+seedA", request.getClientCreatedBlipId());
+    assertContains(
+        deltaJson,
+        "\"1\":\"conversation\"",
+        "{\"5\":7}",
+        "{\"3\":{\"1\":\"blip\",\"2\":[{\"1\":\"id\",\"2\":\"b+seedA\"}]}}",
+        "{\"5\":3}",
+        "\"2\":\"Depth-limited reply\"");
+    Assert.assertFalse("fallback must not create another nested thread", deltaJson.contains("\"1\":\"thread\""));
+    Assert.assertEquals(2, countOccurrences(deltaJson, "b+seedA"));
+  }
+
+  @Test
   public void replyRequestAllowsVersionZeroWriteSession() {
     J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
     J2clSidecarWriteSession session =

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactoryTest.java
@@ -77,6 +77,40 @@ public class J2clPlainTextDeltaFactoryTest {
         countOccurrences(deltaJson, "b+seedA"));
   }
 
+  @Test
+  public void replyRequestAtInlineDepthLimitFallsBackToRegularSiblingReply() {
+    J2clPlainTextDeltaFactory factory = new J2clPlainTextDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession(
+            "example.com/w+reply",
+            "chan-7",
+            44L,
+            "ABCD",
+            "b+deep",
+            java.util.Collections.<String>emptyList(),
+            6,
+            10,
+            7,
+            5,
+            java.util.Collections.singletonMap("b+deep", Integer.valueOf(6)),
+            java.util.Collections.singletonMap("b+deep", Integer.valueOf(7)),
+            java.util.Collections.singletonMap("b+deep", Integer.valueOf(5)));
+
+    SidecarSubmitRequest request =
+        factory.createReplyRequest("user@example.com", session, "Plain reply");
+    String deltaJson = request.getDeltaJson();
+
+    Assert.assertEquals("b+seedA", request.getClientCreatedBlipId());
+    Assert.assertTrue(deltaJson.contains("\"1\":\"conversation\""));
+    Assert.assertTrue(deltaJson.contains("{\"5\":7}"));
+    Assert.assertTrue(deltaJson.contains("{\"5\":3}"));
+    Assert.assertFalse(deltaJson.contains("\"1\":\"thread\""));
+    Assert.assertEquals(
+        "regular fallback still inserts the reply blip into manifest and creates its document",
+        2,
+        countOccurrences(deltaJson, "b+seedA"));
+  }
+
   private static void assertSubmitRequest(
       SidecarSubmitRequest request,
       String expectedWaveletName,

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -2849,7 +2849,7 @@ public class J2clSelectedWaveProjectorTest {
         SidecarConversationManifest.of(
             Arrays.asList(
                 new SidecarConversationManifest.Entry("b+root", "", "root", 0, 0, 9, 10),
-                new SidecarConversationManifest.Entry("b+child", "b+root", "t+child", 5, 0, 6, 7)),
+                new SidecarConversationManifest.Entry("b+child", "b+root", "t+child", 5, 0, -1, 7)),
             12);
     SidecarSelectedWaveUpdate update =
         new SidecarSelectedWaveUpdate(
@@ -2875,6 +2875,8 @@ public class J2clSelectedWaveProjectorTest {
     Assert.assertNotNull(writeSession);
     Assert.assertEquals(10, writeSession.getReplyManifestSiblingInsertPosition());
     Assert.assertEquals(0, writeSession.getReplyTargetDepth());
+    Assert.assertEquals(-1, childSession.getReplyManifestInsertPosition());
+    Assert.assertEquals(12, childSession.getReplyManifestItemCount());
     Assert.assertEquals(7, childSession.getReplyManifestSiblingInsertPosition());
     Assert.assertEquals(5, childSession.getReplyTargetDepth());
   }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -2844,6 +2844,42 @@ public class J2clSelectedWaveProjectorTest {
   }
 
   @Test
+  public void writeSessionCanRetargetSiblingReplyPositionAndDepthToChildBlip() {
+    SidecarConversationManifest manifest =
+        SidecarConversationManifest.of(
+            Arrays.asList(
+                new SidecarConversationManifest.Entry("b+root", "", "root", 0, 0, 9, 10),
+                new SidecarConversationManifest.Entry("b+child", "b+root", "t+child", 5, 0, 6, 7)),
+            12);
+    SidecarSelectedWaveUpdate update =
+        new SidecarSelectedWaveUpdate(
+            1,
+            WAVELET_NAME,
+            true,
+            CHANNEL_ID,
+            44L,
+            "ABCD",
+            Arrays.asList("user@example.com"),
+            Arrays.asList(
+                new SidecarSelectedWaveDocument(
+                    "b+root", "user@example.com", 33L, 44L, "root content"),
+                new SidecarSelectedWaveDocument(
+                    "b+child", "user@example.com", 33L, 44L, "child content")),
+            null,
+            manifest);
+
+    J2clSidecarWriteSession writeSession =
+        J2clSelectedWaveProjector.project(WAVE_ID, null, update, null, 0).getWriteSession();
+    J2clSidecarWriteSession childSession = writeSession.forReplyTarget("b+child");
+
+    Assert.assertNotNull(writeSession);
+    Assert.assertEquals(10, writeSession.getReplyManifestSiblingInsertPosition());
+    Assert.assertEquals(0, writeSession.getReplyTargetDepth());
+    Assert.assertEquals(7, childSession.getReplyManifestSiblingInsertPosition());
+    Assert.assertEquals(5, childSession.getReplyTargetDepth());
+  }
+
+  @Test
   public void writeSessionDoesNotReusePreviousManifestOffsetsWithFreshBasis() {
     SidecarConversationManifest previousManifest =
         SidecarConversationManifest.of(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponseTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarFragmentsResponseTest.java
@@ -189,7 +189,9 @@ public class SidecarFragmentsResponseTest {
 
     Assert.assertEquals(2, manifest.getOrderedEntries().size());
     Assert.assertEquals(6, manifest.findByBlipId("b+root").getReplyInsertPosition());
+    Assert.assertEquals(7, manifest.findByBlipId("b+root").getSiblingReplyInsertPosition());
     Assert.assertEquals(4, manifest.findByBlipId("b+child").getReplyInsertPosition());
+    Assert.assertEquals(5, manifest.findByBlipId("b+child").getSiblingReplyInsertPosition());
     Assert.assertEquals(8, manifest.getItemCount());
   }
 

--- a/wave/config/changelog.d/2026-05-07-j2cl-wave-blip-click-read-parity.json
+++ b/wave/config/changelog.d/2026-05-07-j2cl-wave-blip-click-read-parity.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-05-07-j2cl-wave-blip-click-read-parity",
+  "version": "J2CL parity",
+  "date": "2026-05-07",
+  "title": "J2CL wave blip click and reply parity",
+  "summary": "Improves the J2CL wave reader so blip click, unread, avatar, thread-toggle, and depth-limited reply behavior match the legacy wave view more closely.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Clicking an unread blip now marks it read immediately without shifting the wave panel.",
+        "Unread blips receive a stronger visual highlight and missing author metadata no longer renders a question-mark avatar.",
+        "Inline thread controls now use clearer chevrons with tooltips, hide duplicate inert buttons, and depth-limited inline replies fall back to regular replies."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- fix J2CL blip click focus so clicking an unread blip marks it read without scroll jumps
- strengthen unread visual highlighting and replace `?` fallback avatars with `Unknown user` initials
- hide duplicate inert inline-thread toggles, add chevron labels/tooltips, and fall back to regular sibling replies when inline reply depth reaches the server limit

Fixes #1205.

## Verification
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py`
- `sbt 'Test/testOnly org.waveprotocol.box.j2cl.read.J2clReadSurfaceDomRendererMarkReadTest org.waveprotocol.box.j2cl.read.J2clReadSurfaceDomRendererTest org.waveprotocol.box.j2cl.search.J2clPlainTextDeltaFactoryTest org.waveprotocol.box.j2cl.richtext.J2clRichContentDeltaFactoryTest org.waveprotocol.box.j2cl.search.J2clSelectedWaveProjectorTest org.waveprotocol.box.j2cl.transport.SidecarFragmentsResponseTest'` (compile path passed; sbt reported no JVM tests for these J2CL test classes)
- `cd j2cl && ./mvnw -Psearch-sidecar -Dtest=J2clReadSurfaceDomRendererMarkReadTest,J2clReadSurfaceDomRendererTest,J2clPlainTextDeltaFactoryTest,J2clRichContentDeltaFactoryTest,J2clSelectedWaveProjectorTest,SidecarFragmentsResponseTest test`
- `cd j2cl/lit && npm ci`
- `cd j2cl/lit && npm test -- --files test/wave-blip.test.js`
- `git diff --check`
- `bash scripts/worktree-boot.sh --port 9917`
- `PORT=9917 bash scripts/wave-smoke.sh check`
- Chromium probe of `http://127.0.0.1:9917/?view=j2cl-root`: ready state complete, SupaWave text present


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline replies now fall back to regular sibling replies when inline depth limits are reached.

* **Bug Fixes**
  * Clicking unread blips marks them read immediately without causing page jumps.
  * Missing/blank author metadata now shows a stable "Unknown user" fallback with accessible labels.
  * Unread blips receive stronger, clearer visual highlighting.

* **UI Improvements**
  * Inline-thread toggles use clearer chevrons, improved tooltips, and hide duplicate/inert controls.

* **Documentation**
  * Added plan and changelog entry describing these reader parity updates.

* **Tests**
  * Added tests for unread styling, author fallbacks, reply-depth behavior, and thread toggle UX.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->