### PR TITLE
Fix J2CL mark-blip-read 500 on missing UDW

### DIFF
--- a/wave/config/changelog.d/2026-05-08-j2cl-mark-blip-read-500.json
+++ b/wave/config/changelog.d/2026-05-08-j2cl-mark-blip-read-500.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-08-j2cl-mark-blip-read-500",
+  "version": "Issue #1221",
+  "date": "2026-05-08",
+  "title": "J2CL read markers no longer fail on missing user-data wavelets",
+  "summary": "The J2CL read surface now creates the current user's missing user-data wavelet before marking a blip as read, preventing repeated 500 responses from /j2cl/mark-blip-read.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Avoid false internal-server errors when J2CL marks a visible blip as read for a user whose supplement wavelet has not been created yet"
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelper.java
@@ -25,10 +25,12 @@ import com.google.wave.api.InvalidRequestException;
 import com.google.wave.api.ProtocolVersion;
 import com.google.wave.api.data.converter.EventDataConverterManager;
 
+import org.waveprotocol.box.server.frontend.CommittedWaveletSnapshot;
 import org.waveprotocol.box.server.robots.OperationContextImpl;
 import org.waveprotocol.box.server.robots.RobotWaveletData;
 import org.waveprotocol.box.server.robots.util.ConversationUtil;
 import org.waveprotocol.box.server.robots.util.OperationUtil;
+import org.waveprotocol.box.server.robots.util.RobotsUtil;
 import org.waveprotocol.box.server.waveserver.WaveletProvider.SubmitRequestListener;
 import org.waveprotocol.wave.model.conversation.Conversation;
 import org.waveprotocol.wave.model.conversation.ConversationBlip;
@@ -234,22 +236,21 @@ public class MarkBlipReadHelper {
     }
 
     // Open the user-data wavelet on the same context so the supplement
-    // mutations land in a single delta. UDW is auto-created by openWavelet
-    // when missing (see OperationContextImpl#openWavelet).
+    // mutations land in a single delta. Load the UDW directly instead of
+    // calling OperationContextImpl#openWavelet first: that path checks access
+    // before reaching its own missing-UDW auto-create branch, so a missing
+    // user-data wavelet can otherwise become a false INTERNAL_ERROR.
     WaveletId udwId = IdUtil.buildUserDataWaveletId(user);
-    OpBasedWavelet udw;
+    RobotWaveletData udwData;
     try {
-      udw = openWaveletViaContext(context, waveId, udwId, user);
+      udwData = loadParticipantUserDataWavelet(waveId, user);
     } catch (RuntimeException e) {
       LOG.warning("mark-blip-read: failed to open user-data wavelet "
           + WaveletName.of(waveId, udwId), e);
       return Result.internalError();
     }
-    if (udw == null) {
-      LOG.warning("mark-blip-read: user-data wavelet unavailable "
-          + WaveletName.of(waveId, udwId));
-      return Result.internalError();
-    }
+    context.putWavelet(waveId, udwId, udwData);
+    OpBasedWavelet udw = openWaveletViaContext(context, waveId, udwId, user);
 
     PrimitiveSupplement udwState = WaveletBasedSupplement.create(udw);
     SupplementedWave supplement =
@@ -363,6 +364,21 @@ public class MarkBlipReadHelper {
       // openWavelet wraps load failures and missing wavelets in
       // InvalidRequestException; collapse to null so the caller can map to 404.
       return null;
+    }
+  }
+
+  @VisibleForTesting
+  RobotWaveletData loadParticipantUserDataWavelet(WaveId waveId, ParticipantId user) {
+    WaveletName userDataWaveletName = WaveletName.of(waveId, IdUtil.buildUserDataWaveletId(user));
+    try {
+      CommittedWaveletSnapshot snapshot = waveletProvider.getSnapshot(userDataWaveletName);
+      if (snapshot == null) {
+        return RobotsUtil.createEmptyRobotWavelet(user, userDataWaveletName);
+      }
+      return new RobotWaveletData(snapshot.snapshot, snapshot.committedVersion);
+    } catch (WaveServerException e) {
+      throw new IllegalStateException(
+          "Wavelet " + userDataWaveletName + " couldn't be retrieved", e);
     }
   }
 }

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelper.java
@@ -250,7 +250,19 @@ public class MarkBlipReadHelper {
       return Result.internalError();
     }
     context.putWavelet(waveId, udwId, udwData);
