### PR TITLE
Fix production J2CL asset packaging

### DIFF
--- a/.github/workflows/deploy-contabo.yml
+++ b/.github/workflows/deploy-contabo.yml
@@ -109,7 +109,7 @@ jobs:
             echo "Build attempt $attempt/3"
             log_file="$(mktemp)"
             status=0
-            sbt --batch "pst/compile; wave/compile; Universal/stage" >"$log_file" 2>&1 || status=$?
+            WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 sbt --batch "pst/compile; wave/compile; j2clRuntimeBuild; Universal/stage" >"$log_file" 2>&1 || status=$?
             cat "$log_file"
             if [ "$status" -eq 0 ]; then
               rm -f "$log_file"
@@ -141,6 +141,24 @@ jobs:
             exit 1
           fi
           diff -u wave/config/changelog.json "$staged_changelog"
+
+      - name: Verify staged J2CL assets
+        if: github.event_name == 'push' || github.event.inputs.action == 'deploy'
+        run: |
+          set -euo pipefail
+          for asset in \
+            target/universal/stage/war/j2cl/assets/wavy-thread-collapse.css \
+            target/universal/stage/war/j2cl/assets/shell.css \
+            target/universal/stage/war/j2cl/assets/sidecar.css \
+            target/universal/stage/war/j2cl/assets/wavy-tokens.css \
+            target/universal/stage/war/j2cl/assets/shell.js \
+            target/universal/stage/war/j2cl-search/sidecar/j2cl-sidecar.js
+          do
+            if [ ! -s "$asset" ]; then
+              echo "Missing staged J2CL asset: $asset" >&2
+              exit 1
+            fi
+          done
 
       - name: Log in to GitHub Container Registry
         if: github.event_name == 'push' || github.event.inputs.action == 'deploy'

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,9 @@ COPY j2cl /workspace/j2cl
 COPY scripts /workspace/scripts
 COPY THANKS RELEASE-NOTES KEYS DISCLAIMER /workspace/
 
-# Build sequentially: compile, rebuild the maintained J2CL runtime assets through
-# the staged package path, then stage the distribution.
-RUN sbt --batch "pst/compile; wave/compile; Universal/stage"
+# Build sequentially: compile, rebuild the maintained J2CL runtime assets, then
+# stage the distribution with those assets included.
+RUN WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 sbt --batch "pst/compile; wave/compile; j2clRuntimeBuild; Universal/stage"
 
 # Runtime stage: slim JRE image
 FROM eclipse-temurin:17-jre

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@
 FROM eclipse-temurin:17-jdk AS build
 WORKDIR /workspace
 
-# Install SBT
+# Install SBT plus the Node/npm toolchain required by j2clLitBuild.
 RUN apt-get update -qq && \
-    apt-get install -y -qq apt-transport-https gnupg && \
+    apt-get install -y -qq apt-transport-https gnupg nodejs npm && \
     install -d -m 0755 /etc/apt/keyrings && \
     curl --fail --show-error --location --retry 5 \
       "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" \

--- a/docs/superpowers/plans/2026-05-08-issue-1212-prod-j2cl-assets.md
+++ b/docs/superpowers/plans/2026-05-08-issue-1212-prod-j2cl-assets.md
@@ -1,0 +1,62 @@
+# Issue 1212: restore production J2CL asset packaging
+
+## Problem
+
+Production deploy `c7b3267427fce878e0d681b19ceb5cd4eed88d29` served the
+J2CL root shell while omitting the J2CL runtime assets from the deployed image.
+The browser then requested `/j2cl/assets/*.css`, `/j2cl/assets/shell.js`, and
+`/j2cl-search/sidecar/j2cl-sidecar.js`; those paths returned 404 or HTML, which
+triggered strict MIME failures.
+
+The emergency rollback was attempted first. The standalone rollback workflow
+failed before host access because the host fingerprint variable is unset, then
+`deploy-contabo.yml` with `action=rollback` succeeded and restored the previous
+green slot.
+
+## Root Cause
+
+PR #1211 made J2CL asset staging opt-in to stop stale local J2CL output from
+leaking into default `Universal/stage` builds. That part is valid for default
+developer builds.
+
+The production deploy workflow was not updated to opt in. It still runs:
+
+```bash
+sbt --batch "pst/compile; wave/compile; Universal/stage"
+```
+
+Because `Universal/stage` now cleans J2CL output unless the build explicitly
+requests it, the production image can omit assets that the J2CL root shell still
+references.
+
+## Plan
+
+1. Add a failing contract test that production deploy builds must opt in to the
+   J2CL runtime asset build and must verify the staged J2CL asset paths before
+   building the Docker image.
+2. Update `.github/workflows/deploy-contabo.yml` so deploy builds run
+   `j2clRuntimeBuild` with `WAVE_STAGE_INCLUDE_J2CL_ASSETS=1` before
+   `Universal/stage`.
+3. Add a staged asset verification step for the exact production paths that
+   failed: `war/j2cl/assets/wavy-thread-collapse.css`,
+   `war/j2cl/assets/shell.css`, `war/j2cl/assets/sidecar.css`,
+   `war/j2cl/assets/wavy-tokens.css`, `war/j2cl/assets/shell.js`, and
+   `war/j2cl-search/sidecar/j2cl-sidecar.js`.
+4. Update the source-building `Dockerfile` to use the same explicit opt-in so
+   standalone production-ish images do not regress in the same way.
+5. Keep default `Universal/stage` behavior opt-in for J2CL assets so stale local
+   output is not silently packaged.
+6. Add a changelog fragment and update the issue with rollback, plan, commits,
+   and verification evidence.
+
+## Self Review
+
+- Scope is narrow: production packaging and its contract tests only.
+- It does not revert #1211's useful stale-asset protection for default developer
+  builds.
+- The fix addresses the actual failing boundary: build command plus staged
+  artifact verification, not the browser MIME symptom.
+- Local verification must include a clean-ish staged build with the deploy
+  command and direct filesystem checks for the failed asset paths before PR.
+- Post-merge monitoring must include the production deploy run and public probes
+  for the same asset URLs.

