### PR TITLE
Keep default app build off J2CL sidecar

### DIFF
--- a/.github/workflows/j2cl-gwt-parity-e2e.yml
+++ b/.github/workflows/j2cl-gwt-parity-e2e.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Compile PST and Wave
         run: sbt --batch pst/compile wave/compile
 
+      - name: Build J2CL runtime assets
+        run: sbt --batch j2clRuntimeBuild
+
       - name: Stage distribution
         run: sbt --batch Universal/stage
 
@@ -57,18 +60,12 @@ jobs:
         run: PORT=9898 bash scripts/wave-smoke.sh start
 
       - name: Sanity-check server
-        # G-PORT-4 (#1113): the original `wave-smoke.sh check` subcommand
-        # asserts that the unauthenticated root path serves the GWT
-        # bootstrap asset (webclient.nocache.js). That stopped being
-        # true once `/` started routing signed-out visitors to the
-        # marketing page (this predates G-PORT-4 — see
-        # WaveClientServlet.java:165-178). The Playwright fixtures
-        # register a fresh user before exercising any view, so the
-        # signed-in routing does not depend on the smoke `check`. We
-        # assert a 200 from `/` directly here, which is what the
-        # harness actually needs before launching browsers.
+        # This parity lane explicitly builds J2CL assets above, so keep the
+        # smoke check strict for the J2CL index and sidecar before launching
+        # the browser harness.
         run: |
           PORT=9898 bash scripts/wave-smoke.sh status
+          WAVE_SMOKE_REQUIRE_J2CL_ASSETS=1 PORT=9898 bash scripts/wave-smoke.sh check
           status=$(curl -sS --max-time 15 --connect-timeout 5 -o /dev/null -w "%{http_code}" "http://localhost:9898/")
           if [[ "$status" -ne 200 ]]; then
             echo "Root path returned non-200: $status" >&2

--- a/.github/workflows/j2cl-gwt-parity-e2e.yml
+++ b/.github/workflows/j2cl-gwt-parity-e2e.yml
@@ -51,6 +51,8 @@ jobs:
         run: sbt --batch j2clRuntimeBuild
 
       - name: Stage distribution
+        env:
+          WAVE_STAGE_INCLUDE_J2CL_ASSETS: '1'
         run: sbt --batch Universal/stage
 
       - name: Start Wave server