-    OpBasedWavelet udw = openWaveletViaContext(context, waveId, udwId, user);
+    OpBasedWavelet udw;
+    try {
+      udw = openWaveletViaContext(context, waveId, udwId, user);
+    } catch (RuntimeException e) {
+      LOG.warning("mark-blip-read: failed to open user-data wavelet after seed "
+          + WaveletName.of(waveId, udwId), e);
+      return Result.internalError();
+    }
+    if (udw == null) {
+      LOG.warning("mark-blip-read: user-data wavelet unavailable after seed "
+          + WaveletName.of(waveId, udwId));
+      return Result.internalError();
+    }
 
     PrimitiveSupplement udwState = WaveletBasedSupplement.create(udw);
     SupplementedWave supplement =

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelperTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/MarkBlipReadHelperTest.java
@@ -20,16 +20,20 @@
 package org.waveprotocol.box.server.waveserver;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.wave.api.data.converter.EventDataConverterManager;
 
 import junit.framework.TestCase;
 import org.waveprotocol.box.server.robots.OperationContextImpl;
+import org.waveprotocol.box.server.robots.RobotWaveletData;
 import org.waveprotocol.box.server.robots.util.ConversationUtil;
 import org.waveprotocol.wave.model.id.IdUtil;
 import org.waveprotocol.wave.model.id.WaveId;
 import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.id.WaveletName;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.model.wave.opbased.OpBasedWavelet;
 
@@ -50,12 +54,13 @@ public final class MarkBlipReadHelperTest extends TestCase {
       IdUtil.buildUserDataWaveletId(USER);
   private static final String BLIP_ID = "b+abc";
 
+  private WaveletProvider waveletProvider;
   private SelectedWaveReadStateHelper readStateHelper;
   private MarkBlipReadHelper helper;
 
   @Override
   protected void setUp() {
-    WaveletProvider waveletProvider = mock(WaveletProvider.class);
+    waveletProvider = mock(WaveletProvider.class);
     EventDataConverterManager converterManager = mock(EventDataConverterManager.class);
     ConversationUtil conversationUtil = mock(ConversationUtil.class);
     readStateHelper = mock(SelectedWaveReadStateHelper.class);
@@ -186,6 +191,18 @@ public final class MarkBlipReadHelperTest extends TestCase {
         helperWithMissingConv.markBlipRead(USER, WAVE_ID, CONV_ROOT, BLIP_ID);
     assertEquals(MarkBlipReadHelper.Outcome.NOT_FOUND, result.getOutcome());
     assertEquals(-1, result.getUnreadCountAfter());
+  }
+
+  public void testLoadParticipantUserDataWaveletCreatesMissingOwnUdwWithoutAccessProbe()
+      throws Exception {
+    WaveletName udwName = WaveletName.of(WAVE_ID, IdUtil.buildUserDataWaveletId(USER));
+    when(waveletProvider.getSnapshot(udwName)).thenReturn(null);
+
+    RobotWaveletData udw = helper.loadParticipantUserDataWavelet(WAVE_ID, USER);
+
+    assertEquals(udwName, udw.getWaveletName());
+    verify(waveletProvider).getSnapshot(udwName);
+    verify(waveletProvider, never()).checkAccessPermission(udwName, USER);
   }
 
   public void testResultFactories() {


### PR DESCRIPTION
## Summary\n- Fixes #1221\n- Load/create the current user's user-data wavelet before applying the J2CL mark-blip-read supplement mutation\n- Preserve the existing conversational-wave access probe and not-found/access-denied collapse\n- Add focused regression coverage for missing own UDW handling\n- Add changelog fragment for the user-facing J2CL console-error fix\n\n## Verification\n- python3 scripts/assemble-changelog.py\n- python3 scripts/validate-changelog.py\n- sbt --batch "wave/testOnly org.waveprotocol.box.server.waveserver.MarkBlipReadHelperTest org.waveprotocol.box.server.rpc.MarkBlipReadServletTest"\n- git diff --check\n\n## Notes\nThe repeated browser-console message about an async listener closing before response is typically emitted by browser extensions. This PR fixes the app-owned repeated /j2cl/mark-blip-read 500 path shown in the same console capture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed recurring internal server errors when marking visible items as read by ensuring a user's missing user-data record is created first.

* **Documentation**
  * Added a changelog entry describing the fix and release metadata.

* **Tests**
  * Added a unit test verifying creation of a missing user-data record when marking items as read without an extra access probe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->