### PR TITLE
Fix GWT unload permission warning after J2CL switch

### DIFF
--- a/wave/config/changelog.d/2026-05-08-gwt-unload-permissions-policy.json
+++ b/wave/config/changelog.d/2026-05-08-gwt-unload-permissions-policy.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-08-gwt-unload-permissions-policy",
+  "version": "GWT rollback path",
+  "date": "2026-05-08",
+  "title": "GWT view-switch unload permission",
+  "summary": "The legacy GWT route now sends a permissions policy that allows its same-origin unload handler when users switch back from the J2CL view.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Allows the legacy GWT web client to register its unload handler without Chrome logging a permissions-policy violation during J2CL-to-GWT view switches."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/security/SecurityHeadersFilter.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/security/SecurityHeadersFilter.java
@@ -53,6 +53,7 @@ public final class SecurityHeadersFilter implements Filter {
 
   private static final String DEFAULT_REFERRER = "strict-origin-when-cross-origin";
   private static final String DEFAULT_XCTO = "nosniff";
+  private static final String DEFAULT_PERMISSIONS_POLICY = "unload=(self)";
 
   @Inject
   public SecurityHeadersFilter(Config config) {
@@ -79,11 +80,17 @@ public final class SecurityHeadersFilter implements Filter {
       String xcto = config.hasPath("security.x_content_type_options")
           ? config.getString("security.x_content_type_options")
           : DEFAULT_XCTO;
+      String permissionsPolicy = config.hasPath("security.permissions_policy")
+          ? config.getString("security.permissions_policy")
+          : DEFAULT_PERMISSIONS_POLICY;
 
       if (!isCommitted(http)) {
         http.setHeader("Content-Security-Policy", csp);
         http.setHeader("Referrer-Policy", referrer);
         http.setHeader("X-Content-Type-Options", xcto);
+        if (permissionsPolicy != null && !permissionsPolicy.isBlank()) {
+          http.setHeader("Permissions-Policy", permissionsPolicy);
+        }
 
         // Conditionally add HSTS when connection is secure
         try {

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/jakarta/SecurityHeadersJakartaIT.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/jakarta/SecurityHeadersJakartaIT.java
@@ -82,6 +82,11 @@ public class SecurityHeadersJakartaIT {
     java.util.Map<String, java.util.List<String>> headers = c.getHeaderFields();
     assertNotNull(getHeader(headers, "Content-Security-Policy"));
     assertNotNull(getHeader(headers, "Referrer-Policy"));
+    String permissionsPolicy = getHeader(headers, "Permissions-Policy");
+    assertNotNull("Permissions-Policy header expected", permissionsPolicy);
+    assertTrue(
+        "Permissions-Policy should allow legacy GWT unload handlers, was: " + permissionsPolicy,
+        permissionsPolicy.contains("unload=(self)"));
     String xcto = getHeader(headers, "X-Content-Type-Options");
     assertNotNull(xcto);
     assertTrue("X-Content-Type-Options should be nosniff, was: " + xcto, "nosniff".equalsIgnoreCase(xcto));
@@ -103,7 +108,8 @@ public class SecurityHeadersJakartaIT {
       var cfg = ConfigFactory.parseString(
           "security.csp=\"default-src 'none'\"\n" +
           "security.referrer_policy=\"no-referrer\"\n" +
-          "security.x_content_type_options=\"nosniff\"\n");
+          "security.x_content_type_options=\"nosniff\"\n" +
+          "security.permissions_policy=\"unload=()\"\n");
       var filter = new SecurityHeadersFilter(cfg);
       ctx.addFilter(new org.eclipse.jetty.ee10.servlet.FilterHolder(filter), "/*",
           java.util.EnumSet.allOf(jakarta.servlet.DispatcherType.class));
@@ -124,9 +130,11 @@ public class SecurityHeadersJakartaIT {
       java.util.Map<String, java.util.List<String>> headers = c2.getHeaderFields();
       String csp = getHeader(headers, "Content-Security-Policy");
       String ref = getHeader(headers, "Referrer-Policy");
+      String permissionsPolicy = getHeader(headers, "Permissions-Policy");
       String xcto = getHeader(headers, "X-Content-Type-Options");
       assertEquals("default-src 'none'", csp);
       assertEquals("no-referrer", ref);
+      assertEquals("unload=()", permissionsPolicy);
       assertNotNull("X-Content-Type-Options header expected", xcto);
       assertTrue("X-Content-Type-Options should be nosniff, was: " + xcto, "nosniff".equalsIgnoreCase(xcto));
     } finally {


### PR DESCRIPTION
Fixes #1217

## Summary
- default the Jakarta security header filter to send `Permissions-Policy: unload=(self)`
- keep the policy operator-configurable via `security.permissions_policy`
- add integration coverage and a changelog fragment for the GWT rollback path

## Root cause
Chrome was blocking the legacy GWT webclient unload handler because the app did not emit a Permissions-Policy header. That surfaced as `Permissions policy violation: unload is not allowed in this document` when switching from `?view=j2cl-root` back to `?view=gwt`.

## Verification
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py`
- `sbt -batch 'jakartaIT:testOnly org.waveprotocol.box.server.jakarta.SecurityHeadersJakartaIT'`\n- `WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 bash scripts/worktree-boot.sh --port 9901`\n- `PORT=9901 bash scripts/wave-smoke.sh check`\n- `curl -sSI 'http://localhost:9901/?view=gwt&q=in%3Ainbox&wave=local.net%2Fw%2Bdemo#local.net/w+demo'` returned `Permissions-Policy: unload=(self)`\n- Playwright console probe for that GWT switch URL loaded the GWT bootstrap with no `Permissions policy violation`, no `unload is not allowed`, and no `Uncaught` app error\n\n## Self-review\n- Scope is limited to the shared Jakarta security-header filter, its existing integration test, and a changelog fragment.\n- The default is the minimum browser policy needed for legacy GWT; operators can still override or suppress it with `security.permissions_policy`.\n- The user-reported async-listener console line did not reproduce in Playwright and is consistent with browser-extension noise, not app code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for Permissions-Policy response header with a default same-origin unload policy
  * Policy is configurable via security.permissions_policy setting for customized unload permission handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->