--- a/build.sbt
+++ b/build.sbt
@@ -666,9 +666,13 @@ Universal / mappings ++= {
   val configFiles = (configDir ** "*").get.filter(_.isFile).map { f =>
     f -> ("config/" + IO.relativize(configDir, f).get)
   }
-  // war/ -> war/
+  // war/ -> war/ (excluding J2CL output dirs that are only built on explicit request)
   val warDir = base / "war"
-  val warFiles = (warDir ** "*").get.filter(_.isFile).map { f =>
+  val j2clOutputDirs = Set("j2cl", "j2cl-search", "j2cl-debug")
+  val warFiles = (warDir ** "*").get.filter(_.isFile).filter { f =>
+    val rel = IO.relativize(warDir, f).getOrElse("")
+    !j2clOutputDirs.exists(d => rel == d || rel.startsWith(d + "/"))
+  }.map { f =>
     f -> ("war/" + IO.relativize(warDir, f).get)
   }
   // Root docs

--- a/build.sbt
+++ b/build.sbt
@@ -666,14 +666,13 @@ Universal / mappings ++= {
   val configFiles = (configDir ** "*").get.filter(_.isFile).map { f =>
     f -> ("config/" + IO.relativize(configDir, f).get)
   }
-  // war/ -> war/ (J2CL output dirs are always excluded here; Universal/stage
-  // copies them in post-hoc only when j2clRuntimeBuild populated them, so
-  // packageBin never ships stale sidecar assets from a prior session)
+  // war/ -> war/ (excluding J2CL output dirs unless explicitly requested)
   val warDir = base / "war"
   val j2clOutputDirs = Set("j2cl", "j2cl-search", "j2cl-debug")
+  val includeJ2clAssets = sys.env.get("WAVE_STAGE_INCLUDE_J2CL_ASSETS").contains("1")
   val warFiles = (warDir ** "*").get.filter(_.isFile).filter { f =>
     val rel = IO.relativize(warDir, f).getOrElse("")
-    !j2clOutputDirs.exists(d => rel == d || rel.startsWith(d + "/"))
+    includeJ2clAssets || !j2clOutputDirs.exists(d => rel == d || rel.startsWith(d + "/"))
   }.map { f =>
     f -> ("war/" + IO.relativize(warDir, f).get)
   }
@@ -970,15 +969,11 @@ ThisBuild / j2clProductionBuild := {
   runJ2clWrapper(log, base, "production", "package")
 }
 
-ThisBuild / j2clRuntimeBuild := {
-  Def.sequential(
-    ThisBuild / j2clSearchBuild,
-    ThisBuild / j2clProductionBuild,
-    ThisBuild / j2clLitBuild
-  ).value
-  // Write a sentinel so Universal/stage knows J2CL was built in this sbt invocation.
-  IO.touch(baseDirectory.value / "target" / "j2cl-built.marker")
-}
+ThisBuild / j2clRuntimeBuild := Def.sequential(
+  ThisBuild / j2clSearchBuild,
+  ThisBuild / j2clProductionBuild,
+  ThisBuild / j2clLitBuild
+).value
 
 // sbt-protoc: use embedded protoc to generate Java directly into proto_src
 // Protoc version is managed by sbt-protoc; proto2 syntax is supported.
@@ -1397,6 +1392,7 @@ ThisBuild / compileGwtDev := {
 
 // Prevent packaging distributions with missing GWT assets when -DskipGwt=true
 lazy val verifyGwtAssets = taskKey[Unit]("Fail when packaging would ship with missing GWT assets")
+lazy val cleanStagedJ2clAssets = taskKey[Unit]("Remove stale J2CL assets from the staged default distribution")
 
 ThisBuild / verifyGwtAssets := {
   val log = streams.value.log
@@ -1408,28 +1404,23 @@ ThisBuild / verifyGwtAssets := {
   log.info("[verifyGwtAssets] OK — GWT assets will be compiled")
 }
 
+ThisBuild / cleanStagedJ2clAssets := {
+  val stagedWarDir = target.value / "universal" / "stage" / "war"
+  IO.delete(Seq(
+    stagedWarDir / "j2cl",
+    stagedWarDir / "j2cl-search",
+    stagedWarDir / "j2cl-debug"
+  ))
+}
+
 // Wire compileGwt to run after compileJava (GWT needs compiled classes)
 compileGwt := (compileGwt).dependsOn(Compile / compile).value
 devCompile := (Compile / compile).value
 compileGwtDev := (compileGwtDev).dependsOn(Compile / compile).value
 
-Universal / stage := {
-  val stagedDir = (Universal / stage).dependsOn(compileGwt, verifyGwtAssets).value
-  val stagedWarDir = stagedDir / "war"
-  val warDir = baseDirectory.value / "war"
-  // Copy J2CL dirs only when j2clRuntimeBuild ran in this invocation (marker present),
-  // so stale outputs from a prior build are never silently included in a default stage.
-  val j2clMarker = baseDirectory.value / "target" / "j2cl-built.marker"
-  if (j2clMarker.exists()) {
-    Seq("j2cl", "j2cl-search", "j2cl-debug").foreach { d =>
-      val srcDir = warDir / d
-      if (srcDir.exists && Option(srcDir.listFiles()).exists(_.nonEmpty))
-        IO.copyDirectory(srcDir, stagedWarDir / d)
-    }
-    IO.delete(j2clMarker)
-  }
-  stagedDir
-}
+Universal / stage := (Universal / stage)
+  .dependsOn(cleanStagedJ2clAssets, compileGwt, verifyGwtAssets)
+  .value
 Universal / packageBin := (Universal / packageBin).dependsOn(compileGwt, verifyGwtAssets).value
 
 cleanFiles += baseDirectory.value / "war" / "webclient"

--- a/build.sbt
+++ b/build.sbt
@@ -970,11 +970,15 @@ ThisBuild / j2clProductionBuild := {
   runJ2clWrapper(log, base, "production", "package")
 }
 
-ThisBuild / j2clRuntimeBuild := Def.sequential(
-  ThisBuild / j2clSearchBuild,
-  ThisBuild / j2clProductionBuild,
-  ThisBuild / j2clLitBuild
-).value
+ThisBuild / j2clRuntimeBuild := {
+  Def.sequential(
+    ThisBuild / j2clSearchBuild,
+    ThisBuild / j2clProductionBuild,
+    ThisBuild / j2clLitBuild
+  ).value
+  // Write a sentinel so Universal/stage knows J2CL was built in this sbt invocation.
+  IO.touch(baseDirectory.value / "target" / "j2cl-built.marker")
+}
 
 // sbt-protoc: use embedded protoc to generate Java directly into proto_src
 // Protoc version is managed by sbt-protoc; proto2 syntax is supported.
@@ -1413,12 +1417,16 @@ Universal / stage := {
   val stagedDir = (Universal / stage).dependsOn(compileGwt, verifyGwtAssets).value
   val stagedWarDir = stagedDir / "war"
   val warDir = baseDirectory.value / "war"
-  // J2CL dirs are excluded from Universal/mappings unconditionally; copy them
-  // into the staged distribution only when j2clRuntimeBuild populated them.
-  Seq("j2cl", "j2cl-search", "j2cl-debug").foreach { d =>
-    val srcDir = warDir / d
-    if (srcDir.exists && Option(srcDir.listFiles()).exists(_.nonEmpty))
-      IO.copyDirectory(srcDir, stagedWarDir / d)
+  // Copy J2CL dirs only when j2clRuntimeBuild ran in this invocation (marker present),
+  // so stale outputs from a prior build are never silently included in a default stage.
+  val j2clMarker = baseDirectory.value / "target" / "j2cl-built.marker"
+  if (j2clMarker.exists()) {
+    Seq("j2cl", "j2cl-search", "j2cl-debug").foreach { d =>
+      val srcDir = warDir / d
+      if (srcDir.exists && Option(srcDir.listFiles()).exists(_.nonEmpty))
+        IO.copyDirectory(srcDir, stagedWarDir / d)
+    }
+    IO.delete(j2clMarker)
   }
   stagedDir
 }

--- a/build.sbt
+++ b/build.sbt
@@ -666,12 +666,17 @@ Universal / mappings ++= {
   val configFiles = (configDir ** "*").get.filter(_.isFile).map { f =>
     f -> ("config/" + IO.relativize(configDir, f).get)
   }
-  // war/ -> war/ (excluding J2CL output dirs that are only built on explicit request)
+  // war/ -> war/ (excluding J2CL output dirs only when they are absent/empty;
+  // if j2clRuntimeBuild was run explicitly, honour those assets in staging)
   val warDir = base / "war"
   val j2clOutputDirs = Set("j2cl", "j2cl-search", "j2cl-debug")
+  val absentJ2clDirs = j2clOutputDirs.filter { d =>
+    val dir = warDir / d
+    !dir.exists || Option(dir.listFiles()).forall(_.isEmpty)
+  }
   val warFiles = (warDir ** "*").get.filter(_.isFile).filter { f =>
     val rel = IO.relativize(warDir, f).getOrElse("")
-    !j2clOutputDirs.exists(d => rel == d || rel.startsWith(d + "/"))
+    !absentJ2clDirs.exists(d => rel == d || rel.startsWith(d + "/"))
   }.map { f =>
     f -> ("war/" + IO.relativize(warDir, f).get)
   }

--- a/build.sbt
+++ b/build.sbt
@@ -1407,7 +1407,16 @@ compileGwt := (compileGwt).dependsOn(Compile / compile).value
 devCompile := (Compile / compile).value
 compileGwtDev := (compileGwtDev).dependsOn(Compile / compile).value
 
-Universal / stage := (Universal / stage).dependsOn(compileGwt, verifyGwtAssets).value
+Universal / stage := {
+  val stagedDir = (Universal / stage).dependsOn(compileGwt, verifyGwtAssets).value
+  val stagedWarDir = stagedDir / "war"
+  IO.delete(Seq(
+    stagedWarDir / "j2cl",
+    stagedWarDir / "j2cl-search",
+    stagedWarDir / "j2cl-debug"
+  ))
+  stagedDir
+}
 Universal / packageBin := (Universal / packageBin).dependsOn(compileGwt, verifyGwtAssets).value
 
 cleanFiles += baseDirectory.value / "war" / "webclient"

--- a/build.sbt
+++ b/build.sbt
@@ -666,17 +666,14 @@ Universal / mappings ++= {
   val configFiles = (configDir ** "*").get.filter(_.isFile).map { f =>
     f -> ("config/" + IO.relativize(configDir, f).get)
   }
-  // war/ -> war/ (excluding J2CL output dirs only when they are absent/empty;
-  // if j2clRuntimeBuild was run explicitly, honour those assets in staging)
+  // war/ -> war/ (J2CL output dirs are always excluded here; Universal/stage
+  // copies them in post-hoc only when j2clRuntimeBuild populated them, so
+  // packageBin never ships stale sidecar assets from a prior session)
   val warDir = base / "war"
   val j2clOutputDirs = Set("j2cl", "j2cl-search", "j2cl-debug")
-  val absentJ2clDirs = j2clOutputDirs.filter { d =>
-    val dir = warDir / d
-    !dir.exists || Option(dir.listFiles()).forall(_.isEmpty)
-  }
   val warFiles = (warDir ** "*").get.filter(_.isFile).filter { f =>
     val rel = IO.relativize(warDir, f).getOrElse("")
-    !absentJ2clDirs.exists(d => rel == d || rel.startsWith(d + "/"))
+    !j2clOutputDirs.exists(d => rel == d || rel.startsWith(d + "/"))
   }.map { f =>
     f -> ("war/" + IO.relativize(warDir, f).get)
   }
@@ -1415,11 +1412,14 @@ compileGwtDev := (compileGwtDev).dependsOn(Compile / compile).value
 Universal / stage := {
   val stagedDir = (Universal / stage).dependsOn(compileGwt, verifyGwtAssets).value
   val stagedWarDir = stagedDir / "war"
-  IO.delete(Seq(
-    stagedWarDir / "j2cl",
-    stagedWarDir / "j2cl-search",
-    stagedWarDir / "j2cl-debug"
-  ))
+  val warDir = baseDirectory.value / "war"
+  // J2CL dirs are excluded from Universal/mappings unconditionally; copy them
+  // into the staged distribution only when j2clRuntimeBuild populated them.
+  Seq("j2cl", "j2cl-search", "j2cl-debug").foreach { d =>
+    val srcDir = warDir / d
+    if (srcDir.exists && Option(srcDir.listFiles()).exists(_.nonEmpty))
+      IO.copyDirectory(srcDir, stagedWarDir / d)
+  }
   stagedDir
 }
 Universal / packageBin := (Universal / packageBin).dependsOn(compileGwt, verifyGwtAssets).value

--- a/build.sbt
+++ b/build.sbt
@@ -1189,9 +1189,10 @@ Compile / compile := (Compile / compile)
   // generateGxp removed — GXP replaced by HtmlRenderer
   .value
 
-// Ensure `run` has a config in place and both browser runtimes are rebuilt
-// before launching the server.
-Compile / run := (Compile / run).dependsOn(prepareServerConfig, j2clRuntimeBuild, compileGwt).evaluated
+// Ensure `run` has a config in place and the default GWT browser runtime is
+// rebuilt before launching the server. J2CL sidecar builds remain explicit SBT
+// tasks so the normal app path does not depend on the Maven-backed sidecar.
+Compile / run := (Compile / run).dependsOn(prepareServerConfig, compileGwt).evaluated
 
 // =============================================================================
 // Phase 6: GWT Compilation Bridge
@@ -1402,8 +1403,8 @@ compileGwt := (compileGwt).dependsOn(Compile / compile).value
 devCompile := (Compile / compile).value
 compileGwtDev := (compileGwtDev).dependsOn(Compile / compile).value
 
-Universal / stage := (Universal / stage).dependsOn(j2clRuntimeBuild, compileGwt, verifyGwtAssets).value
-Universal / packageBin := (Universal / packageBin).dependsOn(j2clRuntimeBuild, compileGwt, verifyGwtAssets).value
+Universal / stage := (Universal / stage).dependsOn(compileGwt, verifyGwtAssets).value
+Universal / packageBin := (Universal / packageBin).dependsOn(compileGwt, verifyGwtAssets).value
 
 cleanFiles += baseDirectory.value / "war" / "webclient"
 cleanFiles += baseDirectory.value / "war" / "org"

--- a/docs/BUILDING-sbt.md
+++ b/docs/BUILDING-sbt.md
@@ -54,10 +54,10 @@ supported JDK 17 / Jakarta server path and the repo's current SBT layout.
   - `prepareServerConfig` still bootstraps the root `config/` directory because
     some runtime helpers expect those copies even though the default `sbt run`
     java options point at `wave/config/`.
-  - `sbt run` also rebuilds the maintained J2CL root shell, the J2CL
-    search-sidecar asset, the production `/j2cl/**` asset tree, and the legacy
-    `/webclient/**` asset tree so the runtime does not depend on leftover
-    browser artifacts under `war/`.
+  - `sbt run` rebuilds the legacy `/webclient/**` asset tree through
+    `compileGwt`. It does not build the J2CL sidecar assets by default.
+    Run the explicit J2CL SBT tasks below when you are working on J2CL or need
+    `/j2cl/**` and `/j2cl-search/**` assets for a smoke check.
   - To override, replace the relevant `Compile / javaOptions` entry with your
     own absolute path.
 
@@ -65,10 +65,10 @@ supported JDK 17 / Jakarta server path and the repo's current SBT layout.
   - `sbt j2clSearchBuild`
   - `sbt j2clProductionBuild`
   - `sbt compileGwt`
-  - `sbt run` rebuilds both the maintained J2CL assets and the rollback-ready
-    `/webclient/**` asset tree before launch.
-  - `Universal/stage` and `Universal/packageBin` depend on both the maintained
-    J2CL build tasks and `compileGwt`.
+  - `sbt run` rebuilds the rollback-ready `/webclient/**` asset tree before
+    launch.
+  - `Universal/stage` and `Universal/packageBin` depend on `compileGwt` and do
+    not build the J2CL sidecar unless you run the J2CL tasks explicitly.
 
 - WebSocket endpoint: `/socket` via JSR 356. Socket.IO `/socket.io/*` is disabled.
 - Status: `/statusz/socket` returns websocket/http address info (JSON)

--- a/docs/BUILDING-sbt.md
+++ b/docs/BUILDING-sbt.md
@@ -68,7 +68,9 @@ supported JDK 17 / Jakarta server path and the repo's current SBT layout.
   - `sbt run` rebuilds the rollback-ready `/webclient/**` asset tree before
     launch.
   - `Universal/stage` and `Universal/packageBin` depend on `compileGwt` and do
-    not build the J2CL sidecar unless you run the J2CL tasks explicitly.
+    not build or stage the J2CL sidecar unless you run the J2CL tasks
+    explicitly and set `WAVE_STAGE_INCLUDE_J2CL_ASSETS=1` for the stage/package
+    command.
 
 - WebSocket endpoint: `/socket` via JSR 356. Socket.IO `/socket.io/*` is disabled.
 - Status: `/statusz/socket` returns websocket/http address info (JSON)

--- a/docs/SMOKE_TESTS.md
+++ b/docs/SMOKE_TESTS.md
@@ -24,7 +24,10 @@ distribution:
    - Expected: `ROOT_STATUS=200`, `ROOT_GWT=present`, `ROOT_SHELL=present`
      (compatibility alias), `HEALTH_STATUS=200`, `LANDING_STATUS=200`,
      `J2CL_ROOT_STATUS=200`, `J2CL_ROOT_SHELL=present`,
-     `J2CL_INDEX_STATUS=200`, `SIDECAR_STATUS=200`, `WEBCLIENT_STATUS=200`
+     `J2CL_ASSET_CHECK=optional`, and `WEBCLIENT_STATUS=200`. J2CL asset
+     statuses are still printed; require `J2CL_INDEX_STATUS=200` and
+     `SIDECAR_STATUS=200` only when running
+     `WAVE_SMOKE_REQUIRE_J2CL_ASSETS=1 bash scripts/wave-smoke.sh check`.
 4. Stop: `bash scripts/wave-smoke.sh stop`
 
 For issue worktrees, use

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -88,9 +88,9 @@ Read these files first when resuming work:
   Jakarta replacement exists for a class under `wave/src/main/java/`.
 - The SBT build now uses stable jar naming and `wave/config/`-backed runtime
   defaults.
-- `sbt run` depends on `prepareServerConfig` and both maintained J2CL build
-  tasks; `compileGwt` remains a manual bridge task for the retired legacy
-  webclient path and is no longer wired into the default run/package flow.
+- `sbt run` depends on `prepareServerConfig` and `compileGwt` so the default
+  app path stays SBT/GWT-only. Maintained J2CL sidecar assets are built through
+  explicit SBT tasks such as `j2clSearchBuild` and `j2clProductionBuild`.
 - Phase 6 protobuf and server-side Guava work are already closed in the
   modernization ledger.
 - The Phase 8 baseline docs have been refreshed after the merged Phase 0 cleanup:

--- a/docs/j2cl-gwt3-inventory.md
+++ b/docs/j2cl-gwt3-inventory.md
@@ -71,10 +71,11 @@ What changed since the earlier inventory:
 - the repo now has an isolated `j2cl/` sidecar subtree
 - `build.sbt` now exposes `j2clSandboxBuild`, `j2clSandboxTest`,
   `j2clSearchBuild`, `j2clSearchTest`, and `j2clProductionBuild`
-- `sbt run`, `Universal/stage`, and `Universal/packageBin` now depend on the
-  maintained J2CL build tasks instead of the legacy `compileGwt` path
-- the browser client still has legacy GWT compile/runtime code, but it is no
-  longer part of the default run/package flow
+- `sbt run`, `Universal/stage`, and `Universal/packageBin` now stay on the
+  default `compileGwt` app path and no longer build the J2CL sidecar
+  transitively
+- the maintained J2CL sidecar remains available through explicit SBT tasks for
+  J2CL parity and diagnostic work
 
 The current toolchain picture means a J2CL move is still not just a compiler
 swap, but the dependency-cleanup story is no longer blocked on `guava-gwt`.

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -104,7 +104,8 @@ commit only changelog fragments under `wave/config/changelog.d/`.
 ### 2. Run The Cross-Path Build Gate
 
 ```bash
-sbt -batch j2clSearchBuild j2clSearchTest compileGwt Universal/stage
+sbt --batch "j2clSearchBuild; j2clSearchTest"
+WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 sbt --batch "compileGwt; Universal/stage"
 ```
 
 This is the minimum trustworthy gate for the current coexistence phase because it
@@ -314,7 +315,12 @@ when a local smoke check needs `/j2cl/**` or `/j2cl-search/**` assets:
 ```bash
 sbt --batch "j2clSearchBuild; j2clSearchTest"
 sbt --batch "j2clProductionBuild; j2clLitBuild"
+WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 sbt --batch Universal/stage
 ```
+
+Use `WAVE_STAGE_INCLUDE_J2CL_ASSETS=1` only for those explicit J2CL lanes; the
+default stage/package path removes J2CL output directories so stale sidecar
+assets are not shipped accidentally.
 
 Do not use `j2cl/mvnw` as routine verification evidence. The wrapper remains an
 implementation detail of the current Vertispan sidecar toolchain until the repo

--- a/docs/runbooks/j2cl-sidecar-testing.md
+++ b/docs/runbooks/j2cl-sidecar-testing.md
@@ -125,7 +125,7 @@ Then run the exact printed commands. The normal shape is:
 
 ```bash
 PORT=9900 JAVA_OPTS='-Djava.util.logging.config.file=... -Djava.security.auth.login.config=...' bash scripts/wave-smoke.sh start
-PORT=9900 bash scripts/wave-smoke.sh check
+WAVE_SMOKE_REQUIRE_J2CL_ASSETS=1 PORT=9900 bash scripts/wave-smoke.sh check
 ```
 
 Keep the server running through the route checks and browser verification
@@ -263,7 +263,7 @@ the opt-in J2CL root mode.
 ```bash
 bash scripts/worktree-boot.sh --port 9914
 PORT=9914 bash scripts/wave-smoke.sh start
-PORT=9914 bash scripts/wave-smoke.sh check
+WAVE_SMOKE_REQUIRE_J2CL_ASSETS=1 PORT=9914 bash scripts/wave-smoke.sh check
 curl -fsS http://localhost:9914/ | grep -F 'webclient/webclient.nocache.js'
 curl -fsS http://localhost:9914/?view=landing | grep -F 'nav-link-signin'
 curl -fsS http://localhost:9914/?view=j2cl-root | grep -F 'data-j2cl-root-shell'
@@ -302,22 +302,23 @@ Expected result:
 - `/webclient/webclient.nocache.js` remains reachable in opt-in J2CL mode
 - `/?view=landing` remains the explicit public landing page
 
-## When To Use Direct Maven Instead Of SBT
+## SBT-Only Operator Boundary
 
-Prefer the SBT tasks above for normal repo work. Use the Maven wrapper only
-when you need to debug the J2CL sidecar in isolation.
+Normal app boot, stage, and package commands do not build the J2CL sidecar:
+`sbt run`, `sbt Universal/stage`, and `sbt Universal/packageBin` stay on the
+GWT/default app path.
 
-From `j2cl/`:
+Run J2CL sidecar builds explicitly through SBT when the task touches J2CL or
+when a local smoke check needs `/j2cl/**` or `/j2cl-search/**` assets:
 
 ```bash
-./mvnw -Psearch-sidecar test
-./mvnw -Psearch-sidecar package
-./mvnw -Pdebug-single-project package
-./mvnw -Pproduction package
+sbt --batch "j2clSearchBuild; j2clSearchTest"
+sbt --batch "j2clProductionBuild; j2clLitBuild"
 ```
 
-Use those only for deep sidecar debugging; the repo-standard verification path
-should still go through SBT.
+Do not use `j2cl/mvnw` as routine verification evidence. The wrapper remains an
+implementation detail of the current Vertispan sidecar toolchain until the repo
+migrates J2CL itself to a non-Maven build path.
 
 ## Common Failure Signals
 

--- a/docs/superpowers/plans/2026-05-08-sbt-only-default-build.md
+++ b/docs/superpowers/plans/2026-05-08-sbt-only-default-build.md
@@ -1,0 +1,169 @@
+# SBT-Only Default Build Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the normal app build path use SBT only, without transitively depending on the J2CL Maven wrapper.
+
+**Architecture:** Keep the existing J2CL sidecar tasks available as explicit SBT entrypoints, because the current upstream J2CL toolchain is still exposed through Vertispan Maven plugin goals. Remove the sidecar runtime build from `sbt run`, `Universal/stage`, and `Universal/packageBin` so normal app boot/stage/package no longer invokes Maven unless an operator deliberately runs a J2CL task.
+
+**Tech Stack:** SBT 1.10 build definition, sbt-native-packager, J2CL sidecar tasks under `build.sbt`, contract tests under `wave/src/test/java`, docs under `docs/`.
+
+---
+
+### Task 1: Pin the default-build contract before changing wiring
+
+**Files:**
+- Modify: `wave/src/test/java/org/waveprotocol/box/server/util/J2clBuildStageContractTest.java`
+
+- [ ] **Step 1: Write the failing contract assertions**
+
+Replace the current body of `testBuildSbtSerializesStageJ2clBuilds` so it asserts `j2clRuntimeBuild` remains explicit but is absent from normal run/stage/package wiring. Do not leave any old assertions that require `j2clRuntimeBuild` in `Compile / run`, `Universal / stage`, or `Universal / packageBin`.
+
+```java
+    String normalizedBuild = buildSbt.replaceAll("\\s+", " ");
+
+    assertTrue(buildSbt.contains("lazy val j2clSearchBuild = taskKey[Unit]"));
+    assertTrue(buildSbt.contains("lazy val j2clSearchTest = taskKey[Unit]"));
+    assertTrue(buildSbt.contains("lazy val j2clLitBuild = taskKey[Unit]"));
+    assertTrue(buildSbt.contains("lazy val j2clProductionBuild = taskKey[Unit]"));
+    assertTrue(buildSbt.contains("lazy val j2clRuntimeBuild = taskKey[Unit]"));
+    assertTrue(buildSbt.contains("ThisBuild / j2clRuntimeBuild := Def.sequential("));
+
+    assertTrue(normalizedBuild.contains(
+        "Compile / run := (Compile / run).dependsOn(prepareServerConfig, compileGwt).evaluated"));
+    assertFalse(normalizedBuild.contains(
+        "Compile / run := (Compile / run).dependsOn(prepareServerConfig, j2clRuntimeBuild, compileGwt).evaluated"));
+    assertTrue(normalizedBuild.contains(
+        "Universal / stage := (Universal / stage).dependsOn(compileGwt, verifyGwtAssets).value"));
+    assertFalse(normalizedBuild.contains(
+        "Universal / stage := (Universal / stage).dependsOn(j2clRuntimeBuild, compileGwt, verifyGwtAssets).value"));
+    assertTrue(normalizedBuild.contains(
+        "Universal / packageBin := (Universal / packageBin).dependsOn(compileGwt, verifyGwtAssets).value"));
+    assertFalse(normalizedBuild.contains(
+        "Universal / packageBin := (Universal / packageBin).dependsOn(j2clRuntimeBuild, compileGwt, verifyGwtAssets).value"));
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+sbt --batch "testOnly org.waveprotocol.box.server.util.J2clBuildStageContractTest"
+```
+
+Expected: the test fails because current `build.sbt` still wires `j2clRuntimeBuild` into run/stage/package.
+
+### Task 2: Remove Maven-backed sidecar builds from the normal app path
+
+**Files:**
+- Modify: `build.sbt`
+
+- [ ] **Step 1: Change only the default task dependencies**
+
+Replace these wiring lines:
+
+```scala
+Compile / run := (Compile / run).dependsOn(prepareServerConfig, j2clRuntimeBuild, compileGwt).evaluated
+Universal / stage := (Universal / stage).dependsOn(j2clRuntimeBuild, compileGwt, verifyGwtAssets).value
+Universal / packageBin := (Universal / packageBin).dependsOn(j2clRuntimeBuild, compileGwt, verifyGwtAssets).value
+```
+
+with:
+
+```scala
+Compile / run := (Compile / run).dependsOn(prepareServerConfig, compileGwt).evaluated
+Universal / stage := (Universal / stage).dependsOn(compileGwt, verifyGwtAssets).value
+Universal / packageBin := (Universal / packageBin).dependsOn(compileGwt, verifyGwtAssets).value
+```
+
+Keep `j2clRuntimeBuild`, `j2clSearchBuild`, `j2clSearchTest`, `j2clProductionBuild`, and `j2clLitBuild` intact as explicit SBT tasks.
+
+- [ ] **Step 2: Scan for other default-path Maven call sites**
+
+Run:
+
+```bash
+rg -n "j2clRuntimeBuild|j2cl/mvnw|mvnw" \
+  -g '!target/**' \
+  -g '!**/target/**' \
+  -g '!j2cl/mvnw' \
+  -g '!j2cl/mvnw.cmd' \
+  .
+```
+
+Expected: any remaining `j2clRuntimeBuild` references are task definitions, explicit J2CL docs, historical plan files, or explicit J2CL commands. No normal app build, deploy, Docker, CI, or stage workflow should call `j2cl/mvnw` or depend on `j2clRuntimeBuild`.
+
+- [ ] **Step 3: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+sbt --batch "testOnly org.waveprotocol.box.server.util.J2clBuildStageContractTest"
+```
+
+Expected: the contract test passes.
+
+### Task 3: Update operator docs for the new build boundary
+
+**Files:**
+- Modify: `docs/BUILDING-sbt.md`
+- Modify: `docs/runbooks/j2cl-sidecar-testing.md`
+
+- [ ] **Step 1: Update `docs/BUILDING-sbt.md`**
+
+Document that normal `sbt run`, `Universal/stage`, and `Universal/packageBin` no longer build J2CL sidecar assets. Keep the explicit J2CL SBT commands listed for J2CL parity/debug work.
+
+- [ ] **Step 2: Update `docs/runbooks/j2cl-sidecar-testing.md`**
+
+Replace the direct-Maven guidance section with an SBT-only operator guidance section. Include the exact explicit task names:
+
+```markdown
+## SBT-Only Operator Boundary
+
+Normal app boot, stage, and package commands do not build the J2CL sidecar:
+`sbt run`, `sbt Universal/stage`, and `sbt Universal/packageBin` stay on
+the GWT/default app path.
+
+Run J2CL sidecar builds explicitly through SBT when the task touches J2CL
+or when a local smoke check needs `/j2cl/**` or `/j2cl-search/**` assets:
+
+```bash
+sbt -batch j2clSearchBuild j2clSearchTest
+sbt -batch j2clProductionBuild j2clLitBuild
+```
+
+Do not use `j2cl/mvnw` as routine verification evidence. The wrapper remains
+an implementation detail of the current Vertispan sidecar toolchain until the
+repo migrates J2CL itself to a non-Maven build path.
+```
+
+### Task 4: Verify and record evidence
+
+**Files:**
+- Create: `journal/local-verification/2026-05-08-issue-1209-sbt-only-default-build.md`
+
+- [ ] **Step 1: Run focused verification**
+
+Run:
+
+```bash
+git diff --check
+sbt --batch "testOnly org.waveprotocol.box.server.util.J2clBuildStageContractTest"
+sbt --batch "inspect tree Universal/stage" 2>&1 | tee target/issue-1209-inspect-stage.log
+! grep -F "j2clRuntimeBuild" target/issue-1209-inspect-stage.log
+sbt --batch Universal/stage
+sbt --batch "show j2clSearchBuild" "show j2clSearchTest" "show j2clProductionBuild" "show j2clLitBuild"
+sbt --batch j2clRuntimeBuild
+```
+
+Expected: all commands exit 0. The `inspect tree Universal/stage` output should not include `j2clRuntimeBuild`. The explicit `j2clRuntimeBuild` command should still work, proving the J2CL path remains available when deliberately requested.
+
+- [ ] **Step 2: Record verification**
+
+Write the exact command results in the journal file and mirror these outcomes into issue `#1209` and the PR body: contract test result, grep-backed absence of `j2clRuntimeBuild` from `Universal/stage`, `Universal/stage` result, explicit J2CL task availability result, and explicit `j2clRuntimeBuild` result.
+
+## Plan Self-Review
+
+- Spec coverage: covers investigation result, normal build decoupling, explicit J2CL task preservation, tests, docs, issue traceability, and PR verification.
+- Scope control: does not attempt a full J2CL toolchain rewrite because the official J2CL build/test entrypoints currently used by this repo are Vertispan Maven plugin goals.
+- Test gap: this plan uses a build-contract test plus real `Universal/stage`; it does not run the full J2CL sidecar suite because the narrow default-path change should not modify sidecar behavior.

--- a/journal/local-verification/2026-05-08-issue-1209-sbt-only-default-build.md
+++ b/journal/local-verification/2026-05-08-issue-1209-sbt-only-default-build.md
@@ -1,0 +1,50 @@
+# Issue 1209 - SBT-only default build path
+
+Date: 2026-05-08
+Worktree: `/Users/vega/devroot/worktrees/codex-sbt-only-build-20260508`
+Branch: `codex/sbt-only-build-20260508`
+Issue: https://github.com/vega113/supawave/issues/1209
+Plan: `docs/superpowers/plans/2026-05-08-sbt-only-default-build.md`
+
+## Scope
+
+Default app entrypoints now stay on the SBT/GWT path:
+
+- `Compile / run`
+- `Universal / stage`
+- `Universal / packageBin`
+
+The Maven-backed J2CL sidecar remains available only through explicit SBT tasks
+such as `j2clRuntimeBuild`. The J2CL parity workflow opts into that task before
+running browser parity.
+
+## Review
+
+- Plan review round 1: changes requested; tightened the plan with task-graph
+  evidence and smoke semantics.
+- Plan review round 2: approved with small changes; applied before
+  implementation.
+- Implementation review round 1: changes requested; added changelog, explicit
+  `packageBin` and `Compile/run` graph checks, CI parity opt-in, and smoke docs.
+- Implementation review round 2: pass; addressed follow-up hardening by making
+  the Java contract test reject any `j2cl` dependency on default task lines and
+  making CI smoke require J2CL assets in the parity lane.
+
+## Verification
+
+- `git diff --check` - passed.
+- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json` - passed.
+- `sbt --batch "testOnly org.waveprotocol.box.server.util.J2clBuildStageContractTest"` - passed; 3 tests.
+- `python3 -m pytest scripts/tests/test_wave_smoke_lifecycle.py -q` - passed; 3 tests.
+- `sbt --batch "inspect tree Universal/stage"` plus `grep -F "j2clRuntimeBuild"` - passed; no dependency found.
+- `sbt --batch "inspect tree Universal/packageBin"` plus `grep -F "j2clRuntimeBuild"` - passed; no dependency found.
+- `sbt --batch "inspect tree Compile/run"` plus `grep -F "j2clRuntimeBuild"` - passed; no dependency found.
+- `sbt --batch Universal/stage` - passed.
+- `sbt --batch Universal/packageBin` - passed.
+- `sbt --batch j2clRuntimeBuild` - passed.
+
+## Notes
+
+`sbt --batch j2clRuntimeBuild` still reports the existing npm audit warning from
+the Lit install path when dependencies are installed. That warning is outside
+this SBT-default-build decoupling scope; the explicit J2CL build exits 0.

--- a/journal/local-verification/2026-05-08-issue-1209-sbt-only-default-build.md
+++ b/journal/local-verification/2026-05-08-issue-1209-sbt-only-default-build.md
@@ -42,6 +42,12 @@ running browser parity.
 - `sbt --batch Universal/stage` - passed.
 - `sbt --batch Universal/packageBin` - passed.
 - `sbt --batch j2clRuntimeBuild` - passed.
+- After PR review follow-up commits, `sbt --batch Universal/stage` plus
+  `find target/universal/stage -path '*/war/j2cl*'` - passed; default stage
+  excludes stale J2CL output dirs.
+- After PR review follow-up commits, `sbt --batch Universal/packageBin` plus
+  `unzip -Z1 target/universal/*.zip | grep -E '/war/j2cl($|/|-search|-debug)'`
+  - passed; default package zip excludes stale J2CL output dirs.
 
 ## Notes
 

--- a/journal/local-verification/2026-05-08-issue-1209-sbt-only-default-build.md
+++ b/journal/local-verification/2026-05-08-issue-1209-sbt-only-default-build.md
@@ -15,8 +15,8 @@ Default app entrypoints now stay on the SBT/GWT path:
 - `Universal / packageBin`
 
 The Maven-backed J2CL sidecar remains available only through explicit SBT tasks
-such as `j2clRuntimeBuild`. The J2CL parity workflow opts into that task before
-running browser parity.
+such as `j2clRuntimeBuild`. The J2CL parity workflow opts into that task and
+sets `WAVE_STAGE_INCLUDE_J2CL_ASSETS=1` before running browser parity.
 
 ## Review
 
@@ -45,9 +45,17 @@ running browser parity.
 - After PR review follow-up commits, `sbt --batch Universal/stage` plus
   `find target/universal/stage -path '*/war/j2cl*'` - passed; default stage
   excludes stale J2CL output dirs.
+- After PR review follow-up commits, `WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 sbt --batch Universal/stage`
+  plus file checks for `target/universal/stage/war/j2cl/index.html` and
+  `target/universal/stage/war/j2cl-search/sidecar/j2cl-sidecar.js` - passed;
+  explicit J2CL stage includes the sidecar assets.
 - After PR review follow-up commits, `sbt --batch Universal/packageBin` plus
   `unzip -Z1 target/universal/*.zip | grep -E '/war/j2cl($|/|-search|-debug)'`
   - passed; default package zip excludes stale J2CL output dirs.
+- After PR review follow-up commits, `WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 sbt --batch Universal/packageBin`
+  plus zip entry checks for `/war/j2cl/index.html` and
+  `/war/j2cl-search/sidecar/j2cl-sidecar.js` - passed; explicit J2CL package
+  includes the sidecar assets.
 
 ## Notes
 

--- a/scripts/tests/test_wave_smoke_lifecycle.py
+++ b/scripts/tests/test_wave_smoke_lifecycle.py
@@ -47,7 +47,12 @@ def write_fake_install(tmp_path: Path, server_source: str) -> Path:
     return install
 
 
-def run_smoke(install: Path, port: int, command: str) -> subprocess.CompletedProcess[str]:
+def run_smoke(
+    install: Path,
+    port: int,
+    command: str,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env.update(
         {
@@ -56,6 +61,8 @@ def run_smoke(install: Path, port: int, command: str) -> subprocess.CompletedPro
             "STOP_TIMEOUT": "5",
         }
     )
+    if extra_env:
+        env.update(extra_env)
     args = ["bash", str(SCRIPT), command]
     try:
         return subprocess.run(
@@ -193,6 +200,8 @@ def test_start_check_stop_keeps_fake_staged_server_alive(tmp_path: Path) -> None
                         body = b"<script src='webclient/webclient.nocache.js'></script>"
                     elif route == "/healthz":
                         body = b"ok"
+                    elif route == "/" and query == "view=gwt":
+                        body = b"<script src='webclient/webclient.nocache.js'></script>"
                     elif route == "/" and query == "view=landing":
                         body = b"landing"
                     elif route == "/" and query == "view=j2cl-root":
@@ -265,6 +274,88 @@ def test_start_check_stop_keeps_fake_staged_server_alive(tmp_path: Path) -> None
         stop = run_smoke(install, port, "stop")
         assert stop.returncode == 0, stop.stdout + stop.stderr
         assert not (install / "wave_server.pid").exists()
+        assert not port_accepts_connection(port)
+
+
+def test_check_treats_j2cl_assets_as_opt_in(tmp_path: Path) -> None:
+    port = free_port()
+    install = write_fake_install(
+        tmp_path,
+        textwrap.dedent(
+            """
+            import http.server
+            import os
+            import signal
+            import socketserver
+            import sys
+            from urllib.parse import urlparse
+
+            port = int(os.environ["PORT"])
+
+            class Handler(http.server.BaseHTTPRequestHandler):
+                def do_GET(self):
+                    body = b""
+                    status = 200
+                    parsed = urlparse(self.path)
+                    route = parsed.path
+                    query = parsed.query
+                    if route == "/" and query == "":
+                        body = b"<script src='webclient/webclient.nocache.js'></script>"
+                    elif route == "/healthz":
+                        body = b"ok"
+                    elif route == "/" and query == "view=gwt":
+                        body = b"<script src='webclient/webclient.nocache.js'></script>"
+                    elif route == "/" and query == "view=landing":
+                        body = b"landing"
+                    elif route == "/" and query == "view=j2cl-root":
+                        body = b"<div data-j2cl-root-shell></div>"
+                    elif route == "/webclient/webclient.nocache.js":
+                        body = b"asset"
+                    elif route in (
+                        "/j2cl/index.html",
+                        "/j2cl-search/sidecar/j2cl-sidecar.js",
+                    ):
+                        status = 404
+                    else:
+                        status = 404
+                    self.send_response(status)
+                    self.end_headers()
+                    self.wfile.write(body)
+
+                def log_message(self, format, *args):
+                    return
+
+            class ReusableTCPServer(socketserver.TCPServer):
+                allow_reuse_address = True
+
+            signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+            with ReusableTCPServer(("127.0.0.1", port), Handler) as httpd:
+                httpd.serve_forever()
+            """
+        ),
+    )
+
+    start = run_smoke(install, port, "start")
+    try:
+        assert start.returncode == 0, start.stdout + start.stderr
+
+        default_check = run_smoke(install, port, "check")
+        assert default_check.returncode == 0, default_check.stdout + default_check.stderr
+        assert "J2CL_ASSET_CHECK=optional" in default_check.stdout
+        assert "J2CL_INDEX_STATUS=404" in default_check.stdout
+        assert "SIDECAR_STATUS=404" in default_check.stdout
+
+        required_check = run_smoke(
+            install,
+            port,
+            "check",
+            {"WAVE_SMOKE_REQUIRE_J2CL_ASSETS": "1"},
+        )
+        assert required_check.returncode != 0
+        assert "Missing production J2CL asset" in required_check.stderr
+    finally:
+        stop = run_smoke(install, port, "stop")
+        assert stop.returncode == 0, stop.stdout + stop.stderr
         assert not port_accepts_connection(port)
 
 

--- a/scripts/wave-smoke-ui.sh
+++ b/scripts/wave-smoke-ui.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 # wave-smoke-ui.sh — build (if needed), run briefly, and probe UI endpoints
 # - Starts :wave:run in background
 # - Waits for HTTP 200 from root, verifies the default legacy GWT bootstrap, and
-#   checks both maintained J2CL assets and the rollback-ready /webclient asset
+#   checks the rollback-ready /webclient asset. Set
+#   WAVE_SMOKE_REQUIRE_J2CL_ASSETS=1 to require maintained J2CL assets too.
 # - Tails logs on failure; always cleans up the background process
 
 ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
@@ -47,8 +48,15 @@ j2cl_root_shell_presence=$([[ "$j2cl_root_body" == *'data-j2cl-root-shell'* ]] &
 j2cl_index_status=$(curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:$PORT/j2cl/index.html || true)
 sidecar_status=$(curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:$PORT/j2cl-search/sidecar/j2cl-sidecar.js || true)
 legacy_status=$(curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:$PORT/webclient/webclient.nocache.js || true)
+require_j2cl_assets="${WAVE_SMOKE_REQUIRE_J2CL_ASSETS:-0}"
 
-echo "ROOT=$root_status ROOT_GWT=$root_gwt_presence ROOT_SHELL=$root_gwt_presence LANDING=$landing_status J2CL_ROOT=$j2cl_root_status J2CL_ROOT_SHELL=$j2cl_root_shell_presence J2CL_INDEX=$j2cl_index_status SIDECAR=$sidecar_status WEBCLIENT=$legacy_status"
+if [[ "$require_j2cl_assets" == "1" ]]; then
+  j2cl_asset_check="required"
+else
+  j2cl_asset_check="optional"
+fi
+
+echo "ROOT=$root_status ROOT_GWT=$root_gwt_presence ROOT_SHELL=$root_gwt_presence LANDING=$landing_status J2CL_ROOT=$j2cl_root_status J2CL_ROOT_SHELL=$j2cl_root_shell_presence J2CL_INDEX=$j2cl_index_status SIDECAR=$sidecar_status J2CL_ASSET_CHECK=$j2cl_asset_check WEBCLIENT=$legacy_status"
 
 if [[ "${root_status}" == "000" ]]; then
   echo "Server did not start or port not reachable" >&2
@@ -94,13 +102,13 @@ if [[ "$j2cl_root_body" != *'data-j2cl-root-shell'* ]]; then
   exit 1
 fi
 
-if [[ "$j2cl_index_status" -ne 200 ]]; then
+if [[ "$require_j2cl_assets" == "1" && "$j2cl_index_status" -ne 200 ]]; then
   echo "Missing production /j2cl/index.html asset: $j2cl_index_status" >&2
   tail -n 200 "$RUN_OUT" || true
   exit 1
 fi
 
-if [[ "$sidecar_status" -ne 200 ]]; then
+if [[ "$require_j2cl_assets" == "1" && "$sidecar_status" -ne 200 ]]; then
   echo "Missing compiled /j2cl-search/sidecar/j2cl-sidecar.js asset: $sidecar_status" >&2
   tail -n 200 "$RUN_OUT" || true
   exit 1

--- a/scripts/wave-smoke-ui.sh
+++ b/scripts/wave-smoke-ui.sh
@@ -39,6 +39,7 @@ root_status=$(curl -sS --max-time 10 -o "$root_body_file" -w "%{http_code}" http
 root_body=$(cat "$root_body_file" 2>/dev/null || true)
 rm -f "$root_body_file"
 root_gwt_presence=$([[ "$root_body" == *'webclient/webclient.nocache.js'* ]] && echo present || echo missing)
+root_shell_presence=$([[ "$root_body" == *'data-j2cl-root-shell'* ]] && echo present || echo missing)
 landing_status=$(curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:$PORT/?view=landing || true)
 j2cl_root_body_file=$(mktemp)
 j2cl_root_status=$(curl -sS --max-time 10 -o "$j2cl_root_body_file" -w "%{http_code}" http://127.0.0.1:$PORT/?view=j2cl-root || true)
@@ -56,7 +57,7 @@ else
   j2cl_asset_check="optional"
 fi
 
-echo "ROOT=$root_status ROOT_GWT=$root_gwt_presence ROOT_SHELL=$root_gwt_presence LANDING=$landing_status J2CL_ROOT=$j2cl_root_status J2CL_ROOT_SHELL=$j2cl_root_shell_presence J2CL_INDEX=$j2cl_index_status SIDECAR=$sidecar_status J2CL_ASSET_CHECK=$j2cl_asset_check WEBCLIENT=$legacy_status"
+echo "ROOT=$root_status ROOT_GWT=$root_gwt_presence ROOT_SHELL=$root_shell_presence LANDING=$landing_status J2CL_ROOT=$j2cl_root_status J2CL_ROOT_SHELL=$j2cl_root_shell_presence J2CL_INDEX=$j2cl_index_status SIDECAR=$sidecar_status J2CL_ASSET_CHECK=$j2cl_asset_check WEBCLIENT=$legacy_status"
 
 if [[ "${root_status}" == "000" ]]; then
   echo "Server did not start or port not reachable" >&2

--- a/scripts/wave-smoke.sh
+++ b/scripts/wave-smoke.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 #   ./scripts/wave-smoke.sh status  # prints HTTP status of root endpoint
 #   ./scripts/wave-smoke.sh check   # runs a few endpoint checks
 #   PORT=9899 ./scripts/wave-smoke.sh stop  # stops server listening on the selected port
+# Set WAVE_SMOKE_REQUIRE_J2CL_ASSETS=1 to fail check when J2CL assets are absent.
 #
 # Notes:
 # - Expects the distribution staged at target/universal/stage (SBT) or wave/build/install/wave (legacy)
@@ -194,6 +195,7 @@ check() {
   local j2cl_root_body_file j2cl_root_body legacy_status
   local root_gwt_presence j2cl_root_shell_presence
   local gwt_view_body_file gwt_view_body gwt_view_status
+  local require_j2cl_assets="${WAVE_SMOKE_REQUIRE_J2CL_ASSETS:-0}"
 
   # G-PORT-2 (#1111): bare "/" no longer renders the GWT bootstrap by
   # default (V-1/V-5 swapped the unauthenticated root to the J2CL
@@ -264,16 +266,21 @@ check() {
 
   j2cl_index_status=$(curl -sS --max-time 10 -o /dev/null -w "%{http_code}" "http://localhost:$PORT/j2cl/index.html" || true)
   echo "J2CL_INDEX_STATUS=${j2cl_index_status:-000}"
-  if [[ "${j2cl_index_status}" -ne 200 ]]; then
+  if [[ "$require_j2cl_assets" == "1" && "${j2cl_index_status}" -ne 200 ]]; then
     echo "Missing production J2CL asset: /j2cl/index.html" >&2
     return 1
   fi
 
   sidecar_status=$(curl -sS --max-time 10 -o /dev/null -w "%{http_code}" "http://localhost:$PORT/j2cl-search/sidecar/j2cl-sidecar.js" || true)
   echo "SIDECAR_STATUS=${sidecar_status:-000}"
-  if [[ "${sidecar_status}" -ne 200 ]]; then
+  if [[ "$require_j2cl_assets" == "1" && "${sidecar_status}" -ne 200 ]]; then
     echo "Missing compiled J2CL sidecar asset: /j2cl-search/sidecar/j2cl-sidecar.js" >&2
     return 1
+  fi
+  if [[ "$require_j2cl_assets" == "1" ]]; then
+    echo "J2CL_ASSET_CHECK=required"
+  else
+    echo "J2CL_ASSET_CHECK=optional"
   fi
 
   legacy_status=$(curl -sS --max-time 10 -o /dev/null -w "%{http_code}" "http://localhost:$PORT/webclient/webclient.nocache.js" || true)

--- a/wave/config/changelog.d/2026-05-08-sbt-only-default-build.json
+++ b/wave/config/changelog.d/2026-05-08-sbt-only-default-build.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-08-sbt-only-default-build",
+  "version": "Operator workflow",
+  "date": "2026-05-08",
+  "title": "SBT-only default build path",
+  "summary": "Keeps the normal app run, stage, and package flow on SBT-only build steps while leaving J2CL assets available through explicit SBT tasks.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Normal `sbt run`, `sbt Universal/stage`, and `sbt Universal/packageBin` no longer invoke the Maven-backed J2CL sidecar build by default.",
+        "J2CL parity and sidecar lanes can still build and require those assets explicitly with `sbt j2clRuntimeBuild` and `WAVE_SMOKE_REQUIRE_J2CL_ASSETS=1`."
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.d/2026-05-08-sbt-only-default-build.json
+++ b/wave/config/changelog.d/2026-05-08-sbt-only-default-build.json
@@ -9,7 +9,7 @@
       "type": "fix",
       "items": [
         "Normal `sbt run`, `sbt Universal/stage`, and `sbt Universal/packageBin` no longer invoke the Maven-backed J2CL sidecar build by default.",
-        "J2CL parity and sidecar lanes can still build and require those assets explicitly with `sbt j2clRuntimeBuild` and `WAVE_SMOKE_REQUIRE_J2CL_ASSETS=1`."
+        "J2CL parity and sidecar lanes can still build, stage, and require those assets explicitly with `sbt j2clRuntimeBuild`, `WAVE_STAGE_INCLUDE_J2CL_ASSETS=1`, and `WAVE_SMOKE_REQUIRE_J2CL_ASSETS=1`."
       ]
     }
   ]

--- a/wave/src/test/java/org/waveprotocol/box/server/util/J2clBuildStageContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/J2clBuildStageContractTest.java
@@ -28,15 +28,37 @@ import java.nio.file.Path;
 
 public final class J2clBuildStageContractTest extends TestCase {
 
-  public void testBuildSbtSerializesStageJ2clBuilds() throws Exception {
+  public void testBuildSbtKeepsJ2clBuildsExplicit() throws Exception {
     String buildSbt = read("build.sbt");
+    String normalizedBuild = buildSbt.replaceAll("\\s+", " ");
 
+    assertTrue(buildSbt.contains("lazy val j2clSearchBuild = taskKey[Unit]"));
+    assertTrue(buildSbt.contains("lazy val j2clSearchTest = taskKey[Unit]"));
+    assertTrue(buildSbt.contains("lazy val j2clLitBuild = taskKey[Unit]"));
+    assertTrue(buildSbt.contains("lazy val j2clProductionBuild = taskKey[Unit]"));
     assertTrue(buildSbt.contains("lazy val j2clRuntimeBuild = taskKey[Unit]"));
     assertTrue(buildSbt.contains("ThisBuild / j2clRuntimeBuild := Def.sequential("));
-    assertTrue(buildSbt.contains("Compile / run := (Compile / run).dependsOn(prepareServerConfig, j2clRuntimeBuild, compileGwt).evaluated"));
+
+    String runLine = findLine(buildSbt, "Compile / run :=");
+    String stageLine = findLine(buildSbt, "Universal / stage :=");
+    String packageLine = findLine(buildSbt, "Universal / packageBin :=");
+
+    assertFalse(runLine.contains("j2cl"));
+    assertFalse(stageLine.contains("j2cl"));
+    assertFalse(packageLine.contains("j2cl"));
+    assertTrue(normalizedBuild.contains(
+        "Compile / run := (Compile / run).dependsOn(prepareServerConfig, compileGwt).evaluated"));
+    assertFalse(normalizedBuild.contains(
+        "Compile / run := (Compile / run).dependsOn(prepareServerConfig, j2clRuntimeBuild, compileGwt).evaluated"));
     assertTrue(buildSbt.contains("compileGwt := (compileGwt).dependsOn(Compile / compile).value"));
-    assertTrue(buildSbt.contains("Universal / stage := (Universal / stage).dependsOn(j2clRuntimeBuild, compileGwt, verifyGwtAssets).value"));
-    assertTrue(buildSbt.contains("Universal / packageBin := (Universal / packageBin).dependsOn(j2clRuntimeBuild, compileGwt, verifyGwtAssets).value"));
+    assertTrue(normalizedBuild.contains(
+        "Universal / stage := (Universal / stage).dependsOn(compileGwt, verifyGwtAssets).value"));
+    assertFalse(normalizedBuild.contains(
+        "Universal / stage := (Universal / stage).dependsOn(j2clRuntimeBuild, compileGwt, verifyGwtAssets).value"));
+    assertTrue(normalizedBuild.contains(
+        "Universal / packageBin := (Universal / packageBin).dependsOn(compileGwt, verifyGwtAssets).value"));
+    assertFalse(normalizedBuild.contains(
+        "Universal / packageBin := (Universal / packageBin).dependsOn(j2clRuntimeBuild, compileGwt, verifyGwtAssets).value"));
   }
 
   public void testDockerfileCopiesJ2clTreeAndUsesUniversalStageOnly() throws Exception {
@@ -56,5 +78,12 @@ public final class J2clBuildStageContractTest extends TestCase {
 
   private static String read(String relativePath) throws IOException {
     return Files.readString(Path.of(relativePath), StandardCharsets.UTF_8);
+  }
+
+  private static String findLine(String text, String needle) {
+    return text.lines()
+        .filter(line -> line.contains(needle))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Missing line containing: " + needle));
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/util/J2clBuildStageContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/J2clBuildStageContractTest.java
@@ -38,6 +38,8 @@ public final class J2clBuildStageContractTest extends TestCase {
     assertTrue(buildSbt.contains("lazy val j2clProductionBuild = taskKey[Unit]"));
     assertTrue(buildSbt.contains("lazy val j2clRuntimeBuild = taskKey[Unit]"));
     assertTrue(buildSbt.contains("ThisBuild / j2clRuntimeBuild := Def.sequential("));
+    assertTrue(buildSbt.contains("lazy val cleanStagedJ2clAssets = taskKey[Unit]"));
+    assertTrue(buildSbt.contains("WAVE_STAGE_INCLUDE_J2CL_ASSETS"));
 
     String runLine = findLine(buildSbt, "Compile / run :=");
     String stageLine = findLine(buildSbt, "Universal / stage :=");
@@ -52,7 +54,7 @@ public final class J2clBuildStageContractTest extends TestCase {
         "Compile / run := (Compile / run).dependsOn(prepareServerConfig, j2clRuntimeBuild, compileGwt).evaluated"));
     assertTrue(buildSbt.contains("compileGwt := (compileGwt).dependsOn(Compile / compile).value"));
     assertTrue(normalizedBuild.contains(
-        "val stagedDir = (Universal / stage).dependsOn(compileGwt, verifyGwtAssets).value"));
+        ".dependsOn(cleanStagedJ2clAssets, compileGwt, verifyGwtAssets)"));
     assertTrue(normalizedBuild.contains("stagedWarDir / \"j2cl\""));
     assertTrue(normalizedBuild.contains("stagedWarDir / \"j2cl-search\""));
     assertTrue(normalizedBuild.contains("stagedWarDir / \"j2cl-debug\""));

--- a/wave/src/test/java/org/waveprotocol/box/server/util/J2clBuildStageContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/J2clBuildStageContractTest.java
@@ -52,7 +52,10 @@ public final class J2clBuildStageContractTest extends TestCase {
         "Compile / run := (Compile / run).dependsOn(prepareServerConfig, j2clRuntimeBuild, compileGwt).evaluated"));
     assertTrue(buildSbt.contains("compileGwt := (compileGwt).dependsOn(Compile / compile).value"));
     assertTrue(normalizedBuild.contains(
-        "Universal / stage := (Universal / stage).dependsOn(compileGwt, verifyGwtAssets).value"));
+        "val stagedDir = (Universal / stage).dependsOn(compileGwt, verifyGwtAssets).value"));
+    assertTrue(normalizedBuild.contains("stagedWarDir / \"j2cl\""));
+    assertTrue(normalizedBuild.contains("stagedWarDir / \"j2cl-search\""));
+    assertTrue(normalizedBuild.contains("stagedWarDir / \"j2cl-debug\""));
     assertFalse(normalizedBuild.contains(
         "Universal / stage := (Universal / stage).dependsOn(j2clRuntimeBuild, compileGwt, verifyGwtAssets).value"));
     assertTrue(normalizedBuild.contains(


### PR DESCRIPTION
## Summary

Fixes #1209.

- removes `j2clRuntimeBuild` from default `sbt run`, `Universal/stage`, and `Universal/packageBin` wiring so normal app build/package stays on the SBT/GWT path
- keeps J2CL assets available through explicit SBT tasks and makes the parity E2E workflow opt into `j2clRuntimeBuild` before browser tests
- makes smoke checks treat J2CL static assets as optional by default, with `WAVE_SMOKE_REQUIRE_J2CL_ASSETS=1` for J2CL lanes
- updates docs, changelog, plan, and local verification journal for the new operator boundary

## Verification

- `git diff --check`
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`
- `sbt --batch "testOnly org.waveprotocol.box.server.util.J2clBuildStageContractTest"`
- `python3 -m pytest scripts/tests/test_wave_smoke_lifecycle.py -q`
- `sbt --batch "inspect tree Universal/stage"` plus `grep -F "j2clRuntimeBuild"` -> no dependency found
- `sbt --batch "inspect tree Universal/packageBin"` plus `grep -F "j2clRuntimeBuild"` -> no dependency found
- `sbt --batch "inspect tree Compile/run"` plus `grep -F "j2clRuntimeBuild"` -> no dependency found
- `sbt --batch Universal/stage`
- `sbt --batch Universal/packageBin`
- `sbt --batch j2clRuntimeBuild`

## Review

- Plan reviewed twice with Claude; first round required tightening, second approved with changes.
- Implementation reviewed twice with Claude; first round requested evidence and CI/doc/changelog fixes, second round passed. Follow-up hardening from the passing review is included in this commit.

## Notes

This does not remove Maven from the internal J2CL Vertispan sidecar implementation. It makes Maven-backed J2CL work explicit instead of part of the normal app run/stage/package path.