--- a/wave/config/changelog.d/2026-05-08-prod-j2cl-assets.json
+++ b/wave/config/changelog.d/2026-05-08-prod-j2cl-assets.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-08-prod-j2cl-assets",
+  "version": "Issue #1212",
+  "date": "2026-05-08",
+  "title": "Production deploys include J2CL shell assets again",
+  "summary": "The production deploy build now explicitly rebuilds and packages the J2CL root-shell assets before creating the runtime image, preventing the J2CL shell from loading HTML or 404 responses for CSS and JavaScript files.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Add a deploy guard that fails before image publication if the staged J2CL CSS or JavaScript assets are missing"
+      ]
+    }
+  ]
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/util/J2clBuildStageContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/J2clBuildStageContractTest.java
@@ -89,6 +89,15 @@ public final class J2clBuildStageContractTest extends TestCase {
     assertTrue(workflow.contains("target/universal/stage/war/j2cl/assets/wavy-tokens.css"));
     assertTrue(workflow.contains("target/universal/stage/war/j2cl/assets/shell.js"));
     assertTrue(workflow.contains("target/universal/stage/war/j2cl-search/sidecar/j2cl-sidecar.js"));
+
+    // J2CL build and verification steps must appear before the container image is published.
+    String publishMarker = "Build and push container image";
+    assertTrue("image publication marker missing", workflow.contains(publishMarker));
+    assertTrue("WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 must precede image publication",
+        workflow.indexOf("WAVE_STAGE_INCLUDE_J2CL_ASSETS=1") < workflow.indexOf(publishMarker));
+    assertTrue("j2clRuntimeBuild command must precede image publication",
+        workflow.indexOf("WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 sbt --batch \"pst/compile; wave/compile; j2clRuntimeBuild; Universal/stage\"")
+            < workflow.indexOf(publishMarker));
   }
 
   private static String read(String relativePath) throws IOException {

--- a/wave/src/test/java/org/waveprotocol/box/server/util/J2clBuildStageContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/J2clBuildStageContractTest.java
@@ -70,6 +70,7 @@ public final class J2clBuildStageContractTest extends TestCase {
     String dockerfile = read("Dockerfile");
 
     assertTrue(dockerfile.contains("COPY j2cl /workspace/j2cl"));
+    assertTrue(dockerfile.contains("nodejs npm"));
     assertTrue(dockerfile.contains("WAVE_STAGE_INCLUDE_J2CL_ASSETS=1"));
     assertTrue(dockerfile.contains(
         "RUN WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 sbt --batch \"pst/compile; wave/compile; j2clRuntimeBuild; Universal/stage\""));

--- a/wave/src/test/java/org/waveprotocol/box/server/util/J2clBuildStageContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/J2clBuildStageContractTest.java
@@ -66,19 +66,28 @@ public final class J2clBuildStageContractTest extends TestCase {
         "Universal / packageBin := (Universal / packageBin).dependsOn(j2clRuntimeBuild, compileGwt, verifyGwtAssets).value"));
   }
 
