### PR TITLE
Fix J2CL blip plus continuation behavior

### DIFF
--- a/j2cl/lit/src/elements/reaction-row.js
+++ b/j2cl/lit/src/elements/reaction-row.js
@@ -96,9 +96,10 @@ export class ReactionRow extends LitElement {
           type="button"
           data-reaction-add
           aria-label="Add reaction"
+          title="Add reaction"
           @click=${this.onAdd}
         >
-          +
+          ☺
         </button>
       </div>
       <span class="sr-only" aria-live="polite">${this.liveText()}</span>

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -42,6 +42,8 @@ import "./wavy-task-affordance.js";
  * Events emitted (CustomEvent, bubbles + composed):
  * - `wave-blip-reply-requested` — `{detail: {blipId, waveId}}`. F-3
  *   (compose) listens.
+ * - `wave-blip-continuation-requested` — `{detail: {blipId, waveId}}`.
+ *   Mirrors the GWT reply-box "+" continuation affordance.
  * - `wave-blip-edit-requested` — `{detail: {blipId, waveId}}`. F-3 owns
  *   the edit surface; F-2 only emits the request.
  * - `wave-blip-delete-requested` — `{detail: {blipId, waveId, bodySize}}`. F-3.S4
@@ -178,6 +180,30 @@ export class WaveBlip extends LitElement {
      * with children, so the glyph is purely a visual cue here. */
     .thread-chevron[hidden] {
       display: none;
+    }
+    .continuation-trigger {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 18px;
+      height: 18px;
+      margin: 4px 0 0 3.35em;
+      padding: 0;
+      border-radius: var(--wavy-radius-pill, 999px);
+      border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.24));
+      background: #ffffff;
+      color: var(--wavy-signal-cyan, #0077b6);
+      font: var(--wavy-type-label, 12px / 1 sans-serif);
+      font-weight: 700;
+      cursor: pointer;
+    }
+    .continuation-trigger:hover {
+      border-color: var(--wavy-signal-cyan, #22d3ee);
+      background: #eef8ff;
+    }
+    .continuation-trigger:focus-visible {
+      outline: none;
+      box-shadow: var(--wavy-focus-ring, 0 0 0 2px #22d3ee);
     }
     .thread-chevron:focus-visible {
       outline: none;
@@ -510,6 +536,17 @@ export class WaveBlip extends LitElement {
     );
   }
 
+  _onContinuationClick(event) {
+    event.stopPropagation();
+    this.dispatchEvent(
+      new CustomEvent("wave-blip-continuation-requested", {
+        bubbles: true,
+        composed: true,
+        detail: { blipId: this.blipId, waveId: this.waveId }
+      })
+    );
+  }
+
   _onEditClick(event) {
     event.stopPropagation();
     this.dispatchEvent(
@@ -687,6 +724,14 @@ export class WaveBlip extends LitElement {
         <div class="body">
           <slot></slot>
         </div>
+        <button
+          type="button"
+          class="continuation-trigger"
+          data-blip-continuation-trigger
+          aria-label="Add reply below this blip"
+          title="Add reply below this blip"
+          @click=${this._onContinuationClick}
+        >+</button>
         <slot name="blip-extension" slot="blip-extension"></slot>
         <slot name="reactions" slot="reactions"></slot>
       </wavy-blip-card>

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -1782,6 +1782,7 @@ export class WavyComposer extends LitElement {
 
   _composeBodyAriaLabel() {
     if (this.mode === "edit") return "Edit blip";
+    if (this.mode === "continuation") return "Add reply below this blip";
     if (this.mode === "wave-root") return "Reply to wave";
     if (this.mode === "create") return "New wave";
     return this.targetLabel ? `Reply to ${this.targetLabel}` : "Reply";
@@ -2860,7 +2861,12 @@ export class WavyComposer extends LitElement {
 
   _renderReplyChip(sendLabel, sendDisabled) {
     if (!this.replyTargetBlipId) return null;
-    const verb = this.mode === "edit" ? "Editing" : "Replying to";
+    const verb =
+      this.mode === "edit"
+        ? "Editing"
+        : this.mode === "continuation"
+          ? "Replying below"
+          : "Replying to";
     const label = this._replyHeaderLabel();
     const time = this._replyHeaderTime();
     return html`

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -265,7 +265,7 @@ function inlineFormatAnnotationsForNode(node) {
  * - replyTargetBlipId (String, attribute "reply-target-blip-id") —
  *   the blip the composer is replying to (absent for wave-root +
  *   create-wave composers).
- * - mode (String) — "reply" | "edit" | "create" | "wave-root";
+ * - mode (String) — "reply" | "edit" | "create" | "wave-root" | "continuation";
  *   surfaces the verb used in the host chip and submit button label.
  * - targetLabel (String) — display name of the reply target ("Yuri",
  *   "Top thread", …) used in the "Replying to <author>" chip.

--- a/j2cl/lit/src/elements/wavy-wave-root-reply-trigger.js
+++ b/j2cl/lit/src/elements/wavy-wave-root-reply-trigger.js
@@ -76,6 +76,7 @@ export class WavyWaveRootReplyTrigger extends LitElement {
         type="button"
         data-wave-root-reply-trigger
         aria-label="Reply to the wave"
+        title="Reply to the wave"
         @click=${this._onClick}
       >
         +

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -145,6 +145,21 @@ describe("<wave-blip>", () => {
     expect(ev.detail.waveId).to.equal("w4");
   });
 
+  it("renders a GWT-style continuation + that requests a same-thread reply", async () => {
+    const el = await fixture(html`
+      <wave-blip data-blip-id="b4" data-wave-id="w4" author-name="A"></wave-blip>
+    `);
+    await el.updateComplete;
+    const button = el.renderRoot.querySelector("[data-blip-continuation-trigger]");
+    expect(button).to.exist;
+    expect(button.textContent.trim()).to.equal("+");
+    expect(button.getAttribute("aria-label")).to.equal("Add reply below this blip");
+    expect(button.getAttribute("title")).to.equal("Add reply below this blip");
+    setTimeout(() => button.click(), 0);
+    const ev = await oneEvent(el, "wave-blip-continuation-requested");
+    expect(ev.detail).to.deep.equal({ blipId: "b4", waveId: "w4" });
+  });
+
   it("re-emits wave-blip-edit-requested when toolbar Edit fires", async () => {
     const el = await fixture(html`
       <wave-blip data-blip-id="b5" data-wave-id="w5" author-name="A"></wave-blip>

--- a/j2cl/lit/test/wavy-composer-inline-mount.test.js
+++ b/j2cl/lit/test/wavy-composer-inline-mount.test.js
@@ -45,7 +45,12 @@ before(async () => {
 function attachInlineComposerHandler() {
   const composers = new Map();
   const handler = (event) => {
-    const mode = event.type === "wave-blip-edit-requested" ? "edit" : "reply";
+    const mode =
+      event.type === "wave-blip-edit-requested"
+        ? "edit"
+        : event.type === "wave-blip-continuation-requested"
+          ? "continuation"
+          : "reply";
     const blipId = event.detail.blipId;
     if (composers.has(blipId)) return;
     const composer = document.createElement("wavy-composer");
@@ -66,11 +71,13 @@ function attachInlineComposerHandler() {
     composers.delete(blipId);
   };
   document.body.addEventListener("wave-blip-reply-requested", handler);
+  document.body.addEventListener("wave-blip-continuation-requested", handler);
   document.body.addEventListener("wave-blip-edit-requested", handler);
   document.body.addEventListener("wavy-composer-cancelled", cancelHandler);
   return {
     teardown() {
       document.body.removeEventListener("wave-blip-reply-requested", handler);
+      document.body.removeEventListener("wave-blip-continuation-requested", handler);
       document.body.removeEventListener("wave-blip-edit-requested", handler);
       document.body.removeEventListener("wavy-composer-cancelled", cancelHandler);
       for (const composer of composers.values()) {
@@ -128,6 +135,26 @@ describe("F-3.S1 inline composer mount integration", () => {
       await new Promise((r) => requestAnimationFrame(r));
       const composer = blip.querySelector("wavy-composer");
       expect(composer.getAttribute("mode")).to.equal("edit");
+    } finally {
+      ctx.teardown();
+    }
+  });
+
+  it("mounts a continuation composer from the blip + affordance", async () => {
+    const blip = await fixture(html`
+      <wave-blip data-blip-id="b99" data-wave-id="w1" author-name="A" posted-at="1m">
+      </wave-blip>
+    `);
+    await blip.updateComplete;
+    const ctx = attachInlineComposerHandler();
+    try {
+      const button = blip.renderRoot.querySelector("[data-blip-continuation-trigger]");
+      button.click();
+      await new Promise((r) => requestAnimationFrame(r));
+      const composer = blip.querySelector('wavy-composer[data-inline-composer="true"]');
+      expect(composer).to.exist;
+      expect(composer.getAttribute("reply-target-blip-id")).to.equal("b99");
+      expect(composer.getAttribute("mode")).to.equal("continuation");
     } finally {
       ctx.teardown();
     }

--- a/j2cl/lit/test/wavy-wave-root-reply-trigger.test.js
+++ b/j2cl/lit/test/wavy-wave-root-reply-trigger.test.js
@@ -21,6 +21,7 @@ describe("<wavy-wave-root-reply-trigger>", () => {
     expect(button).to.exist;
     expect(button.textContent.trim()).to.equal("+");
     expect(button.getAttribute("aria-label")).to.equal("Reply to the wave");
+    expect(button.getAttribute("title")).to.equal("Reply to the wave");
   });
 
   it("emits wave-root-reply-requested with the wave id on click", async () => {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -1103,27 +1103,20 @@ public final class J2clComposeSurfaceController {
 
   public void onReplySubmittedWithComponents(
       List<SubmittedComponent> components, String replyTargetBlipId) {
-    if (components == null) {
-      pendingSubmittedComponents = null;
-      onReplySubmitted("", replyTargetBlipId);
-      return;
-    }
-    StringBuilder plainBuilder = new StringBuilder();
-    for (SubmittedComponent component : components) {
-      if (component != null && component.getText() != null) {
-        plainBuilder.append(component.getText());
-      }
-    }
-    replyDraft = normalizeDraft(plainBuilder.toString());
-    pendingSubmittedComponents = new ArrayList<SubmittedComponent>(components);
-    submitReply(replyTargetBlipId, false);
+    submitWithComponents(components, replyTargetBlipId, false);
   }
 
   public void onContinuationSubmittedWithComponents(
       List<SubmittedComponent> components, String replyTargetBlipId) {
+    submitWithComponents(components, replyTargetBlipId, true);
+  }
+
+  private void submitWithComponents(
+      List<SubmittedComponent> components, String replyTargetBlipId, boolean continuation) {
     if (components == null) {
+      replyDraft = normalizeDraft("");
       pendingSubmittedComponents = null;
-      onContinuationSubmitted("", replyTargetBlipId);
+      submitReply(replyTargetBlipId, continuation);
       return;
     }
     StringBuilder plainBuilder = new StringBuilder();
@@ -1134,7 +1127,7 @@ public final class J2clComposeSurfaceController {
     }
     replyDraft = normalizeDraft(plainBuilder.toString());
     pendingSubmittedComponents = new ArrayList<SubmittedComponent>(components);
-    submitReply(replyTargetBlipId, true);
+    submitReply(replyTargetBlipId, continuation);
   }
 
   public boolean onToolbarAction(J2clDailyToolbarAction action) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -99,6 +99,10 @@ public final class J2clComposeSurfaceController {
       onReplySubmitted(draft);
     }
 
+    default void onContinuationSubmitted(String draft, String replyTargetBlipId) {
+      onReplySubmitted(draft, replyTargetBlipId);
+    }
+
     /**
      * J-UI-5 (#1083, R-5.1 + R-5.7): the user submitted a reply from the
      * inline rich-text composer. {@code components} carries the
@@ -137,6 +141,19 @@ public final class J2clComposeSurfaceController {
         }
       }
       onReplySubmitted(builder.toString(), replyTargetBlipId);
+    }
+
+    default void onContinuationSubmittedWithComponents(
+        List<SubmittedComponent> components, String replyTargetBlipId) {
+      StringBuilder builder = new StringBuilder();
+      if (components != null) {
+        for (SubmittedComponent component : components) {
+          if (component != null && component.getText() != null) {
+            builder.append(component.getText());
+          }
+        }
+      }
+      onContinuationSubmitted(builder.toString(), replyTargetBlipId);
     }
 
     void onAttachmentFilesSelected(List<AttachmentFileSelection> selections);
@@ -806,6 +823,11 @@ public final class J2clComposeSurfaceController {
           }
 
           @Override
+          public void onContinuationSubmitted(String draft, String replyTargetBlipId) {
+            J2clComposeSurfaceController.this.onContinuationSubmitted(draft, replyTargetBlipId);
+          }
+
+          @Override
           public void onReplySubmittedWithComponents(List<SubmittedComponent> components) {
             J2clComposeSurfaceController.this.onReplySubmittedWithComponents(components);
           }
@@ -814,6 +836,13 @@ public final class J2clComposeSurfaceController {
           public void onReplySubmittedWithComponents(
               List<SubmittedComponent> components, String replyTargetBlipId) {
             J2clComposeSurfaceController.this.onReplySubmittedWithComponents(
+                components, replyTargetBlipId);
+          }
+
+          @Override
+          public void onContinuationSubmittedWithComponents(
+              List<SubmittedComponent> components, String replyTargetBlipId) {
+            J2clComposeSurfaceController.this.onContinuationSubmittedWithComponents(
                 components, replyTargetBlipId);
           }
 
@@ -1051,7 +1080,13 @@ public final class J2clComposeSurfaceController {
   public void onReplySubmitted(String draft, String replyTargetBlipId) {
     replyDraft = normalizeDraft(draft);
     pendingSubmittedComponents = null;
-    submitReply(replyTargetBlipId);
+    submitReply(replyTargetBlipId, false);
+  }
+
+  public void onContinuationSubmitted(String draft, String replyTargetBlipId) {
+    replyDraft = normalizeDraft(draft);
+    pendingSubmittedComponents = null;
+    submitReply(replyTargetBlipId, true);
   }
 
   /**
@@ -1081,7 +1116,25 @@ public final class J2clComposeSurfaceController {
     }
     replyDraft = normalizeDraft(plainBuilder.toString());
     pendingSubmittedComponents = new ArrayList<SubmittedComponent>(components);
-    submitReply(replyTargetBlipId);
+    submitReply(replyTargetBlipId, false);
+  }
+
+  public void onContinuationSubmittedWithComponents(
+      List<SubmittedComponent> components, String replyTargetBlipId) {
+    if (components == null) {
+      pendingSubmittedComponents = null;
+      onContinuationSubmitted("", replyTargetBlipId);
+      return;
+    }
+    StringBuilder plainBuilder = new StringBuilder();
+    for (SubmittedComponent component : components) {
+      if (component != null && component.getText() != null) {
+        plainBuilder.append(component.getText());
+      }
+    }
+    replyDraft = normalizeDraft(plainBuilder.toString());
+    pendingSubmittedComponents = new ArrayList<SubmittedComponent>(components);
+    submitReply(replyTargetBlipId, true);
   }
 
   public boolean onToolbarAction(J2clDailyToolbarAction action) {
@@ -2151,15 +2204,15 @@ public final class J2clComposeSurfaceController {
   }
 
   private void submitReply() {
-    submitReply(null);
+    submitReply(null, false);
   }
 
-  private void submitReply(String replyTargetBlipId) {
+  private void submitReply(String replyTargetBlipId, boolean continuation) {
     if (signedOut || replySubmitting) {
       render();
       return;
     }
-    J2clSidecarWriteSession submitSession = sessionForReplyTarget(replyTargetBlipId);
+    J2clSidecarWriteSession submitSession = sessionForReplyTarget(replyTargetBlipId, continuation);
     if (submitSession == null || isEmpty(submitSession.getSelectedWaveId())) {
       replyStatusText = "";
       replyErrorText =
@@ -2220,12 +2273,18 @@ public final class J2clComposeSurfaceController {
         error -> handleReplyFailure(generation, error));
   }
 
-  private J2clSidecarWriteSession sessionForReplyTarget(String replyTargetBlipId) {
+  private J2clSidecarWriteSession sessionForReplyTarget(
+      String replyTargetBlipId, boolean continuation) {
     if (writeSession == null) {
       return null;
     }
     String normalizedTarget = replyTargetBlipId == null ? "" : replyTargetBlipId.trim();
-    return normalizedTarget.isEmpty() ? writeSession : writeSession.forReplyTarget(normalizedTarget);
+    if (normalizedTarget.isEmpty()) {
+      return writeSession;
+    }
+    return continuation
+        ? writeSession.forContinuationTarget(normalizedTarget)
+        : writeSession.forReplyTarget(normalizedTarget);
   }
 
   private void handleReplyResponse(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -2280,7 +2280,7 @@ public final class J2clComposeSurfaceController {
     }
     String normalizedTarget = replyTargetBlipId == null ? "" : replyTargetBlipId.trim();
     if (normalizedTarget.isEmpty()) {
-      return writeSession;
+      return continuation ? null : writeSession;
     }
     return continuation
         ? writeSession.forContinuationTarget(normalizedTarget)

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -218,6 +218,9 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           "wave-blip-reply-requested",
           event -> openInlineComposer(eventDetailString(event, "blipId"), "reply"));
       DomGlobal.document.body.addEventListener(
+          "wave-blip-continuation-requested",
+          event -> openInlineComposer(eventDetailString(event, "blipId"), "continuation"));
+      DomGlobal.document.body.addEventListener(
           "wave-blip-edit-requested",
           event -> openInlineComposer(eventDetailString(event, "blipId"), "edit"));
       DomGlobal.document.body.addEventListener(
@@ -498,6 +501,7 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     composer.setAttribute("reply-target-blip-id", key);
     composer.setAttribute("mode", mode);
     setProperty(composer, "available", true);
+    setProperty(composer, "mode", mode);
     composer.addEventListener(
         "draft-change",
         event -> {
@@ -517,9 +521,17 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           List<J2clComposeSurfaceController.SubmittedComponent> components =
               decodeSubmittedComponents(event);
           if (components.isEmpty()) {
-            listener.onReplySubmitted(propertyString(composer, "draft"), key);
+            if ("continuation".equals(propertyString(composer, "mode"))) {
+              listener.onContinuationSubmitted(propertyString(composer, "draft"), key);
+            } else {
+              listener.onReplySubmitted(propertyString(composer, "draft"), key);
+            }
           } else {
-            listener.onReplySubmittedWithComponents(components, key);
+            if ("continuation".equals(propertyString(composer, "mode"))) {
+              listener.onContinuationSubmittedWithComponents(components, key);
+            } else {
+              listener.onReplySubmittedWithComponents(components, key);
+            }
           }
         });
     composer.addEventListener(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -876,6 +876,10 @@ public final class J2clRichContentDeltaFactory {
     }
     String replyBlipId = nextToken("b+");
     String operationsJson = buildDocumentOperation(replyBlipId, document);
+    if (session.isContinuationReply() && session.getReplyManifestSiblingInsertPosition() < 0) {
+      throw new IllegalArgumentException(
+          "Missing manifest sibling reply insert position for continuation.");
+    }
     if (shouldCreateRegularReply(session)) {
       operationsJson =
           buildConversationRegularReplyOperation(
@@ -939,7 +943,8 @@ public final class J2clRichContentDeltaFactory {
   }
 
   private static boolean shouldCreateRegularReply(J2clSidecarWriteSession session) {
-    return session.getReplyTargetDepth() >= DEFAULT_MAX_INLINE_REPLY_DEPTH
+    return (session.isContinuationReply()
+            || session.getReplyTargetDepth() >= DEFAULT_MAX_INLINE_REPLY_DEPTH)
         && session.getReplyManifestSiblingInsertPosition() >= 0;
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -925,7 +925,8 @@ public final class J2clRichContentDeltaFactory {
   private String buildConversationRegularReplyOperation(
       int insertPosition, int manifestItemCount, String replyBlipId) {
     if (insertPosition < 0) {
-      throw new IllegalArgumentException("Invalid manifest sibling reply insert position.");
+      throw new IllegalArgumentException(
+          "Reply failed: the sibling insert position is invalid. Please try again.");
     }
     StringBuilder components = new StringBuilder();
     if (insertPosition > 0) {
@@ -952,7 +953,8 @@ public final class J2clRichContentDeltaFactory {
   private String buildConversationReplyThreadOperation(
       int insertPosition, int manifestItemCount, String threadId, String replyBlipId) {
     if (insertPosition < 0) {
-      throw new IllegalArgumentException("Invalid manifest reply insert position.");
+      throw new IllegalArgumentException(
+          "Reply failed: the thread insert position is invalid. Please try again.");
     }
     StringBuilder components = new StringBuilder();
     if (insertPosition > 0) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -878,7 +878,8 @@ public final class J2clRichContentDeltaFactory {
     String operationsJson = buildDocumentOperation(replyBlipId, document);
     if (session.isContinuationReply() && session.getReplyManifestSiblingInsertPosition() < 0) {
       throw new IllegalArgumentException(
-          "Missing manifest sibling reply insert position for continuation.");
+          "Unable to submit continuation reply: missing insert position for blip "
+              + session.getReplyTargetBlipId() + ".");
     }
     if (shouldCreateRegularReply(session)) {
       operationsJson =

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactory.java
@@ -115,7 +115,8 @@ public class J2clPlainTextDeltaFactory {
   private static String buildConversationReplyThreadOperation(
       int insertPosition, int manifestItemCount, String threadId, String replyBlipId) {
     if (insertPosition < 0) {
-      throw new IllegalArgumentException("Invalid manifest reply insert position.");
+      throw new IllegalArgumentException(
+          "Reply failed: the thread insert position is invalid. Please try again.");
     }
     int trailingRetain = manifestItemCount < 0 ? 0 : manifestItemCount - insertPosition;
     String componentsJson =
@@ -133,7 +134,8 @@ public class J2clPlainTextDeltaFactory {
   private static String buildConversationRegularReplyOperation(
       int insertPosition, int manifestItemCount, String replyBlipId) {
     if (insertPosition < 0) {
-      throw new IllegalArgumentException("Invalid manifest sibling reply insert position.");
+      throw new IllegalArgumentException(
+          "Reply failed: the sibling insert position is invalid. Please try again.");
     }
     int trailingRetain = manifestItemCount < 0 ? 0 : manifestItemCount - insertPosition;
     String componentsJson =

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactory.java
@@ -68,7 +68,8 @@ public class J2clPlainTextDeltaFactory {
             + "\"}]}}}";
     if (session.isContinuationReply() && session.getReplyManifestSiblingInsertPosition() < 0) {
       throw new IllegalArgumentException(
-          "Missing manifest sibling reply insert position for continuation.");
+          "Unable to submit continuation reply: missing insert position for blip "
+              + session.getReplyTargetBlipId() + ".");
     }
     if (shouldCreateRegularReply(session)) {
       operationsJson =

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactory.java
@@ -66,6 +66,10 @@ public class J2clPlainTextDeltaFactory {
             + "\",\"2\":{\"1\":[{\"2\":\""
             + escapeJson(text)
             + "\"}]}}}";
+    if (session.isContinuationReply() && session.getReplyManifestSiblingInsertPosition() < 0) {
+      throw new IllegalArgumentException(
+          "Missing manifest sibling reply insert position for continuation.");
+    }
     if (shouldCreateRegularReply(session)) {
       operationsJson =
           buildConversationRegularReplyOperation(
@@ -141,7 +145,8 @@ public class J2clPlainTextDeltaFactory {
   }
 
   private static boolean shouldCreateRegularReply(J2clSidecarWriteSession session) {
-    return session.getReplyTargetDepth() >= DEFAULT_MAX_INLINE_REPLY_DEPTH
+    return (session.isContinuationReply()
+            || session.getReplyTargetDepth() >= DEFAULT_MAX_INLINE_REPLY_DEPTH)
         && session.getReplyManifestSiblingInsertPosition() >= 0;
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarWriteSession.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarWriteSession.java
@@ -17,6 +17,7 @@ public final class J2clSidecarWriteSession {
   private final int replyManifestItemCount;
   private final int replyManifestSiblingInsertPosition;
   private final int replyTargetDepth;
+  private final boolean continuationReply;
   private final Map<String, Integer> replyManifestInsertPositionsByBlipId;
   private final Map<String, Integer> replyManifestSiblingInsertPositionsByBlipId;
   private final Map<String, Integer> replyTargetDepthsByBlipId;
@@ -124,6 +125,7 @@ public final class J2clSidecarWriteSession {
         replyManifestItemCount,
         -1,
         -1,
+        false,
         singletonReplyPosition(replyTargetBlipId, replyManifestInsertPosition),
         Collections.<String, Integer>emptyMap(),
         Collections.<String, Integer>emptyMap());
@@ -150,6 +152,7 @@ public final class J2clSidecarWriteSession {
         replyManifestItemCount,
         -1,
         -1,
+        false,
         replyManifestInsertPositionsByBlipId,
         Collections.<String, Integer>emptyMap(),
         Collections.<String, Integer>emptyMap());
@@ -169,6 +172,38 @@ public final class J2clSidecarWriteSession {
       Map<String, Integer> replyManifestInsertPositionsByBlipId,
       Map<String, Integer> replyManifestSiblingInsertPositionsByBlipId,
       Map<String, Integer> replyTargetDepthsByBlipId) {
+    this(
+        selectedWaveId,
+        channelId,
+        baseVersion,
+        historyHash,
+        replyTargetBlipId,
+        participantIds,
+        replyManifestInsertPosition,
+        replyManifestItemCount,
+        replyManifestSiblingInsertPosition,
+        replyTargetDepth,
+        false,
+        replyManifestInsertPositionsByBlipId,
+        replyManifestSiblingInsertPositionsByBlipId,
+        replyTargetDepthsByBlipId);
+  }
+
+  private J2clSidecarWriteSession(
+      String selectedWaveId,
+      String channelId,
+      long baseVersion,
+      String historyHash,
+      String replyTargetBlipId,
+      List<String> participantIds,
+      int replyManifestInsertPosition,
+      int replyManifestItemCount,
+      int replyManifestSiblingInsertPosition,
+      int replyTargetDepth,
+      boolean continuationReply,
+      Map<String, Integer> replyManifestInsertPositionsByBlipId,
+      Map<String, Integer> replyManifestSiblingInsertPositionsByBlipId,
+      Map<String, Integer> replyTargetDepthsByBlipId) {
     this.selectedWaveId = selectedWaveId;
     this.channelId = channelId;
     this.baseVersion = baseVersion;
@@ -182,6 +217,7 @@ public final class J2clSidecarWriteSession {
     this.replyManifestItemCount = Math.max(-1, replyManifestItemCount);
     this.replyManifestSiblingInsertPosition = Math.max(-1, replyManifestSiblingInsertPosition);
     this.replyTargetDepth = Math.max(-1, replyTargetDepth);
+    this.continuationReply = continuationReply;
     this.replyManifestInsertPositionsByBlipId =
         immutableReplyPositions(
             replyManifestInsertPositionsByBlipId,
@@ -239,10 +275,26 @@ public final class J2clSidecarWriteSession {
     return replyTargetDepth;
   }
 
+  public boolean isContinuationReply() {
+    return continuationReply;
+  }
+
   public J2clSidecarWriteSession forReplyTarget(String replyTargetBlipId) {
+    return forReplyTarget(replyTargetBlipId, false);
+  }
+
+  public J2clSidecarWriteSession forContinuationTarget(String replyTargetBlipId) {
+    return forReplyTarget(replyTargetBlipId, true);
+  }
+
+  private J2clSidecarWriteSession forReplyTarget(
+      String replyTargetBlipId, boolean continuationReply) {
     String target = replyTargetBlipId == null ? "" : replyTargetBlipId.trim();
-    if (target.isEmpty() || target.equals(this.replyTargetBlipId)) {
-      return this;
+    if (target.isEmpty()) {
+      return continuationReply == this.continuationReply ? this : withContinuation(continuationReply);
+    }
+    if (target.equals(this.replyTargetBlipId)) {
+      return continuationReply == this.continuationReply ? this : withContinuation(continuationReply);
     }
     Integer insertPosition = replyManifestInsertPositionsByBlipId.get(target);
     int normalizedInsertPosition = insertPosition == null ? -1 : Math.max(-1, insertPosition.intValue());
@@ -266,6 +318,28 @@ public final class J2clSidecarWriteSession {
         normalizedItemCount,
         normalizedSiblingInsertPosition,
         normalizedTargetDepth,
+        continuationReply,
+        replyManifestInsertPositionsByBlipId,
+        replyManifestSiblingInsertPositionsByBlipId,
+        replyTargetDepthsByBlipId);
+  }
+
+  private J2clSidecarWriteSession withContinuation(boolean continuationReply) {
+    if (continuationReply == this.continuationReply) {
+      return this;
+    }
+    return new J2clSidecarWriteSession(
+        selectedWaveId,
+        channelId,
+        baseVersion,
+        historyHash,
+        replyTargetBlipId,
+        participantIds,
+        replyManifestInsertPosition,
+        replyManifestItemCount,
+        replyManifestSiblingInsertPosition,
+        replyTargetDepth,
+        continuationReply,
         replyManifestInsertPositionsByBlipId,
         replyManifestSiblingInsertPositionsByBlipId,
         replyTargetDepthsByBlipId);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
@@ -225,6 +225,63 @@ public class J2clRichContentDeltaFactoryTest {
   }
 
   @Test
+  public void continuationReplyUsesSiblingManifestPositionLikeGwtPlus() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession baseSession =
+        new J2clSidecarWriteSession(
+            "example.com/w+reply",
+            "chan-7",
+            44L,
+            "ABCD",
+            "b+root",
+            Collections.<String>emptyList(),
+            6,
+            10,
+            7,
+            1,
+            Collections.singletonMap("b+root", Integer.valueOf(6)),
+            Collections.singletonMap("b+root", Integer.valueOf(7)),
+            Collections.singletonMap("b+root", Integer.valueOf(1)));
+    J2clSidecarWriteSession session = baseSession.forContinuationTarget("b+root");
+    J2clComposerDocument document =
+        J2clComposerDocument.builder().text("Continuation reply").build();
+
+    SidecarSubmitRequest request = factory.createReplyRequest("user@example.com", session, document);
+    String deltaJson = request.getDeltaJson();
+
+    Assert.assertEquals("b+seedA", request.getClientCreatedBlipId());
+    assertContains(
+        deltaJson,
+        "\"1\":\"conversation\"",
+        "{\"5\":7}",
+        "{\"3\":{\"1\":\"blip\",\"2\":[{\"1\":\"id\",\"2\":\"b+seedA\"}]}}",
+        "{\"5\":3}",
+        "\"2\":\"Continuation reply\"");
+    Assert.assertFalse("GWT-style continuation must not create a nested thread", deltaJson.contains("\"1\":\"thread\""));
+    Assert.assertEquals(2, countOccurrences(deltaJson, "b+seedA"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void continuationReplyRequiresSiblingManifestPosition() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession baseSession =
+        new J2clSidecarWriteSession(
+            "example.com/w+reply",
+            "chan-7",
+            44L,
+            "ABCD",
+            "b+root",
+            Collections.<String>emptyList(),
+            6,
+            10);
+    J2clComposerDocument document =
+        J2clComposerDocument.builder().text("Continuation reply").build();
+
+    factory.createReplyRequest(
+        "user@example.com", baseSession.forContinuationTarget("b+root"), document);
+  }
+
+  @Test
   public void replyRequestAllowsVersionZeroWriteSession() {
     J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
     J2clSidecarWriteSession session =

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clPlainTextDeltaFactoryTest.java
@@ -111,6 +111,60 @@ public class J2clPlainTextDeltaFactoryTest {
         countOccurrences(deltaJson, "b+seedA"));
   }
 
+  @Test
+  public void continuationReplyUsesSiblingManifestPositionLikeGwtPlus() {
+    J2clPlainTextDeltaFactory factory = new J2clPlainTextDeltaFactory("seed");
+    J2clSidecarWriteSession baseSession =
+        new J2clSidecarWriteSession(
+            "example.com/w+reply",
+            "chan-7",
+            44L,
+            "ABCD",
+            "b+root",
+            java.util.Collections.<String>emptyList(),
+            6,
+            10,
+            7,
+            1,
+            java.util.Collections.singletonMap("b+root", Integer.valueOf(6)),
+            java.util.Collections.singletonMap("b+root", Integer.valueOf(7)),
+            java.util.Collections.singletonMap("b+root", Integer.valueOf(1)));
+
+    SidecarSubmitRequest request =
+        factory.createReplyRequest(
+            "user@example.com", baseSession.forContinuationTarget("b+root"), "Plain continuation");
+    String deltaJson = request.getDeltaJson();
+
+    Assert.assertEquals("b+seedA", request.getClientCreatedBlipId());
+    Assert.assertTrue(deltaJson.contains("\"1\":\"conversation\""));
+    Assert.assertTrue(deltaJson.contains("{\"5\":7}"));
+    Assert.assertTrue(deltaJson.contains("{\"5\":3}"));
+    Assert.assertFalse(deltaJson.contains("\"1\":\"thread\""));
+    Assert.assertTrue(deltaJson.contains("Plain continuation"));
+    Assert.assertEquals(
+        "continuation inserts the reply blip into manifest and creates its document",
+        2,
+        countOccurrences(deltaJson, "b+seedA"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void continuationReplyRequiresSiblingManifestPosition() {
+    J2clPlainTextDeltaFactory factory = new J2clPlainTextDeltaFactory("seed");
+    J2clSidecarWriteSession baseSession =
+        new J2clSidecarWriteSession(
+            "example.com/w+reply",
+            "chan-7",
+            44L,
+            "ABCD",
+            "b+root",
+            java.util.Collections.<String>emptyList(),
+            6,
+            10);
+
+    factory.createReplyRequest(
+        "user@example.com", baseSession.forContinuationTarget("b+root"), "Plain continuation");
+  }
+
   private static void assertSubmitRequest(
       SidecarSubmitRequest request,
       String expectedWaveletName,

--- a/wave/config/changelog.d/2026-05-08-j2cl-gwt-continuation-plus.json
+++ b/wave/config/changelog.d/2026-05-08-j2cl-gwt-continuation-plus.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-08-j2cl-gwt-continuation-plus",
+  "version": "J2CL root shell",
+  "date": "2026-05-08",
+  "title": "J2CL blip plus follows GWT continuation behavior",
+  "summary": "Makes the visible plus below J2CL blips open a same-thread continuation composer instead of leaving an unclear inert-looking control.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "The J2CL blip plus now has a tooltip, opens the inline composer for that blip, and submits through the same sibling-continuation manifest path used by the GWT reply-box plus."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- make the visible + below J2CL blips open a same-thread continuation composer like the GWT reply-box plus
- route continuation submits through sibling manifest insertion instead of nested reply creation
- disambiguate the reaction add control with a tooltip and non-plus icon so it no longer looks like the blip continuation affordance
- add Lit and J2CL delta factory regression coverage plus a changelog fragment

## Verification
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py`
- `sbt j2clLitTest`
- `sbt Test/compile`
- `bash scripts/worktree-boot.sh --port 9908`
- `PORT=9908 JAVA_OPTS='...wiab-logging.conf ...jaas.config' bash scripts/wave-smoke.sh start && PORT=9908 bash scripts/wave-smoke.sh check && PORT=9908 bash scripts/wave-smoke.sh stop`

Smoke result included `ROOT_STATUS=200`, `GWT_VIEW_STATUS=200`, `J2CL_ROOT_STATUS=200`, and `J2CL_ROOT_SHELL=present`. The boot script still reports `J2CL_INDEX_STATUS=404` / `SIDECAR_STATUS=404` as optional in this staged worktree environment; the changed J2CL component behavior is covered by `sbt j2clLitTest`.

## Notes
- GWT `+` behavior maps to continuation: add a new blip after the target in the current thread. This PR preserves normal nested inline reply behavior for the existing reply action and uses continuation mode only for the visible blip `+`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Click the "+" on a blip to open an inline continuation composer and post a same-thread reply.

* **Bug Fixes / Accessibility**
  * Reply and reaction buttons now include descriptive title/tooltips for improved discoverability.

* **UI**
  * "Add reaction" button label changed from "+" to a smiley (☺).

* **Tests**
  * Added tests covering continuation reply flow and updated button labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->