### PR TITLE
Fix J2CL wave render and reply parity

### DIFF
--- a/j2cl/lit/src/design/wavy-thread-collapse.css
+++ b/j2cl/lit/src/design/wavy-thread-collapse.css
@@ -12,6 +12,70 @@
   position: relative;
 }
 
+/* Prevent the server-first <wave-blip> light DOM from painting as raw
+ * unformatted text while the Lit bundle is still defining the custom
+ * element. The skeleton keeps a stable block in the wave so upgrade
+ * replaces it with the final card instead of flashing text. */
+wave-blip:not(:defined) {
+  display: block;
+  min-height: 96px;
+  margin: var(--wavy-spacing-2, 8px) 0;
+  border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+  border-radius: var(--wavy-radius-sm, 4px);
+  background:
+    linear-gradient(90deg, rgba(34, 211, 238, 0.08), rgba(255, 255, 255, 0.72), rgba(34, 211, 238, 0.08)),
+    var(--wavy-bg-surface, #f8fafc);
+  color: transparent;
+  overflow: hidden;
+}
+
+wave-blip:not(:defined) > * {
+  visibility: hidden;
+}
+
+.j2cl-read-attachments {
+  display: grid;
+  gap: var(--wavy-spacing-2, 8px);
+  margin: var(--wavy-spacing-2, 8px) 0 0;
+}
+
+.j2cl-read-attachment {
+  display: grid;
+  gap: var(--wavy-spacing-1, 4px);
+  padding: var(--wavy-spacing-2, 8px);
+  border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+  border-radius: var(--wavy-radius-sm, 4px);
+  background: var(--wavy-bg-surface, #f8fafc);
+}
+
+.j2cl-read-attachment[data-display-size="small"] {
+  max-width: 240px;
+}
+
+.j2cl-read-attachment[data-display-size="medium"] {
+  max-width: 360px;
+}
+
+.j2cl-read-attachment[data-display-size="large"] {
+  max-width: 520px;
+}
+
+.j2cl-read-attachment-preview {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: 320px;
+  object-fit: contain;
+  border-radius: var(--wavy-radius-sm, 4px);
+  background: rgba(226, 232, 240, 0.72);
+}
+
+.j2cl-read-attachment[data-attachment-state="pending"],
+.j2cl-read-attachment[data-attachment-state="metadata-failure"],
+.j2cl-read-attachment[data-attachment-state="blocked"] {
+  min-height: 72px;
+}
+
 /* Inline reply threads animate height + opacity per F-0 token. Default
  * max-height covers any plausible thread height; the collapsed state
  * snaps to 0. The root thread ([data-thread-id="root"]) is excluded from

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -42,8 +42,6 @@ import "./wavy-task-affordance.js";
  * Events emitted (CustomEvent, bubbles + composed):
  * - `wave-blip-reply-requested` — `{detail: {blipId, waveId}}`. F-3
  *   (compose) listens.
- * - `wave-blip-continuation-requested` — `{detail: {blipId, waveId}}`.
- *   Mirrors the GWT reply-box "+" continuation affordance.
  * - `wave-blip-edit-requested` — `{detail: {blipId, waveId}}`. F-3 owns
  *   the edit surface; F-2 only emits the request.
  * - `wave-blip-delete-requested` — `{detail: {blipId, waveId, bodySize}}`. F-3.S4
@@ -180,30 +178,6 @@ export class WaveBlip extends LitElement {
      * with children, so the glyph is purely a visual cue here. */
     .thread-chevron[hidden] {
       display: none;
-    }
-    .continuation-trigger {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 18px;
-      height: 18px;
-      margin: 4px 0 0 3.35em;
-      padding: 0;
-      border-radius: var(--wavy-radius-pill, 999px);
-      border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.24));
-      background: #ffffff;
-      color: var(--wavy-signal-cyan, #0077b6);
-      font: var(--wavy-type-label, 12px / 1 sans-serif);
-      font-weight: 700;
-      cursor: pointer;
-    }
-    .continuation-trigger:hover {
-      border-color: var(--wavy-signal-cyan, #22d3ee);
-      background: #eef8ff;
-    }
-    .continuation-trigger:focus-visible {
-      outline: none;
-      box-shadow: var(--wavy-focus-ring, 0 0 0 2px #22d3ee);
     }
     .thread-chevron:focus-visible {
       outline: none;
@@ -536,17 +510,6 @@ export class WaveBlip extends LitElement {
     );
   }
 
-  _onContinuationClick(event) {
-    event.stopPropagation();
-    this.dispatchEvent(
-      new CustomEvent("wave-blip-continuation-requested", {
-        bubbles: true,
-        composed: true,
-        detail: { blipId: this.blipId, waveId: this.waveId }
-      })
-    );
-  }
-
   _onEditClick(event) {
     event.stopPropagation();
     this.dispatchEvent(
@@ -724,14 +687,6 @@ export class WaveBlip extends LitElement {
         <div class="body">
           <slot></slot>
         </div>
-        <button
-          type="button"
-          class="continuation-trigger"
-          data-blip-continuation-trigger
-          aria-label="Add reply below this blip"
-          title="Add reply below this blip"
-          @click=${this._onContinuationClick}
-        >+</button>
         <slot name="blip-extension" slot="blip-extension"></slot>
         <slot name="reactions" slot="reactions"></slot>
       </wavy-blip-card>

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -265,7 +265,7 @@ function inlineFormatAnnotationsForNode(node) {
  * - replyTargetBlipId (String, attribute "reply-target-blip-id") —
  *   the blip the composer is replying to (absent for wave-root +
  *   create-wave composers).
- * - mode (String) — "reply" | "edit" | "create" | "wave-root" | "continuation";
+ * - mode (String) — "reply" | "edit" | "create" | "wave-root";
  *   surfaces the verb used in the host chip and submit button label.
  * - targetLabel (String) — display name of the reply target ("Yuri",
  *   "Top thread", …) used in the "Replying to <author>" chip.
@@ -1782,7 +1782,6 @@ export class WavyComposer extends LitElement {
 
   _composeBodyAriaLabel() {
     if (this.mode === "edit") return "Edit blip";
-    if (this.mode === "continuation") return "Add reply below this blip";
     if (this.mode === "wave-root") return "Reply to wave";
     if (this.mode === "create") return "New wave";
     return this.targetLabel ? `Reply to ${this.targetLabel}` : "Reply";
@@ -2864,9 +2863,7 @@ export class WavyComposer extends LitElement {
     const verb =
       this.mode === "edit"
         ? "Editing"
-        : this.mode === "continuation"
-          ? "Replying below"
-          : "Replying to";
+        : "Replying to";
     const label = this._replyHeaderLabel();
     const time = this._replyHeaderTime();
     return html`

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -145,19 +145,13 @@ describe("<wave-blip>", () => {
     expect(ev.detail.waveId).to.equal("w4");
   });
 
-  it("renders a GWT-style continuation + that requests a same-thread reply", async () => {
+  it("does not render a redundant below-blip continuation + beside the Reply action", async () => {
     const el = await fixture(html`
       <wave-blip data-blip-id="b4" data-wave-id="w4" author-name="A"></wave-blip>
     `);
     await el.updateComplete;
     const button = el.renderRoot.querySelector("[data-blip-continuation-trigger]");
-    expect(button).to.exist;
-    expect(button.textContent.trim()).to.equal("+");
-    expect(button.getAttribute("aria-label")).to.equal("Add reply below this blip");
-    expect(button.getAttribute("title")).to.equal("Add reply below this blip");
-    setTimeout(() => button.click(), 0);
-    const ev = await oneEvent(el, "wave-blip-continuation-requested");
-    expect(ev.detail).to.deep.equal({ blipId: "b4", waveId: "w4" });
+    expect(button).to.not.exist;
   });
 
   it("re-emits wave-blip-edit-requested when toolbar Edit fires", async () => {

--- a/j2cl/lit/test/wavy-composer-inline-mount.test.js
+++ b/j2cl/lit/test/wavy-composer-inline-mount.test.js
@@ -45,12 +45,7 @@ before(async () => {
 function attachInlineComposerHandler() {
   const composers = new Map();
   const handler = (event) => {
-    const mode =
-      event.type === "wave-blip-edit-requested"
-        ? "edit"
-        : event.type === "wave-blip-continuation-requested"
-          ? "continuation"
-          : "reply";
+    const mode = event.type === "wave-blip-edit-requested" ? "edit" : "reply";
     const blipId = event.detail.blipId;
     if (composers.has(blipId)) return;
     const composer = document.createElement("wavy-composer");
@@ -71,13 +66,11 @@ function attachInlineComposerHandler() {
     composers.delete(blipId);
   };
   document.body.addEventListener("wave-blip-reply-requested", handler);
-  document.body.addEventListener("wave-blip-continuation-requested", handler);
   document.body.addEventListener("wave-blip-edit-requested", handler);
   document.body.addEventListener("wavy-composer-cancelled", cancelHandler);
   return {
     teardown() {
       document.body.removeEventListener("wave-blip-reply-requested", handler);
-      document.body.removeEventListener("wave-blip-continuation-requested", handler);
       document.body.removeEventListener("wave-blip-edit-requested", handler);
       document.body.removeEventListener("wavy-composer-cancelled", cancelHandler);
       for (const composer of composers.values()) {
@@ -140,24 +133,13 @@ describe("F-3.S1 inline composer mount integration", () => {
     }
   });
 
-  it("mounts a continuation composer from the blip + affordance", async () => {
+  it("does not expose the redundant continuation + affordance", async () => {
     const blip = await fixture(html`
       <wave-blip data-blip-id="b99" data-wave-id="w1" author-name="A" posted-at="1m">
       </wave-blip>
     `);
     await blip.updateComplete;
-    const ctx = attachInlineComposerHandler();
-    try {
-      const button = blip.renderRoot.querySelector("[data-blip-continuation-trigger]");
-      button.click();
-      await new Promise((r) => requestAnimationFrame(r));
-      const composer = blip.querySelector('wavy-composer[data-inline-composer="true"]');
-      expect(composer).to.exist;
-      expect(composer.getAttribute("reply-target-blip-id")).to.equal("b99");
-      expect(composer.getAttribute("mode")).to.equal("continuation");
-    } finally {
-      ctx.teardown();
-    }
+    expect(blip.renderRoot.querySelector("[data-blip-continuation-trigger]")).to.not.exist;
   });
 
   it("removes the composer on wavy-composer-cancelled (R-5.1 step 7)", async () => {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/attachment/J2clAttachmentRenderModel.java
@@ -20,6 +20,8 @@ public final class J2clAttachmentRenderModel {
   private final String downloadUrl;
   private final String downloadFileName;
   private final String statusText;
+  private final int imageWidth;
+  private final int imageHeight;
   private final boolean inlineImage;
   private final boolean blocked;
   private final boolean metadataFailure;
@@ -35,6 +37,8 @@ public final class J2clAttachmentRenderModel {
       String openUrl,
       String downloadUrl,
       String statusText,
+      int imageWidth,
+      int imageHeight,
       boolean inlineImage,
       boolean blocked,
       boolean metadataFailure,
@@ -54,6 +58,8 @@ public final class J2clAttachmentRenderModel {
     this.downloadUrl = safeUrl(downloadUrl);
     this.downloadFileName = safeDownloadFileName(this.fileName, this.attachmentId);
     this.statusText = normalize(statusText);
+    this.imageWidth = Math.max(0, imageWidth);
+    this.imageHeight = Math.max(0, imageHeight);
     this.inlineImage = inlineImage && !this.sourceUrl.isEmpty();
     this.blocked = blocked;
     this.metadataFailure = metadataFailure;
@@ -86,6 +92,8 @@ public final class J2clAttachmentRenderModel {
           "",
           "",
           "Attachment blocked by malware scan.",
+          0,
+          0,
           false,
           true,
           false,
@@ -93,7 +101,8 @@ public final class J2clAttachmentRenderModel {
     }
 
     boolean image = isImageMimeType(normalizedMimeType);
-    boolean hasImageDimensions = hasDimensions(metadata.getImageMetadata());
+    J2clAttachmentMetadata.ImageMetadata imageMetadata = metadata.getImageMetadata();
+    boolean hasImageDimensions = hasDimensions(imageMetadata);
     boolean inlineImage =
         image
             && hasImageDimensions
@@ -123,6 +132,8 @@ public final class J2clAttachmentRenderModel {
         metadata.getAttachmentUrl(),
         metadata.getAttachmentUrl(),
         "",
+        hasImageDimensions ? imageMetadata.getWidth() : 0,
+        hasImageDimensions ? imageMetadata.getHeight() : 0,
         inlineImage,
         false,
         false,
@@ -144,6 +155,8 @@ public final class J2clAttachmentRenderModel {
         "",
         "",
         metadataFailureStatus(normalizedReason),
+        0,
+        0,
         false,
         false,
         true,
@@ -164,6 +177,8 @@ public final class J2clAttachmentRenderModel {
         "",
         "",
         "Attachment metadata loading...",
+        0,
+        0,
         false,
         false,
         false,
@@ -208,6 +223,14 @@ public final class J2clAttachmentRenderModel {
 
   public String getStatusText() {
     return statusText;
+  }
+
+  public int getImageWidth() {
+    return imageWidth;
+  }
+
+  public int getImageHeight() {
+    return imageHeight;
   }
 
   public boolean isInlineImage() {
@@ -258,6 +281,8 @@ public final class J2clAttachmentRenderModel {
         && downloadUrl.equals(that.downloadUrl)
         && downloadFileName.equals(that.downloadFileName)
         && statusText.equals(that.statusText)
+        && imageWidth == that.imageWidth
+        && imageHeight == that.imageHeight
         && inlineImage == that.inlineImage
         && blocked == that.blocked
         && metadataFailure == that.metadataFailure
@@ -276,6 +301,8 @@ public final class J2clAttachmentRenderModel {
     result = 31 * result + downloadUrl.hashCode();
     result = 31 * result + downloadFileName.hashCode();
     result = 31 * result + statusText.hashCode();
+    result = 31 * result + imageWidth;
+    result = 31 * result + imageHeight;
     result = 31 * result + (inlineImage ? 1 : 0);
     result = 31 * result + (blocked ? 1 : 0);
     result = 31 * result + (metadataFailure ? 1 : 0);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -218,9 +218,6 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           "wave-blip-reply-requested",
           event -> openInlineComposer(eventDetailString(event, "blipId"), "reply"));
       DomGlobal.document.body.addEventListener(
-          "wave-blip-continuation-requested",
-          event -> openInlineComposer(eventDetailString(event, "blipId"), "continuation"));
-      DomGlobal.document.body.addEventListener(
           "wave-blip-edit-requested",
           event -> openInlineComposer(eventDetailString(event, "blipId"), "edit"));
       DomGlobal.document.body.addEventListener(
@@ -521,17 +518,9 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           List<J2clComposeSurfaceController.SubmittedComponent> components =
               decodeSubmittedComponents(event);
           if (components.isEmpty()) {
-            if ("continuation".equals(propertyString(composer, "mode"))) {
-              listener.onContinuationSubmitted(propertyString(composer, "draft"), key);
-            } else {
-              listener.onReplySubmitted(propertyString(composer, "draft"), key);
-            }
+            listener.onReplySubmitted(propertyString(composer, "draft"), key);
           } else {
-            if ("continuation".equals(propertyString(composer, "mode"))) {
-              listener.onContinuationSubmittedWithComponents(components, key);
-            } else {
-              listener.onReplySubmittedWithComponents(components, key);
-            }
+            listener.onReplySubmittedWithComponents(components, key);
           }
         });
     composer.addEventListener(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -2145,6 +2145,10 @@ public final class J2clReadSurfaceDomRenderer {
       preview.setAttribute("src", model.getSourceUrl());
       preview.setAttribute("data-display-size", displaySize);
       preview.setAttribute("referrerpolicy", "no-referrer");
+      if (model.getImageWidth() > 0 && model.getImageHeight() > 0) {
+        preview.setAttribute("width", Integer.toString(model.getImageWidth()));
+        preview.setAttribute("height", Integer.toString(model.getImageHeight()));
+      }
       if (model.isInlineImage()) {
         preview.setAttribute("alt", model.getCaption());
         preview.setAttribute("loading", "lazy");

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -1366,6 +1366,45 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void renderInlineImageStampsIntrinsicDimensionsToReserveLayoutSpace() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clAttachmentRenderModel attachment =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+large",
+            "Large image",
+            "large",
+            attachmentMetadata(
+                "example.com/att+large",
+                "large.png",
+                "image/png",
+                "/attachment/example.com/att+large",
+                "/thumbnail/example.com/att+large",
+                new J2clAttachmentMetadata.ImageMetadata(1600, 900),
+                false));
+
+    Assert.assertTrue(
+        new J2clReadSurfaceDomRenderer(host)
+            .render(
+                Arrays.asList(new J2clReadBlip("b+root", "Root text", Arrays.asList(attachment))),
+                Collections.<String>emptyList()));
+
+    HTMLElement preview =
+        (HTMLElement) host.querySelector(".j2cl-read-attachment-preview");
+    Assert.assertNotNull(preview);
+    Assert.assertEquals(
+        "Read-surface attachment images need intrinsic width so the browser "
+            + "can reserve the final aspect ratio before the image decodes.",
+        "1600",
+        preview.getAttribute("width"));
+    Assert.assertEquals(
+        "Read-surface attachment images need intrinsic height so attachment "
+            + "loads do not resize the wave after first paint.",
+        "900",
+        preview.getAttribute("height"));
+  }
+
+  @Test
   public void renderWindowEntriesPropagatePerBlipMetadataIntoTheRenderedBlipElement() {
     // F-2 (#1037, R-3.1) — the viewport-window path is the dominant render
     // path. The window entry now carries author / timestamp / unread /

--- a/wave/config/changelog.d/2026-05-08-j2cl-render-reply-parity.json
+++ b/wave/config/changelog.d/2026-05-08-j2cl-render-reply-parity.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-05-08-j2cl-render-reply-parity",
+  "version": "J2CL parity",
+  "date": "2026-05-08",
+  "title": "Smooth J2CL wave loading and reply parity",
+  "summary": "J2CL waves now avoid flashing raw blip text before the Lit read surface upgrades, reserve attachment preview space to reduce resizing while images load, and remove the redundant below-blip plus reply affordance so replying matches the GWT action flow.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Hides pre-upgrade J2CL blip light DOM behind the wave-blip shell so users no longer see unformatted wave text while Lit finishes upgrading the read surface.",
+        "Stamps known attachment image dimensions and adds read-surface attachment sizing CSS so image previews reserve their final layout space while loading.",
+        "Removes the redundant below-blip continuation plus from the J2CL blip surface so users reply through the existing GWT-style blip action affordance."
+      ]
+    }
+  ]
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -364,6 +364,35 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
             ".sidecar-selected-compose[data-j2cl-compose-host=\"true\"]:empty"));
   }
 
+  public void testWaveBlipPreUpgradeCssHidesRawLightDomText() {
+    String css = readWavyThreadCollapseCss();
+    assertTrue(
+        "Before Lit defines <wave-blip>, the global read-surface CSS must "
+            + "hide raw light-DOM blip text so users do not see unformatted waves.",
+        java.util.regex.Pattern.compile(
+                "wave-blip:not\\(:defined\\)\\s*>\\s*\\*\\s*\\{[^}]*\\bvisibility\\s*:\\s*hidden\\s*;")
+            .matcher(css)
+            .find());
+  }
+
+  public void testReadSurfaceAttachmentCssReservesPreviewSpace() {
+    String css = readWavyThreadCollapseCss();
+    assertTrue(
+        "Read-surface attachments need display-size box rules so image decode "
+            + "does not resize the wave after first paint.",
+        java.util.regex.Pattern.compile(
+                "\\.j2cl-read-attachment\\[data-display-size=\"large\"\\]\\s*\\{[^}]*\\bmax-width\\s*:")
+            .matcher(css)
+            .find());
+    assertTrue(
+        "Read-surface attachment previews must be block-level and constrained "
+            + "by width/height rules to preserve intrinsic aspect ratio.",
+        java.util.regex.Pattern.compile(
+                "\\.j2cl-read-attachment-preview\\s*\\{[^}]*\\bdisplay\\s*:\\s*block\\s*;[^}]*\\bheight\\s*:\\s*auto\\s*;")
+            .matcher(css)
+            .find());
+  }
+
   public void testLegacySearchFormHideRulePresent() {
     String css = readWavyThreadCollapseCss();
     assertTrue(


### PR DESCRIPTION
Fixes #1219.

## Summary
- hide server-first J2CL `<wave-blip>` light DOM until the Lit custom element upgrades, preventing raw unformatted wave text from flashing
- reserve attachment preview layout by carrying image metadata dimensions into the render model, stamping image `width`/`height`, and adding read-surface attachment sizing CSS
- remove the redundant below-blip continuation plus and its orphaned production event wiring so replies flow through the existing GWT-style blip Reply action

## Review
- self-review completed after implementation
- external Claude review completed; no blockers found, and its stale-continuation-wiring concern was addressed before PR creation

## Verification
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `git diff --check`
- `cd j2cl/lit && npm test -- --files test/wave-blip.test.js` -> 43 passed, 0 failed
- `cd j2cl/lit && npm test -- --files test/wavy-composer-inline-mount.test.js` -> 6 passed, 0 failed
- `sbt -batch "testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellIntegrationTest"` -> 45 passed, 0 failed
- `sbt -batch "testOnly org.waveprotocol.box.j2cl.read.J2clReadSurfaceDomRendererTest"` -> no tests to run under plain JVM `testOnly`
- `sbt -batch compile`
- `sbt -batch j2clRuntimeBuild Universal/stage`
- `WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 bash scripts/worktree-boot.sh --port 9907`
- `WAVE_SMOKE_REQUIRE_J2CL_ASSETS=1 PORT=9907 bash scripts/wave-smoke.sh check` -> root/GWT/health/landing/J2CL root/J2CL index/sidecar/webclient all 200
- Browser verification: `http://127.0.0.1:9907/?view=j2cl-root` loaded the J2CL shell, linked bundled `wavy-thread-collapse.css`, defined `wave-blip`, and had continuation trigger count `0`
- `curl -sS http://127.0.0.1:9907/j2cl/assets/shell.js | rg -n "wave-blip-continuation-requested|data-blip-continuation-trigger|Replying below|Add reply below" || true` -> no matches


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented raw content from flashing during component initialization
  * Improved attachment image display by reserving layout space with intrinsic dimensions
  * Simplified reply flow by removing redundant continuation affordance

* **New Features**
  * Enhanced attachment card styling with responsive sizing variants for improved visual presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->