### PR TITLE
Fix J2CL inline reply plus affordance

### DIFF
--- a/docs/superpowers/plans/2026-05-08-issue-1208-j2cl-blip-plus-parity.md
+++ b/docs/superpowers/plans/2026-05-08-issue-1208-j2cl-blip-plus-parity.md
@@ -1,0 +1,37 @@
+# Issue 1208: J2CL Blip Plus Parity
+
+## Root Cause
+
+- J2CL renders parent-owned inline reply threads with a parent `<wave-blip>` chevron via `reply-count`.
+- The same renderer also injects a legacy `.j2cl-read-thread-toggle` button into every enhanced inline thread.
+- For J2CL-owned threads carrying `data-parent-blip-id`, that generated thread button is redundant with the parent chevron and can paint as the unexplained gutter plus/control shown in the report.
+- GWT does not expose that duplicate J2CL per-thread button as the normal read-surface affordance; the continuation/reply path remains separate.
+
+## Acceptance Criteria
+
+- Parent-owned J2CL inline threads do not get generated `.j2cl-read-thread-toggle` controls.
+- The parent blip chevron still collapses and expands all inline threads for that blip.
+- Legacy/server-rendered inline threads without `data-parent-blip-id` keep their generated toggle so old SSR enhancement remains operable.
+- Focus recovery, keyboard navigation, and collapse telemetry continue to work.
+- Add focused regression tests and run local browser/server sanity before PR.
+
+## Implementation Plan
+
+- Update `J2clReadSurfaceDomRenderer.enhanceInlineThread` to skip creating or retaining generated thread-toggle buttons for threads with `data-parent-blip-id`.
+- Update `toggleInlineThreadsForParent` so parent-chevron toggling works even when no per-thread button exists.
+- Keep `toggleThread` tolerant of a null button; it already updates the button only if present.
+- Change/extend `J2clReadSurfaceDomRendererTest` to lock the no-generated-toggle behavior and prove the parent chevron still toggles parent-owned threads.
+- Leave legacy enhancement tests for inline threads without `data-parent-blip-id` intact.
+
+## Verification Plan
+
+- Run the focused J2CL renderer test target for `J2clReadSurfaceDomRendererTest`.
+- Run `git diff --check`.
+- Run a local server sanity check and browser-visible verification against a J2CL wave surface, checking that no standalone `.j2cl-read-thread-toggle` appears for parent-owned threads and that the parent chevron remains functional.
+
+## Self Review Of Plan
+
+- Scope is narrow to the redundant J2CL inline-thread toggle seam; it does not remove reply creation or per-blip toolbar reply.
+- The plan preserves legacy SSR enhancement where no parent chevron exists.
+- The likely regression risk is collapse/focus behavior, so the tests target parent-chevron collapse plus existing legacy toggle behavior.
+- No migration, data model, or user-facing changelog JSON hand edit is needed; this is user-visible behavior, so a changelog fragment is required.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1073,9 +1073,7 @@ public final class J2clReadSurfaceDomRenderer {
           continue;
         }
         HTMLElement button = (HTMLElement) thread.querySelector(".j2cl-read-thread-toggle");
-        if (button != null) {
-          toggleThread(thread, button);
-        }
+        toggleThread(thread, button);
       }
     }
   }
