### PR TITLE
Pin Contabo SSH host key in deploy workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,7 @@ jobs:
           bash scripts/ci-validate-deploy-healthcheck.sh
           python3 -m unittest scripts.tests.test_doc_guardrails -v
           python3 -m unittest scripts.tests.test_deploy_sanity_gate -v
+          python3 -m unittest scripts.tests.test_contabo_host_key_workflows -v
           python3 -m unittest scripts.tests.test_send_resend_email -v
           python3 -m unittest scripts.tests.test_deploy_overlap_safety -v
           python3 -m unittest scripts.tests.test_repair_corrupted_waves -v

--- a/.github/workflows/deploy-contabo.yml
+++ b/.github/workflows/deploy-contabo.yml
@@ -60,6 +60,7 @@ jobs:
       CANONICAL_HOST: supawave.ai
       ROOT_HOST: wave.supawave.ai
       WWW_HOST: www.supawave.ai
+      CONTABO_HOST_FINGERPRINT: ${{ vars.CONTABO_HOST_FINGERPRINT || secrets.CONTABO_HOST_FINGERPRINT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -193,8 +194,10 @@ jobs:
       - name: Trust Contabo host key
         run: |
           set -euo pipefail
-          mkdir -p "$HOME/.ssh"
-          ssh-keyscan -p "${{ secrets.CONTABO_SSH_PORT || '22' }}" -H "${{ secrets.CONTABO_SSH_HOST }}" >> "$HOME/.ssh/known_hosts"
+          scripts/deployment/trust-ssh-host-key.sh \
+            "${{ secrets.CONTABO_SSH_HOST }}" \
+            "${{ secrets.CONTABO_SSH_PORT || '22' }}" \
+            "$CONTABO_HOST_FINGERPRINT"
 
       - name: Upload bundle
         run: |

--- a/.github/workflows/rollback-contabo.yml
+++ b/.github/workflows/rollback-contabo.yml
@@ -52,27 +52,10 @@ jobs:
       - name: Trust Contabo host key
         run: |
           set -euo pipefail
-          mkdir -p "$HOME/.ssh"
-          scanned_host_keys="$RUNNER_TEMP/contabo_known_hosts"
-          ssh-keyscan -p "${{ secrets.CONTABO_SSH_PORT || '22' }}" -H "${{ secrets.CONTABO_SSH_HOST }}" > "$scanned_host_keys"
-          expected_fingerprint="${CONTABO_HOST_FINGERPRINT:-}"
-          actual_fingerprints="$(ssh-keygen -lf "$scanned_host_keys" | awk '{print $2}')"
-          if [ -z "$expected_fingerprint" ]; then
-            echo "CONTABO_HOST_FINGERPRINT must be set as a repo variable or secret" >&2
-            exit 1
-          fi
-          if [ -z "$actual_fingerprints" ]; then
-            echo "Failed to read SSH host key fingerprint for ${{ secrets.CONTABO_SSH_HOST }}" >&2
-            exit 1
-          fi
-          if ! printf '%s\n' "$actual_fingerprints" | grep -Fx -- "$expected_fingerprint" > /dev/null; then
-            echo "SSH host key fingerprint mismatch for ${{ secrets.CONTABO_SSH_HOST }}" >&2
-            echo "Expected: $expected_fingerprint" >&2
-            echo "Actual fingerprints:" >&2
-            printf '%s\n' "$actual_fingerprints" >&2
-            exit 1
-          fi
-          cat "$scanned_host_keys" >> "$HOME/.ssh/known_hosts"
+          scripts/deployment/trust-ssh-host-key.sh \
+            "${{ secrets.CONTABO_SSH_HOST }}" \
+            "${{ secrets.CONTABO_SSH_PORT || '22' }}" \
+            "$CONTABO_HOST_FINGERPRINT"
 
       - name: Upload rollback bundle
         run: |

--- a/docs/deployment/contabo.md
+++ b/docs/deployment/contabo.md
@@ -23,13 +23,19 @@ opening an SSH connection:
 - `.github/workflows/deploy-contabo.yml`
 - `.github/workflows/rollback-contabo.yml`
 
-Configure `CONTABO_HOST_FINGERPRINT` as either a repository variable or a
+Configure `CONTABO_HOST_FINGERPRINT` as a repository variable (recommended) or a
 repository secret. Use the `SHA256:...` fingerprint for the trusted Contabo SSH
 host key, not a value captured from a failed workflow run. Verify it from a
 trusted channel first, then set it with:
 
 ```bash
 gh variable set CONTABO_HOST_FINGERPRINT --repo vega113/supawave --body 'SHA256:...'
+```
+
+To store it as a secret instead (not visible in workflow logs):
+
+```bash
+gh secret set CONTABO_HOST_FINGERPRINT --repo vega113/supawave --body 'SHA256:...'
 ```
 
 If this value is missing or does not match the key returned by the host, deploy

--- a/docs/deployment/contabo.md
+++ b/docs/deployment/contabo.md
@@ -14,3 +14,23 @@ Contabo-specific assumptions in the current project history:
 
 The canonical deploy assets are now provider-neutral and live under `deploy/caddy/`.
 Do not treat `deploy/contabo/` as the source of truth for new work.
+
+## GitHub Actions Host Key Pinning
+
+Both Contabo deployment workflows require a pinned SSH host key fingerprint before
+opening an SSH connection:
+
+- `.github/workflows/deploy-contabo.yml`
+- `.github/workflows/rollback-contabo.yml`
+
+Configure `CONTABO_HOST_FINGERPRINT` as either a repository variable or a
+repository secret. Use the `SHA256:...` fingerprint for the trusted Contabo SSH
+host key, not a value captured from a failed workflow run. Verify it from a
+trusted channel first, then set it with:
+
+```bash
+gh variable set CONTABO_HOST_FINGERPRINT --repo vega113/supawave --body 'SHA256:...'
+```
+
+If this value is missing or does not match the key returned by the host, deploy
+and rollback workflows fail before uploading or executing the deployment bundle.

--- a/docs/superpowers/plans/2026-05-08-issue-1214-contabo-host-fingerprint.md
+++ b/docs/superpowers/plans/2026-05-08-issue-1214-contabo-host-fingerprint.md
@@ -1,0 +1,35 @@
+# Issue #1214 Contabo Host Key Fingerprint Plan
+
+## Problem
+
+The standalone `rollback-contabo.yml` workflow requires
+`CONTABO_HOST_FINGERPRINT`, but production recovery showed the value is not
+configured. The deploy workflow can still connect by appending an `ssh-keyscan`
+result directly to `known_hosts`, so deploy and rollback currently use different
+trust models.
+
+## Plan
+
+1. Add a focused contract test that fails while the deploy workflow lacks the
+   pinned fingerprint guard and while the shared trust script is missing.
+2. Add one shared `scripts/deployment/trust-ssh-host-key.sh` helper that:
+   - rejects missing host or fingerprint configuration before network access,
+   - scans the host key,
+   - compares all scanned fingerprints against the pinned value, and
+   - appends only the scanned host-key lines whose fingerprint matches.
+3. Use that helper from both `deploy-contabo.yml` and `rollback-contabo.yml`.
+4. Document the required `CONTABO_HOST_FINGERPRINT` repository variable or
+   secret in the Contabo deployment overlay.
+5. Add a changelog fragment because this changes production deploy and rollback
+   operator behavior.
+6. Verify with the focused Python tests, changelog validation, shell syntax
+   checks, and whitespace checks before opening the PR.
+
+## Self Review
+
+- Scope is limited to GitHub Actions host-key trust and operator docs.
+- The fix deliberately strengthens deploy to match rollback instead of weakening
+  rollback to match deploy.
+- The shared script reduces future drift between deploy and rollback workflows.
+- No production workflow should be executed as part of local verification; this
+  PR changes workflow behavior but should not trigger a real rollback.

--- a/scripts/deployment/trust-ssh-host-key.sh
+++ b/scripts/deployment/trust-ssh-host-key.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+host="${1:-}"
+port="${2:-22}"
+expected_fingerprint="${3:-}"
+
+if [ -z "$host" ]; then
+  echo "CONTABO_SSH_HOST must be set" >&2
+  exit 1
+fi
+
+if [ -z "$expected_fingerprint" ]; then
+  echo "CONTABO_HOST_FINGERPRINT must be set as a repo variable or secret" >&2
+  exit 1
+fi
+
+mkdir -p "$HOME/.ssh"
+tmp_dir="${RUNNER_TEMP:-$(mktemp -d)}"
+mkdir -p "$tmp_dir"
+scanned_host_keys="$tmp_dir/contabo_known_hosts"
+
+ssh-keyscan -p "$port" -H "$host" > "$scanned_host_keys"
+actual_fingerprints="$(ssh-keygen -lf "$scanned_host_keys" | awk '{print $2}')"
+
+if [ -z "$actual_fingerprints" ]; then
+  echo "Failed to read SSH host key fingerprint for $host" >&2
+  exit 1
+fi
+
+matched_host_keys=""
+while IFS= read -r host_key_line; do
+  [ -n "$host_key_line" ] || continue
+  case "$host_key_line" in
+    "#"*) continue ;;
+  esac
+  key_file="$tmp_dir/contabo_known_host_key"
+  printf '%s\n' "$host_key_line" > "$key_file"
+  line_fingerprint="$(ssh-keygen -lf "$key_file" | awk '{print $2}')"
+  if [ "$line_fingerprint" = "$expected_fingerprint" ]; then
+    matched_host_keys="${matched_host_keys}${host_key_line}"$'\n'
+  fi
+done < "$scanned_host_keys"
+
+if [ -z "$matched_host_keys" ]; then
+  echo "SSH host key fingerprint mismatch for $host" >&2
+  echo "Expected: $expected_fingerprint" >&2
+  echo "Actual fingerprints:" >&2
+  printf '%s\n' "$actual_fingerprints" >&2
+  exit 1
+fi
+
+printf '%s' "$matched_host_keys" >> "$HOME/.ssh/known_hosts"

--- a/scripts/deployment/trust-ssh-host-key.sh
+++ b/scripts/deployment/trust-ssh-host-key.sh
@@ -20,7 +20,14 @@ tmp_dir="${RUNNER_TEMP:-$(mktemp -d)}"
 mkdir -p "$tmp_dir"
 scanned_host_keys="$tmp_dir/contabo_known_hosts"
 
-ssh-keyscan -p "$port" -H "$host" > "$scanned_host_keys"
+ssh_keyscan_err="$tmp_dir/ssh_keyscan_err"
+ssh_keyscan_exit=0
+ssh-keyscan -p "$port" -H "$host" > "$scanned_host_keys" 2>"$ssh_keyscan_err" || ssh_keyscan_exit=$?
+if [ "$ssh_keyscan_exit" -ne 0 ]; then
+  echo "ssh-keyscan failed (exit $ssh_keyscan_exit) for $host:$port" >&2
+  cat "$ssh_keyscan_err" >&2
+  exit 1
+fi
 actual_fingerprints="$(ssh-keygen -lf "$scanned_host_keys" | awk '{print $2}')"
 
 if [ -z "$actual_fingerprints" ]; then

--- a/scripts/tests/test_contabo_host_key_workflows.py
+++ b/scripts/tests/test_contabo_host_key_workflows.py
@@ -1,0 +1,136 @@
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEPLOY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy-contabo.yml"
+ROLLBACK_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "rollback-contabo.yml"
+TRUST_SCRIPT = REPO_ROOT / "scripts" / "deployment" / "trust-ssh-host-key.sh"
+
+FINGERPRINT_ENV = (
+    "CONTABO_HOST_FINGERPRINT: ${{ vars.CONTABO_HOST_FINGERPRINT || "
+    "secrets.CONTABO_HOST_FINGERPRINT }}"
+)
+
+
+class ContaboHostKeyWorkflowTest(unittest.TestCase):
+  def test_deploy_and_rollback_require_pinned_host_fingerprint(self):
+    for workflow_path in (DEPLOY_WORKFLOW, ROLLBACK_WORKFLOW):
+      workflow = workflow_path.read_text(encoding="utf-8")
+
+      self.assertIn(FINGERPRINT_ENV, workflow)
+      self.assertIn("scripts/deployment/trust-ssh-host-key.sh", workflow)
+      self.assertIn('"$CONTABO_HOST_FINGERPRINT"', workflow)
+
+  def test_deploy_trusts_pinned_host_key_before_uploading_bundle(self):
+    workflow = DEPLOY_WORKFLOW.read_text(encoding="utf-8")
+
+    trust_idx = workflow.index("name: Trust Contabo host key")
+    upload_idx = workflow.index("name: Upload bundle")
+    self.assertLess(trust_idx, upload_idx)
+    self.assertIn("CONTABO_HOST_FINGERPRINT", workflow[trust_idx:upload_idx])
+
+  def test_shared_trust_script_rejects_missing_fingerprint_without_network(self):
+    result = subprocess.run(
+        [str(TRUST_SCRIPT), "contabo.example", "22", ""],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    self.assertNotEqual(0, result.returncode)
+    self.assertIn("CONTABO_HOST_FINGERPRINT must be set", result.stderr)
+
+  def test_shared_trust_script_accepts_matching_scanned_fingerprint(self):
+    result, known_hosts = run_trust_script_with_fake_ssh_key_tools(
+        expected="SHA256:expected",
+        actual="SHA256:expected",
+    )
+
+    self.assertEqual(
+        0,
+        result.returncode,
+        msg=f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}",
+    )
+    self.assertIn("ssh-ed25519 AAAATESTKEY", known_hosts)
+
+  def test_shared_trust_script_rejects_mismatched_scanned_fingerprint(self):
+    result, _home = run_trust_script_with_fake_ssh_key_tools(
+        expected="SHA256:expected",
+        actual="SHA256:actual",
+    )
+
+    self.assertNotEqual(0, result.returncode)
+    self.assertIn("SSH host key fingerprint mismatch", result.stderr)
+    self.assertIn("Expected: SHA256:expected", result.stderr)
+    self.assertIn("SHA256:actual", result.stderr)
+
+  def test_build_workflow_runs_host_key_workflow_tests(self):
+    workflow = (REPO_ROOT / ".github" / "workflows" / "build.yml").read_text(
+        encoding="utf-8"
+    )
+
+    self.assertIn(
+        "python3 -m unittest scripts.tests.test_contabo_host_key_workflows -v",
+        workflow,
+    )
+
+
+def run_trust_script_with_fake_ssh_key_tools(expected: str, actual: str):
+  with tempfile.TemporaryDirectory() as temp_dir:
+    root = Path(temp_dir)
+    fake_bin = root / "bin"
+    home = root / "home"
+    runner_temp = root / "runner"
+    fake_bin.mkdir()
+    home.mkdir()
+    runner_temp.mkdir()
+
+    write_executable(
+        fake_bin / "ssh-keyscan",
+        """\
+        #!/usr/bin/env bash
+        set -euo pipefail
+        printf '# contabo.example:22 SSH-2.0-OpenSSH_test\\n'
+        printf 'contabo.example ssh-ed25519 AAAATESTKEY\\n'
+        """,
+    )
+    write_executable(
+        fake_bin / "ssh-keygen",
+        f"""\
+        #!/usr/bin/env bash
+        set -euo pipefail
+        printf '256 {actual} contabo.example (ED25519)\\n'
+        """,
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["HOME"] = str(home)
+    env["RUNNER_TEMP"] = str(runner_temp)
+
+    result = subprocess.run(
+        [str(TRUST_SCRIPT), "contabo.example", "22", expected],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    known_hosts_path = home / ".ssh" / "known_hosts"
+    known_hosts = (
+        known_hosts_path.read_text(encoding="utf-8")
+        if known_hosts_path.exists()
+        else ""
+    )
+    return result, known_hosts
+
+
+def write_executable(path: Path, content: str):
+  path.write_text(textwrap.dedent(content), encoding="utf-8")
+  path.chmod(0o755)

--- a/scripts/tests/test_contabo_host_key_workflows.py
+++ b/scripts/tests/test_contabo_host_key_workflows.py
@@ -35,16 +35,34 @@ class ContaboHostKeyWorkflowTest(unittest.TestCase):
     self.assertIn("CONTABO_HOST_FINGERPRINT", workflow[trust_idx:upload_idx])
 
   def test_shared_trust_script_rejects_missing_fingerprint_without_network(self):
-    result = subprocess.run(
-        [str(TRUST_SCRIPT), "contabo.example", "22", ""],
-        cwd=REPO_ROOT,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+      root = Path(temp_dir)
+      fake_bin = root / "bin"
+      fake_bin.mkdir()
+      sentinel = root / "ssh_keyscan_called"
+      write_executable(
+          fake_bin / "ssh-keyscan",
+          f"""\
+          #!/usr/bin/env bash
+          touch {sentinel}
+          exit 0
+          """,
+      )
+      env = os.environ.copy()
+      env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+
+      result = subprocess.run(
+          [str(TRUST_SCRIPT), "contabo.example", "22", ""],
+          cwd=REPO_ROOT,
+          env=env,
+          text=True,
+          capture_output=True,
+          check=False,
+      )
 
     self.assertNotEqual(0, result.returncode)
     self.assertIn("CONTABO_HOST_FINGERPRINT must be set", result.stderr)
+    self.assertFalse(sentinel.exists(), "ssh-keyscan must not be called when fingerprint is missing")
 
   def test_shared_trust_script_accepts_matching_scanned_fingerprint(self):
     result, known_hosts = run_trust_script_with_fake_ssh_key_tools(

--- a/scripts/tests/test_contabo_host_key_workflows.py
+++ b/scripts/tests/test_contabo_host_key_workflows.py
@@ -60,9 +60,9 @@ class ContaboHostKeyWorkflowTest(unittest.TestCase):
           check=False,
       )
 
-    self.assertNotEqual(0, result.returncode)
-    self.assertIn("CONTABO_HOST_FINGERPRINT must be set", result.stderr)
-    self.assertFalse(sentinel.exists(), "ssh-keyscan must not be called when fingerprint is missing")
+      self.assertNotEqual(0, result.returncode)
+      self.assertIn("CONTABO_HOST_FINGERPRINT must be set", result.stderr)
+      self.assertFalse(sentinel.exists(), "ssh-keyscan must not be called when fingerprint is missing")
 
   def test_shared_trust_script_accepts_matching_scanned_fingerprint(self):
     result, known_hosts = run_trust_script_with_fake_ssh_key_tools(

--- a/wave/config/changelog.d/2026-05-08-contabo-host-key-pinning.json
+++ b/wave/config/changelog.d/2026-05-08-contabo-host-key-pinning.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-08-contabo-host-key-pinning",
+  "version": "Issue #1214",
+  "date": "2026-05-08",
+  "title": "Contabo deploys require a pinned SSH host key",
+  "summary": "The Contabo deploy and rollback workflows now share the same pinned SSH host-key verification path, so emergency rollback tooling fails early when the trusted fingerprint is missing or mismatched.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Document the required CONTABO_HOST_FINGERPRINT repository variable or secret for production deploy and rollback workflows"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- set the missing `CONTABO_HOST_FINGERPRINT` repo variable to the trusted ED25519 fingerprint already present in local `known_hosts` for the documented Contabo host `86.48.3.138`
- add a shared `scripts/deployment/trust-ssh-host-key.sh` verifier and use it from both deploy and standalone rollback workflows
- make deploy refuse unpinned/mismatched host keys before upload, matching rollback safety
- document the required variable and add CI contract tests plus a changelog fragment

Fixes #1214.

## Verification
- `python3 -m unittest scripts.tests.test_contabo_host_key_workflows -v`
- `tmp_home=$(mktemp -d) && tmp_runner=$(mktemp -d) && HOME="$tmp_home" RUNNER_TEMP="$tmp_runner" scripts/deployment/trust-ssh-host-key.sh 86.48.3.138 22 'SHA256:395Sy1wv9g95b5Yy/8P0Ga+okJJ91tx+5ruTkj+9xkU' && ssh-keygen -lf "$tmp_home/.ssh/known_hosts"`
- `python3 -m unittest scripts.tests.test_deploy_sanity_gate scripts.tests.test_contabo_host_key_workflows -v`
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json && git diff --check && bash -n scripts/deployment/trust-ssh-host-key.sh && bash -n deploy/caddy/deploy.sh && bash -n deploy/contabo/deploy.sh`
- `sbt -batch 'testOnly org.waveprotocol.box.server.util.J2clBuildStageContractTest'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deploy and rollback workflows now validate Contabo SSH host keys against a pinned fingerprint and fail early on mismatch.

* **Documentation**
  * Added guidance for configuring the required CONTABO_HOST_FINGERPRINT repository variable/secret and host-key pinning behavior.

* **Tests**
  * Added unit tests verifying workflows reference the pinned fingerprint, the shared host-key verifier behavior, and that the build runs these tests.

* **Chores**
  * Introduced a shared host-key verification helper used by deploy and rollback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->