-  public void testDockerfileCopiesJ2clTreeAndUsesUniversalStageOnly() throws Exception {
+  public void testDockerfileCopiesJ2clTreeAndBuildsRuntimeAssets() throws Exception {
     String dockerfile = read("Dockerfile");
 
     assertTrue(dockerfile.contains("COPY j2cl /workspace/j2cl"));
-    assertTrue(dockerfile.contains("RUN sbt --batch \"pst/compile; wave/compile; Universal/stage\""));
-    assertFalse(dockerfile.contains("j2clSearchBuild; j2clProductionBuild; Universal/stage"));
+    assertTrue(dockerfile.contains("WAVE_STAGE_INCLUDE_J2CL_ASSETS=1"));
+    assertTrue(dockerfile.contains(
+        "RUN WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 sbt --batch \"pst/compile; wave/compile; j2clRuntimeBuild; Universal/stage\""));
   }
 
-  public void testDeployWorkflowUsesUniversalStageOnly() throws Exception {
+  public void testDeployWorkflowBuildsAndVerifiesJ2clAssets() throws Exception {
     String workflow = read(".github/workflows/deploy-contabo.yml");
 
-    assertTrue(workflow.contains("sbt --batch \"pst/compile; wave/compile; Universal/stage\""));
-    assertFalse(workflow.contains("j2clSearchBuild; j2clProductionBuild; Universal/stage"));
+    assertTrue(workflow.contains("WAVE_STAGE_INCLUDE_J2CL_ASSETS=1"));
+    assertTrue(workflow.contains(
+        "WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 sbt --batch \"pst/compile; wave/compile; j2clRuntimeBuild; Universal/stage\""));
+    assertTrue(workflow.contains("Verify staged J2CL assets"));
+    assertTrue(workflow.contains("target/universal/stage/war/j2cl/assets/wavy-thread-collapse.css"));
+    assertTrue(workflow.contains("target/universal/stage/war/j2cl/assets/shell.css"));
+    assertTrue(workflow.contains("target/universal/stage/war/j2cl/assets/sidecar.css"));
+    assertTrue(workflow.contains("target/universal/stage/war/j2cl/assets/wavy-tokens.css"));
+    assertTrue(workflow.contains("target/universal/stage/war/j2cl/assets/shell.js"));
+    assertTrue(workflow.contains("target/universal/stage/war/j2cl-search/sidecar/j2cl-sidecar.js"));
   }
 
   private static String read(String relativePath) throws IOException {


### PR DESCRIPTION
Fixes #1212.

## Summary
- Make production deploy builds explicitly run `j2clRuntimeBuild` with `WAVE_STAGE_INCLUDE_J2CL_ASSETS=1` before `Universal/stage`.
- Add a deploy guard that fails before Docker image publication if the staged J2CL CSS/JS assets are missing.
- Make the source-building Dockerfile use the same production asset opt-in.
- Update the build contract test and add a changelog fragment.

## Incident recovery
- Standalone rollback workflow `25553817931` failed before host access because `CONTABO_HOST_FINGERPRINT` is unset.
- `deploy-contabo.yml` rollback run `25553863224` succeeded and logged `Rolled back to green`.
- Post-rollback public probes for the reported J2CL asset URLs returned `200` with CSS/JavaScript MIME types.

## Local verification
- `sbt -batch 'testOnly org.waveprotocol.box.server.util.J2clBuildStageContractTest'`\n  - red before fix on deploy/Dockerfile assertions\n  - green after fix: 3 tests, 0 failures\n- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py`\n- `WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 sbt -batch "pst/compile; wave/compile; j2clRuntimeBuild; Universal/stage"`\n- Verified staged files are non-empty:\n  - `target/universal/stage/war/j2cl/assets/wavy-thread-collapse.css`\n  - `target/universal/stage/war/j2cl/assets/shell.css`\n  - `target/universal/stage/war/j2cl/assets/sidecar.css`\n  - `target/universal/stage/war/j2cl/assets/wavy-tokens.css`\n  - `target/universal/stage/war/j2cl/assets/shell.js`\n  - `target/universal/stage/war/j2cl-search/sidecar/j2cl-sidecar.js`\n- Booted the fixed staged distribution locally on port `9937`; `/healthz` returned `ok`, and all six reported asset URLs returned `200` with non-HTML CSS/JavaScript content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed production deployments to include required shell assets (CSS/JavaScript), resolving 404 errors

* **Chores**
  * Enhanced deployment build process with explicit asset staging and verification

* **Tests**
  * Added build contract tests to verify asset staging and prevent regressions

* **Documentation**
  * Documented production asset packaging resolution and deployment requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->