@@ -1318,7 +1316,7 @@ public final class J2clReadSurfaceDomRenderer {
       String threadId = thread.getAttribute("data-thread-id");
       if (threadId != null && collapsedIds.contains(threadId)) {
         HTMLElement button = (HTMLElement) thread.querySelector(".j2cl-read-thread-toggle");
-        if (button != null) {
+        if (!thread.classList.contains("j2cl-read-thread-collapsed")) {
           toggleThread(thread, button);
         }
       }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -2519,6 +2519,15 @@ public final class J2clReadSurfaceDomRenderer {
     String label = threadLabel(thread, ordinal);
     thread.setAttribute("aria-label", label);
     thread.setAttribute("data-j2cl-thread-label", label);
+    if (thread.hasAttribute("data-parent-blip-id")) {
+      HTMLElement existingButton =
+          (HTMLElement) thread.querySelector(".j2cl-read-thread-toggle");
+      if (existingButton != null && existingButton.parentElement != null) {
+        existingButton.parentElement.removeChild(existingButton);
+      }
+      thread.setAttribute("data-j2cl-collapse-ready", "true");
+      return;
+    }
     if (thread.hasAttribute("data-j2cl-collapse-ready")) {
       HTMLElement existingButton = (HTMLElement) thread.querySelector(".j2cl-read-thread-toggle");
       if (existingButton != null) {
@@ -2672,9 +2681,6 @@ public final class J2clReadSurfaceDomRenderer {
     }
     for (HTMLElement thread : threads) {
       HTMLElement button = (HTMLElement) thread.querySelector(".j2cl-read-thread-toggle");
-      if (button == null) {
-        continue;
-      }
       boolean currentlyCollapsed = thread.classList.contains("j2cl-read-thread-collapsed");
       if (currentlyCollapsed != collapse) {
         toggleThread(thread, button);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -2521,7 +2521,10 @@ public final class J2clReadSurfaceDomRenderer {
     thread.setAttribute("data-j2cl-thread-label", label);
     if (thread.hasAttribute("data-parent-blip-id")) {
       HTMLElement existingButton =
-          (HTMLElement) thread.querySelector(".j2cl-read-thread-toggle");
+          (thread.firstElementChild != null
+                  && thread.firstElementChild.classList.contains("j2cl-read-thread-toggle"))
+              ? (HTMLElement) thread.firstElementChild
+              : null;
       if (existingButton != null && existingButton.parentElement != null) {
         existingButton.parentElement.removeChild(existingButton);
       }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1072,7 +1072,7 @@ public final class J2clReadSurfaceDomRenderer {
         if (thread == null || thread.classList.contains("j2cl-read-thread-collapsed")) {
           continue;
         }
-        HTMLElement button = (HTMLElement) thread.querySelector(".j2cl-read-thread-toggle");
+        HTMLElement button = ownToggleButton(thread);
         toggleThread(thread, button);
       }
     }
@@ -1315,7 +1315,7 @@ public final class J2clReadSurfaceDomRenderer {
       }
       String threadId = thread.getAttribute("data-thread-id");
       if (threadId != null && collapsedIds.contains(threadId)) {
-        HTMLElement button = (HTMLElement) thread.querySelector(".j2cl-read-thread-toggle");
+        HTMLElement button = ownToggleButton(thread);
         if (!thread.classList.contains("j2cl-read-thread-collapsed")) {
           toggleThread(thread, button);
         }
@@ -2530,7 +2530,7 @@ public final class J2clReadSurfaceDomRenderer {
       return;
     }
     if (thread.hasAttribute("data-j2cl-collapse-ready")) {
-      HTMLElement existingButton = (HTMLElement) thread.querySelector(".j2cl-read-thread-toggle");
+      HTMLElement existingButton = ownToggleButton(thread);
       if (existingButton != null) {
         updateThreadToggleButton(
             thread, existingButton, thread.classList.contains("j2cl-read-thread-collapsed"));
@@ -2681,7 +2681,7 @@ public final class J2clReadSurfaceDomRenderer {
       }
     }
     for (HTMLElement thread : threads) {
-      HTMLElement button = (HTMLElement) thread.querySelector(".j2cl-read-thread-toggle");
+      HTMLElement button = ownToggleButton(thread);
       boolean currentlyCollapsed = thread.classList.contains("j2cl-read-thread-collapsed");
       if (currentlyCollapsed != collapse) {
         toggleThread(thread, button);
@@ -3277,6 +3277,18 @@ public final class J2clReadSurfaceDomRenderer {
     button.setAttribute("aria-label", label);
     button.setAttribute("title", label);
     button.textContent = collapsed ? "\u25b8" : "\u25be";
+  }
+
+  // Returns the thread's own toggle button (always first child when present),
+  // or null for parent-owned threads that intentionally have no own button.
+  // Never descends into nested threads so callers cannot accidentally operate
+  // on a descendant legacy toggle.
+  private static HTMLElement ownToggleButton(HTMLElement thread) {
+    if (thread.firstElementChild != null
+        && thread.firstElementChild.classList.contains("j2cl-read-thread-toggle")) {
+      return (HTMLElement) thread.firstElementChild;
+    }
+    return null;
   }
 
   private void setFocusMarkers(HTMLElement blip) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -116,7 +116,7 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
-  public void parentOwnedInlineThreadToggleIsVisibleAndDescribed() {
+  public void parentOwnedInlineThreadUsesParentChevronWithoutGeneratedThreadToggle() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();
     J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
@@ -143,17 +143,12 @@ public class J2clReadSurfaceDomRendererTest {
                     false)),
             Collections.<String>emptyList()));
 
-    HTMLButtonElement toggle =
-        (HTMLButtonElement) host.querySelector(".inline-thread .j2cl-read-thread-toggle");
-    Assert.assertNotNull(toggle);
-    Assert.assertFalse(toggle.hasAttribute("hidden"));
-    Assert.assertNull(toggle.getAttribute("aria-hidden"));
-    Assert.assertEquals("true", toggle.getAttribute("aria-expanded"));
     Assert.assertEquals(
-        "Collapse inline reply thread 2 (b+root::t+inline)", toggle.getAttribute("aria-label"));
-    Assert.assertEquals(
-        "Collapse inline reply thread 2 (b+root::t+inline)", toggle.getAttribute("title"));
-    Assert.assertEquals("▾", toggle.textContent);
+        "Parent-owned J2CL threads use the parent wave-blip chevron; the generated"
+            + " per-thread toggle paints as a stray gutter control.",
+        0,
+        host.querySelectorAll(".inline-thread[data-parent-blip-id] .j2cl-read-thread-toggle").length);
+    Assert.assertEquals("1", blip(host, "b+root").getAttribute("reply-count"));
   }
 
   @Test
@@ -1196,6 +1191,10 @@ public class J2clReadSurfaceDomRendererTest {
     HTMLElement root = blip(host, "b+root");
     HTMLElement thread =
         (HTMLElement) host.querySelector(".inline-thread[data-thread-id='t+inline']");
+    Assert.assertEquals(
+        "Parent chevron is the only visible J2CL affordance for this thread.",
+        0,
+        host.querySelectorAll(".inline-thread[data-parent-blip-id] .j2cl-read-thread-toggle").length);
 
     dispatchThreadToggle(root, "b+root");
     Assert.assertTrue(thread.classList.contains("j2cl-read-thread-collapsed"));

--- a/wave/config/changelog.d/2026-05-08-issue-1208-j2cl-inline-thread-plus.json
+++ b/wave/config/changelog.d/2026-05-08-issue-1208-j2cl-inline-thread-plus.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-08-issue-1208-j2cl-inline-thread-plus",
+  "version": "Issue #1208",
+  "date": "2026-05-08",
+  "title": "J2CL inline reply controls match GWT",
+  "summary": "Removes redundant J2CL inline-thread plus controls from parent-owned blips so the visible reply-thread affordance matches the GWT-style parent chevron.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Parent-owned inline replies in the J2CL wave view now use the blip's existing reply chevron instead of an extra gutter plus control that had no useful label and often appeared inert."
+      ]
+    }
+  ]
+}

--- a/wave/src/e2e/j2cl-gwt-parity/tests/issue-1208-inline-thread-plus.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/issue-1208-inline-thread-plus.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect, Page } from "@playwright/test";
+import { freshCredentials, registerAndSignIn } from "../fixtures/testUser";
+import { GwtPage } from "../pages/GwtPage";
+import { J2clPage } from "../pages/J2clPage";
+
+const BASE_URL = process.env.WAVE_E2E_BASE_URL ?? "http://127.0.0.1:9900";
+
+async function blipIds(page: Page): Promise<string[]> {
+  return await page
+    .locator("wave-blip[data-blip-id], [kind='b'][data-blip-id]")
+    .evaluateAll(els =>
+      els
+        .map(el => el.getAttribute("data-blip-id") || "")
+        .filter(id => id.length > 0)
+    );
+}
+
+async function waitForBlipCount(page: Page, n: number): Promise<void> {
+  await expect
+    .poll(async () => (await blipIds(page)).length, {
+      timeout: 30_000,
+      message: `expected at least ${n} blips`
+    })
+    .toBeGreaterThanOrEqual(n);
+}
+
+test.describe("Issue #1208 J2CL inline reply affordance", () => {
+  test.setTimeout(180_000);
+
+  test("parent-owned inline replies use the parent chevron without a gutter plus", async ({
+    page
+  }) => {
+    const creds = freshCredentials("i1208");
+    await registerAndSignIn(page, BASE_URL, creds);
+
+    const gwt = new GwtPage(page, BASE_URL);
+    await gwt.goto("/");
+    await gwt.assertInboxLoaded();
+    await page.waitForLoadState("networkidle", { timeout: 30_000 });
+
+    await expect(gwt.newWaveAffordance()).toBeVisible({ timeout: 15_000 });
+    await gwt.newWaveAffordance().click();
+    await waitForBlipCount(page, 1);
+    const waveId = await gwt.readWaveIdFromHash();
+    await gwt.typeIntoBlipDocument("Issue 1208 root");
+
+    const rootBlipId = (await blipIds(page))[0];
+    await gwt.clickReplyOnBlip(rootBlipId);
+    await waitForBlipCount(page, 2);
+    await gwt.typeIntoBlipDocument("Issue 1208 inline parent");
+
+    const replyParentBlipId = (await blipIds(page))[1];
+    await gwt.clickReplyOnBlip(replyParentBlipId);
+    await waitForBlipCount(page, 3);
+    await gwt.typeIntoBlipDocument("Issue 1208 nested reply");
+
+    const j2cl = new J2clPage(page, BASE_URL);
+    await j2cl.gotoWave(waveId);
+    await j2cl.assertInboxLoaded();
+
+    const inlineThread = page.locator(
+      `.inline-thread[data-parent-blip-id="${replyParentBlipId}"]`
+    );
+    await expect
+      .poll(async () => await inlineThread.count(), {
+        timeout: 60_000,
+        message: "expected at least one parent-owned inline thread"
+      })
+      .toBeGreaterThanOrEqual(1);
+    await expect(inlineThread.locator(".j2cl-read-thread-toggle")).toHaveCount(
+      0
+    );
+
+    const chevron = page
+      .locator(
+        `wave-blip[data-blip-id="${replyParentBlipId}"] [data-thread-chevron="true"]`
+      )
+      .first();
+    await expect(chevron).toBeVisible({ timeout: 10_000 });
+
+    await chevron.click();
+    await expect
+      .poll(
+        async () =>
+          await inlineThread.evaluateAll(els =>
+            els.every(
+              el => el.getAttribute("data-j2cl-thread-collapsed") === "true"
+            )
+          ),
+        {
+          timeout: 10_000,
+          message: "parent chevron should collapse every inline thread"
+        }
+      )
+      .toBe(true);
+  });
+});

--- a/wave/src/e2e/j2cl-gwt-parity/tests/wave-reading-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/wave-reading-parity.spec.ts
@@ -399,9 +399,9 @@ async function assertFocusMovesOnArrowDown(
 }
 
 /**
- * Clicks the collapse chevron / toggle for the inline-reply thread
- * under the parent blip and asserts at least one descendant blip
- * disappears from the visible blip count.
+ * Clicks the parent blip's collapse chevron for the inline-reply
+ * thread and asserts at least one descendant blip disappears from the
+ * visible blip count.
  */
 async function assertCollapseFoldsReplyChain(
   page: Page,
@@ -412,19 +412,23 @@ async function assertCollapseFoldsReplyChain(
     .count();
   expect(before).toBeGreaterThanOrEqual(4);
 
-  // The J2CL renderer mounts a `.j2cl-read-thread-toggle` button on
-  // every inline-thread wrapper under the parent blip. Fail hard when
-  // absent so a regression in the renderer's enhanceInlineThread wiring
-  // stays visible rather than silently passing via a wrong-thread fallback.
+  await expect(
+    page.locator(
+      `[data-parent-blip-id="${parentBlipId}"] .j2cl-read-thread-toggle`
+    ),
+    "J2CL parent-owned inline threads should use the parent blip chevron, " +
+      "not a generated per-thread gutter toggle."
+  ).toHaveCount(0);
+
   const toggle = page
     .locator(
-      `[data-parent-blip-id="${parentBlipId}"] .j2cl-read-thread-toggle`
+      `wave-blip[data-blip-id="${parentBlipId}"] [data-thread-chevron="true"]`
     )
     .first();
   await expect(
     toggle,
-    `assertCollapseFoldsReplyChain: no .j2cl-read-thread-toggle found under ` +
-      `[data-parent-blip-id="${parentBlipId}"] on J2CL view.`
+    `assertCollapseFoldsReplyChain: no parent wave-blip chevron found for ` +
+      `${parentBlipId} on J2CL view.`
   ).toBeVisible({ timeout: 10_000 });
 
   await toggle.click();


### PR DESCRIPTION
## Summary
- Remove generated `.j2cl-read-thread-toggle` controls from parent-owned J2CL inline threads so the visible affordance matches the parent blip chevron used by the GWT-style surface.
- Keep legacy/server-rendered inline-thread toggles for threads without `data-parent-blip-id`.
- Add focused browser regression coverage for issue #1208 and update the parity helper to assert no redundant J2CL gutter toggle.

Fixes #1208

## Verification
- `sbt -batch j2clSearchTest`
- `cd j2cl && ./mvnw -Psearch-sidecar test` (1059 tests, 0 failures, 0 errors, 188 skipped; browser-DOM renderer tests are skipped by the JVM runner)
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py`
- `sbt -batch j2clSearchBuild`
- `cd j2cl && ./mvnw -Psearch-sidecar package`
- `bash scripts/worktree-boot.sh --port 9928`
- `PORT=9928 bash scripts/wave-smoke.sh check`
- `cd wave/src/e2e/j2cl-gwt-parity && WAVE_E2E_BASE_URL=http://127.0.0.1:9928 npx playwright test tests/issue-1208-inline-thread-plus.spec.ts --project=chromium`
- `git diff --check`

## Known unrelated local note
- `wave-reading-parity.spec.ts` still fails before its collapse assertion on the existing J2CL metadata gate: after 60s it sees 1 populated J2CL blip instead of the expected 4. The focused #1208 browser regression avoids that unrelated gate and verifies the redundant-toggle removal plus parent-chevron collapse behavior.
