### PR TITLE
Fix J2CL wave title and participant chrome parity

### DIFF
--- a/j2cl/lit/src/elements/wavy-wave-header-actions.js
+++ b/j2cl/lit/src/elements/wavy-wave-header-actions.js
@@ -97,20 +97,22 @@ export class WavyWaveHeaderActions extends LitElement {
     :host {
       display: block;
       box-sizing: border-box;
-      background: linear-gradient(
-        90deg,
-        var(--wavy-toolbar-pill-bg, #f0f4f8),
-        var(--wavy-bg-elevated, #ffffff)
-      );
+      background: linear-gradient(180deg, #e8f4f8 0%, #ffffff 100%);
       border-bottom: 1px solid var(--wavy-border-hairline, #e2e8f0);
-      padding: var(--wavy-spacing-2, 8px) var(--wavy-spacing-2, 8px);
+      min-height: 34px;
+      margin-top: -46px;
+      padding: 4px;
     }
 
     .row {
       display: flex;
       align-items: center;
-      flex-wrap: wrap;
-      gap: var(--wavy-spacing-2, 8px);
+      justify-content: flex-end;
+      flex-wrap: nowrap;
+      gap: 4px;
+      width: var(--wavy-wave-actions-reserved-width, 174px);
+      max-width: 100%;
+      margin-left: auto;
     }
 
     button {
@@ -131,8 +133,8 @@ export class WavyWaveHeaderActions extends LitElement {
     }
 
     button svg {
-      width: 18px;
-      height: 18px;
+      width: 15px;
+      height: 15px;
       display: block;
       color: currentColor;
       stroke: currentColor;
@@ -145,11 +147,40 @@ export class WavyWaveHeaderActions extends LitElement {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      min-width: 42px;
+      width: 26px;
+      height: 26px;
+      min-width: 26px;
+      min-height: 26px;
       padding: 0;
-      background: var(--wavy-signal-cyan-soft, #e6f6ff);
-      border-color: rgba(0, 119, 182, 0.32);
-      color: var(--wavy-signal-cyan-strong, #005f93);
+      border: 0;
+      border-radius: 50%;
+      background: linear-gradient(135deg, #48cae4, #00b4d8);
+      color: #ffffff;
+      box-shadow: 0 2px 6px rgba(0, 180, 216, 0.30);
+      transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.2s ease;
+    }
+
+    .row > button[data-action="new-with-participants"] {
+      background: linear-gradient(135deg, #00b4d8, #0077b6);
+      box-shadow: 0 2px 6px rgba(0, 119, 182, 0.30);
+    }
+
+    .row > button[data-action="publicity-toggle"] {
+      width: 24px;
+      height: 24px;
+      min-width: 24px;
+      min-height: 24px;
+      background: #0077b6;
+      box-shadow: 0 2px 6px rgba(0, 119, 182, 0.30);
+    }
+
+    .row > button[data-action="lock-toggle"] {
+      width: 24px;
+      height: 24px;
+      min-width: 24px;
+      min-height: 24px;
+      background: #6c757d;
+      box-shadow: 0 2px 6px rgba(108, 117, 125, 0.25);
     }
 
     .action-label {
@@ -166,9 +197,10 @@ export class WavyWaveHeaderActions extends LitElement {
     }
 
     button:hover:not([disabled]) {
-      background: var(--wavy-toolbar-tile-hover-bg, rgba(0, 119, 182, 0.08));
-      border-color: var(--wavy-signal-cyan, #0077b6);
-      color: var(--wavy-signal-cyan, #0077b6);
+      transform: scale(1.12);
+      background: linear-gradient(135deg, #00b4d8, #0096c7);
+      color: #ffffff;
+      box-shadow: 0 4px 12px rgba(0, 180, 216, 0.40);
     }
 
     button:focus-visible,
@@ -185,9 +217,8 @@ export class WavyWaveHeaderActions extends LitElement {
     button[data-action="publicity-toggle"][aria-pressed="true"],
     button[data-action="lock-toggle"][data-lock-state="root"],
     button[data-action="lock-toggle"][data-lock-state="all"] {
-      background: var(--wavy-signal-amber-soft, #fff4e5);
-      border-color: var(--wavy-signal-amber, #9a6700);
-      color: var(--wavy-signal-amber, #9a6700);
+      background: linear-gradient(135deg, #f59e0b, #d97706);
+      color: #ffffff;
     }
 
     .add-popover {

--- a/j2cl/lit/src/elements/wavy-wave-header-actions.js
+++ b/j2cl/lit/src/elements/wavy-wave-header-actions.js
@@ -100,8 +100,11 @@ export class WavyWaveHeaderActions extends LitElement {
       background: linear-gradient(180deg, #e8f4f8 0%, #ffffff 100%);
       border-bottom: 1px solid var(--wavy-border-hairline, #e2e8f0);
       min-height: 34px;
-      margin-top: -46px;
       padding: 4px;
+    }
+
+    :host([has-participants]) {
+      margin-top: -46px;
     }
 
     .row {
@@ -303,6 +306,9 @@ export class WavyWaveHeaderActions extends LitElement {
       this._pendingConfirm = null;
       this._addDialogOpen = false;
       this._participantDraft = "";
+    }
+    if (changedProperties.has("participants")) {
+      this.toggleAttribute("has-participants", participantList(this.participants).length > 0);
     }
   }
 

--- a/j2cl/lit/src/elements/wavy-wave-header-actions.js
+++ b/j2cl/lit/src/elements/wavy-wave-header-actions.js
@@ -97,6 +97,7 @@ export class WavyWaveHeaderActions extends LitElement {
     :host {
       display: block;
       box-sizing: border-box;
+      position: relative;
       background: linear-gradient(180deg, #e8f4f8 0%, #ffffff 100%);
       border-bottom: 1px solid var(--wavy-border-hairline, #e2e8f0);
       min-height: 34px;
@@ -104,7 +105,10 @@ export class WavyWaveHeaderActions extends LitElement {
     }
 
     :host([has-participants]) {
-      margin-top: -46px;
+      background: transparent;
+      border-bottom: none;
+      min-height: 0;
+      padding: 0;
     }
 
     .row {
@@ -116,6 +120,12 @@ export class WavyWaveHeaderActions extends LitElement {
       width: var(--wavy-wave-actions-reserved-width, 174px);
       max-width: 100%;
       margin-left: auto;
+    }
+
+    :host([has-participants]) .row {
+      position: absolute;
+      right: 4px;
+      top: -42px;
     }
 
     button {

--- a/j2cl/lit/test/wavy-wave-header-actions.test.js
+++ b/j2cl/lit/test/wavy-wave-header-actions.test.js
@@ -97,6 +97,11 @@ describe("<wavy-wave-header-actions>", () => {
     expect(el.hasAttribute("has-participants")).to.be.false;
   });
 
+  it("makes host transparent when overlaying participants to avoid covering avatars", () => {
+    const cssText = WavyWaveHeaderActions_styleText();
+    expect(cssText).to.match(/:host\(\[has-participants\]\)\s*\{[^}]*background:\s*transparent/);
+  });
+
   it("disables write buttons when no source wave is selected", async () => {
     const el = await createActions({ sourceWaveId: "" });
 

--- a/j2cl/lit/test/wavy-wave-header-actions.test.js
+++ b/j2cl/lit/test/wavy-wave-header-actions.test.js
@@ -62,6 +62,13 @@ describe("<wavy-wave-header-actions>", () => {
     );
   });
 
+  it("keeps the add-participant popover clickable while reserving the shared panel action width", () => {
+    const cssText = WavyWaveHeaderActions_styleText();
+    expect(cssText).to.not.match(/:host\s*\{[^}]*pointer-events:\s*none/);
+    expect(cssText).to.include("var(--wavy-wave-actions-reserved-width, 174px)");
+    expect(cssText).to.include("max-width: 100%");
+  });
+
   it("disables write buttons when no source wave is selected", async () => {
     const el = await createActions({ sourceWaveId: "" });
 
@@ -313,3 +320,10 @@ describe("<wavy-wave-header-actions>", () => {
     });
   });
 });
+
+function WavyWaveHeaderActions_styleText() {
+  const cls = customElements.get("wavy-wave-header-actions");
+  const styles = cls.styles;
+  const arr = Array.isArray(styles) ? styles : [styles];
+  return arr.map((s) => (s && s.cssText) || "").join("\n");
+}

--- a/j2cl/lit/test/wavy-wave-header-actions.test.js
+++ b/j2cl/lit/test/wavy-wave-header-actions.test.js
@@ -69,7 +69,17 @@ describe("<wavy-wave-header-actions>", () => {
     expect(cssText).to.include("max-width: 100%");
   });
 
-  it("does not apply negative margin-top on :host when no participants", async () => {
+  it("keeps participant-present host transparent and zero-height in flow", () => {
+    const cssText = WavyWaveHeaderActions_styleText();
+    expect(cssText).to.not.include("margin-top: -46px");
+    expect(cssText).to.include(":host([has-participants])");
+    expect(cssText).to.include("background: transparent");
+    expect(cssText).to.include("min-height: 0");
+    expect(cssText).to.include("position: absolute");
+    expect(cssText).to.include("top: -42px");
+  });
+
+  it("does not offset host when no participants", async () => {
     const el = await createActions({ participants: [] });
     expect(el.hasAttribute("has-participants")).to.be.false;
   });

--- a/j2cl/lit/test/wavy-wave-header-actions.test.js
+++ b/j2cl/lit/test/wavy-wave-header-actions.test.js
@@ -69,6 +69,24 @@ describe("<wavy-wave-header-actions>", () => {
     expect(cssText).to.include("max-width: 100%");
   });
 
+  it("does not apply negative margin-top on :host when no participants", async () => {
+    const el = await createActions({ participants: [] });
+    expect(el.hasAttribute("has-participants")).to.be.false;
+  });
+
+  it("sets has-participants attribute when participants are provided", async () => {
+    const el = await createActions({ participants: ["alice@example.com"] });
+    expect(el.hasAttribute("has-participants")).to.be.true;
+  });
+
+  it("removes has-participants attribute when participants are cleared", async () => {
+    const el = await createActions({ participants: ["alice@example.com"] });
+    expect(el.hasAttribute("has-participants")).to.be.true;
+    el.participants = [];
+    await el.updateComplete;
+    expect(el.hasAttribute("has-participants")).to.be.false;
+  });
+
   it("disables write buttons when no source wave is selected", async () => {
     const el = await createActions({ sourceWaveId: "" });
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -816,6 +816,11 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       image.setAttribute("alt", address);
       image.setAttribute("loading", "lazy");
       image.setAttribute("decoding", "async");
+      String initials = participantInitials(address);
+      image.addEventListener("error", e -> {
+        image.hidden = true;
+        button.textContent = initials;
+      });
       button.appendChild(image);
       button.addEventListener("click", event -> dispatchParticipantProfileRequest(address));
       item.appendChild(button);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -114,10 +114,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       // status is NOT marked debug-only here — error text must stay visible
       // even when the debug overlay is off; visibility is set in render().
       markDebugOnly(detail);
-      HTMLElement reboundEyebrow = (HTMLElement) existingCard.querySelector(".sidecar-eyebrow");
-      if (reboundEyebrow != null) {
-        markDebugOnly(reboundEyebrow);
-      }
+      removeSelectedWaveEyebrow(existingCard);
       participantSummary = queryRequired(existingCard, ".sidecar-selected-participants");
       snippet = queryRequired(existingCard, ".sidecar-selected-snippet");
       composeHost = queryRequired(existingCard, ".sidecar-selected-compose");
@@ -155,12 +152,6 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     coldCard.setAttribute("data-j2cl-selected-wave-host", "");
     host.appendChild(coldCard);
     this.card = coldCard;
-
-    HTMLElement eyebrow = (HTMLElement) DomGlobal.document.createElement("p");
-    eyebrow.className = "sidecar-eyebrow";
-    eyebrow.textContent = "Opened wave";
-    markDebugOnly(eyebrow);
-    coldCard.appendChild(eyebrow);
 
     // F-2 slice 2 (#1046, R-3.7-chrome): depth-nav bar (G.2 + G.3).
     // Hidden by default until S5 writes a current depth.
@@ -250,6 +241,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
    * node is the live element the view writes properties on.
    */
   private static HTMLElement ensureDepthNavBar(HTMLElement card) {
+    removeSelectedWaveEyebrow(card);
     HTMLElement existing = (HTMLElement) card.querySelector("wavy-depth-nav-bar");
     if (existing != null) {
       return existing;
@@ -257,15 +249,18 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     HTMLElement bar =
         (HTMLElement) DomGlobal.document.createElement("wavy-depth-nav-bar");
     bar.setAttribute("hidden", "");
-    // Insert directly after the eyebrow if present, else as the first
-    // child of the card.
-    HTMLElement eyebrow = (HTMLElement) card.querySelector(".sidecar-eyebrow");
-    if (eyebrow != null && eyebrow.nextSibling != null) {
-      card.insertBefore(bar, eyebrow.nextSibling);
-    } else {
-      card.insertBefore(bar, card.firstChild);
-    }
+    card.insertBefore(bar, card.firstChild);
     return bar;
+  }
+
+  private static void removeSelectedWaveEyebrow(HTMLElement card) {
+    if (card == null) {
+      return;
+    }
+    HTMLElement eyebrow = (HTMLElement) card.querySelector(".sidecar-eyebrow");
+    if (eyebrow != null && eyebrow.parentElement != null) {
+      eyebrow.parentElement.removeChild(eyebrow);
+    }
   }
 
   /**
@@ -816,7 +811,12 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       button.setAttribute("data-participant-id", address);
       button.setAttribute("aria-label", "Open " + address + " profile");
       button.setAttribute("title", address);
-      button.textContent = participantInitials(address);
+      HTMLElement image = (HTMLElement) DomGlobal.document.createElement("img");
+      image.setAttribute("src", participantProfileImageUrl(address));
+      image.setAttribute("alt", address);
+      image.setAttribute("loading", "lazy");
+      image.setAttribute("decoding", "async");
+      button.appendChild(image);
       button.addEventListener("click", event -> dispatchParticipantProfileRequest(address));
       item.appendChild(button);
       participantSummary.appendChild(item);
@@ -886,6 +886,58 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       initials.append(Character.toUpperCase(value.charAt(0)));
     }
     return initials.toString();
+  }
+
+  static String participantProfileImageUrl(String participantId) {
+    String address = participantId == null ? "" : participantId.trim();
+    return address.isEmpty() ? "" : "/userprofile/image/" + encodePathSegment(address);
+  }
+
+  static String encodePathSegment(String value) {
+    if (value == null || value.isEmpty()) {
+      return "";
+    }
+    StringBuilder encoded = new StringBuilder(value.length());
+    for (int index = 0; index < value.length(); index++) {
+      char ch = value.charAt(index);
+      if (isPathSegmentSafe(ch)) {
+        encoded.append(ch);
+      } else {
+        appendPercentEncodedUtf16CodeUnit(encoded, ch);
+      }
+    }
+    return encoded.toString();
+  }
+
+  private static boolean isPathSegmentSafe(char ch) {
+    return (ch >= 'A' && ch <= 'Z')
+        || (ch >= 'a' && ch <= 'z')
+        || (ch >= '0' && ch <= '9')
+        || ch == '-'
+        || ch == '.'
+        || ch == '_'
+        || ch == '~'
+        || ch == '@';
+  }
+
+  private static void appendPercentEncodedUtf16CodeUnit(StringBuilder encoded, char ch) {
+    if (ch <= 0x7F) {
+      appendPercentByte(encoded, ch);
+    } else if (ch <= 0x7FF) {
+      appendPercentByte(encoded, 0xC0 | ((ch >> 6) & 0x1F));
+      appendPercentByte(encoded, 0x80 | (ch & 0x3F));
+    } else {
+      appendPercentByte(encoded, 0xE0 | ((ch >> 12) & 0x0F));
+      appendPercentByte(encoded, 0x80 | ((ch >> 6) & 0x3F));
+      appendPercentByte(encoded, 0x80 | (ch & 0x3F));
+    }
+  }
+
+  private static void appendPercentByte(StringBuilder encoded, int value) {
+    final char[] hex = "0123456789ABCDEF".toCharArray();
+    encoded.append('%');
+    encoded.append(hex[(value >> 4) & 0x0F]);
+    encoded.append(hex[value & 0x0F]);
   }
 
   private void publishWaveHeaderActions(J2clSelectedWaveModel model, String waveId) {

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -186,6 +186,7 @@ body.j2cl-root-shell-page:not(.j2cl-debug-overlay-on) [data-j2cl-debug-only] {
 }
 
 .sidecar-selected-card {
+  --wavy-wave-actions-reserved-width: 174px;
   background: rgba(255, 255, 255, 0.97);
   border: 1px solid #e2e8f0;
   border-radius: 4px;
@@ -196,7 +197,7 @@ body.j2cl-root-shell-page:not(.j2cl-debug-overlay-on) [data-j2cl-debug-only] {
   height: 100%;
   min-height: 0;
   overflow: hidden;
-  padding: 12px;
+  padding: 0;
   width: 100%;
 }
 
@@ -211,24 +212,29 @@ shell-root[data-wave-controls-compact="true"] wavy-wave-nav-row {
  * and let the wave panel breathe with simple padding — the inner blip
  * cards keep their own surfaces.
  *
- * V-5 (#1103): the V-1 24 px symmetric inset left a perceptible top
- * gap between the 64 px header bar and the first row of wave content
- * (e.g. "OPENED WAVE"). The pane-gutter tokens from wavy-tokens.css
- * tighten the top inset to 12 px and keep 20 px on the sides so the
- * wave panel widens visibly without cropping. */
+ * #1223: the selected-wave panel now owns its own compact title and
+ * participant bars, so the server-first wrapper must not add a second
+ * inset around the GWT-style panel chrome. */
 [data-j2cl-server-first-workflow="true"] .sidecar-selected-card {
   background: transparent;
   border: 0;
   border-radius: 0;
   box-shadow: none;
-  padding: var(--wavy-pane-gutter-y, 12px) var(--wavy-pane-gutter-x, 20px)
-    var(--wavy-pane-gutter-x, 20px);
+  padding: 0;
 }
 
 .sidecar-selected-title {
+  box-sizing: border-box;
+  min-height: 22px;
   margin: 0;
-  font-size: 1.5rem;
-  line-height: 1.2;
+  padding: 3px 8px;
+  border-bottom: 1px solid #7aa7d9;
+  background: linear-gradient(180deg, #69a9ec 0%, #2f80d1 100%);
+  color: #ffffff;
+  font: 700 12px / 16px Arial, Helvetica, sans-serif;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .sidecar-selected-unread {
@@ -264,8 +270,14 @@ shell-root[data-wave-controls-compact="true"] wavy-wave-nav-row {
 .sidecar-selected-participants[role="list"] {
   display: flex;
   align-items: center;
-  gap: 6px;
-  min-height: 30px;
+  gap: 4px;
+  min-height: 46px;
+  margin: 0;
+  padding: 4px var(--wavy-wave-actions-reserved-width, 174px) 4px 4px;
+  box-sizing: border-box;
+  border-bottom: 1px solid #e2e8f0;
+  background: linear-gradient(180deg, #e8f4f8 0%, #ffffff 100%);
+  overflow: hidden;
 }
 
 .sidecar-selected-participants [role="listitem"] {
@@ -273,23 +285,36 @@ shell-root[data-wave-controls-compact="true"] wavy-wave-nav-row {
 }
 
 .sidecar-selected-participant-avatar {
-  width: 28px;
-  height: 28px;
-  border: 1px solid #d7e3ef;
-  border-radius: 999px;
-  background: linear-gradient(135deg, #e0f2fe, #f8fafc);
-  color: #075985;
+  width: 44px;
+  height: 44px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   cursor: pointer;
-  font: 700 11px / 1 Arial, sans-serif;
   padding: 0;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  box-shadow: none;
+}
+
+.sidecar-selected-participant-avatar img {
+  display: block;
+  width: 40px;
+  height: 40px;
+  margin: 0;
+  border: 2px solid #ffffff;
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.10);
+  object-fit: cover;
+  transition: transform 0.15s ease;
 }
 
 .sidecar-selected-participant-avatar:hover,
 .sidecar-selected-participant-avatar:focus-visible {
-  border-color: #0077b6;
-  box-shadow: 0 0 0 2px rgba(0, 119, 182, 0.14);
   outline: none;
+}
+
+.sidecar-selected-participant-avatar:hover img,
+.sidecar-selected-participant-avatar:focus-visible img {
+  transform: scale(1.08);
 }
 
 .sidecar-selected-content {

--- a/j2cl/src/main/webapp/assets/sidecar.css
+++ b/j2cl/src/main/webapp/assets/sidecar.css
@@ -285,12 +285,19 @@ shell-root[data-wave-controls-compact="true"] wavy-wave-nav-row {
 }
 
 .sidecar-selected-participant-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 44px;
   height: 44px;
   border: 0;
-  border-radius: 0;
-  background: transparent;
+  border-radius: 50%;
+  background: #dff4ff;
+  color: #173355;
   cursor: pointer;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
   padding: 0;
   box-shadow: none;
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -58,6 +58,17 @@ public class J2clSelectedWaveViewChromeTest {
   }
 
   @Test
+  public void coldMountDoesNotRenderOpenedWaveEyebrow() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    new J2clSelectedWaveView(host);
+
+    Assert.assertNull(
+        "Selected-wave chrome must not render the J2CL-only 'Opened wave' eyebrow",
+        host.querySelector(".sidecar-eyebrow"));
+  }
+
+  @Test
   public void coldMountPlacesHeaderActionsBetweenParticipantsAndNavRow() {
     assumeBrowserDom();
     HTMLElement host = createHost();
@@ -248,6 +259,13 @@ public class J2clSelectedWaveViewChromeTest {
     Assert.assertEquals("Open alice@example.com profile", first.getAttribute("aria-label"));
     Assert.assertNull("avatar button keeps native button semantics", first.getAttribute("role"));
     Assert.assertEquals("listitem", first.parentElement.getAttribute("role"));
+    HTMLElement image = (HTMLElement) first.querySelector("img");
+    Assert.assertNotNull("Participant avatars should use profile images, not initials text", image);
+    Assert.assertEquals(
+        "/userprofile/image/alice@example.com",
+        image.getAttribute("src"));
+    Assert.assertEquals("alice@example.com", image.getAttribute("alt"));
+    Assert.assertEquals("", first.textContent.trim());
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -269,6 +269,30 @@ public class J2clSelectedWaveViewChromeTest {
   }
 
   @Test
+  public void participantAvatarShowsInitialsOnImageError() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+
+    view.render(
+        selectedModel(
+            "example.com/w+fallback",
+            Arrays.asList("alice@example.com")));
+
+    HTMLElement button =
+        (HTMLElement) host.querySelector("[data-selected-participant-avatar]");
+    HTMLElement image = (HTMLElement) button.querySelector("img");
+    Assert.assertNotNull(image);
+
+    elemental2.dom.EventInit init = elemental2.dom.EventInit.create();
+    init.setBubbles(false);
+    image.dispatchEvent(new elemental2.dom.Event("error", init));
+
+    Assert.assertTrue("img should be hidden after error", image.hidden);
+    Assert.assertEquals("A", button.textContent);
+  }
+
+  @Test
   public void renderPublishesParticipantsToProfileOverlay() {
     assumeBrowserDom();
     HTMLElement host = createHost();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewServerFirstLogicTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewServerFirstLogicTest.java
@@ -153,4 +153,16 @@ public class J2clSelectedWaveViewServerFirstLogicTest {
     Assert.assertEquals("Selected wave content", attributes.get("aria-label"));
     Assert.assertEquals("0", attributes.get("tabindex"));
   }
+
+  @Test
+  public void participantProfileImageUrlUsesExistingProfileImageEndpoint() {
+    Assert.assertEquals(
+        "/userprofile/image/alice@example.com",
+        J2clSelectedWaveView.participantProfileImageUrl(" alice@example.com "));
+    Assert.assertEquals(
+        "/userprofile/image/weird%2Fname%3F%23%25@example.com",
+        J2clSelectedWaveView.participantProfileImageUrl("weird/name?#%@example.com"));
+    Assert.assertEquals("", J2clSelectedWaveView.participantProfileImageUrl(" "));
+    Assert.assertEquals("", J2clSelectedWaveView.participantProfileImageUrl(null));
+  }
 }

--- a/wave/config/changelog.d/2026-05-08-j2cl-wave-chrome-title-participants.json
+++ b/wave/config/changelog.d/2026-05-08-j2cl-wave-chrome-title-participants.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-05-08-j2cl-wave-chrome-title-participants",
+  "version": "Issue #1223",
+  "date": "2026-05-08",
+  "title": "J2CL wave chrome now matches the legacy wave title and participant panels more closely.",
+  "summary": "The J2CL selected-wave view uses a compact title bar, removes the extra Opened wave label, shows participant profile images, and aligns wave action buttons with the legacy panel controls.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Replaces the large selected-wave heading with a compact legacy-style title bar.",
+        "Removes the J2CL-only Opened wave eyebrow from cold and server-first selected-wave markup.",
+        "Renders selected-wave participants as profile image avatars and restyles the wave action strip to match the legacy participant panel density."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3935,7 +3935,6 @@ public final class HtmlRenderer {
     sb.append("          </div>\n");
     sb.append("          <div class=\"sidecar-selected-host\" data-j2cl-selected-wave-host=\"true\">\n");
     sb.append("            <section class=\"sidecar-selected-card\" data-j2cl-server-first-mode=\"snapshot\" data-j2cl-server-first-selected-wave=\"preview-fixture-1\" data-j2cl-upgrade-placeholder=\"selected-wave\">\n");
-    sb.append("              <p class=\"sidecar-eyebrow\" data-j2cl-debug-only=\"true\">Opened wave</p>\n");
     sb.append("              <wavy-depth-nav-bar data-j2cl-server-first-chrome=\"true\" data-current-depth=\"top-thread\"></wavy-depth-nav-bar>\n");
     sb.append("              <h2 class=\"sidecar-selected-title\">Sample read-surface preview wave</h2>\n");
     sb.append("              <p class=\"sidecar-selected-unread\">3 unread</p>\n");
@@ -4710,7 +4709,6 @@ public final class HtmlRenderer {
       // no-JS path never leaves the region permanently aria-busy.
       sb.append("              <script>document.currentScript.parentElement.setAttribute('aria-busy','true');</script>\n");
     }
-    sb.append("              <p class=\"sidecar-eyebrow\" data-j2cl-debug-only=\"true\">Opened wave</p>\n");
     // F-2 slice 2 (#1046, R-3.7-chrome): depth-nav-bar landmark.
     // Hidden by default; the J2CL client (S5) writes the current depth
     // and toggles the hidden attribute via property assignment.

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -808,12 +808,11 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         html.contains("<body class=\"j2cl-root-shell-page j2cl-debug-overlay-on\">"));
   }
 
-  public void testV2PreviewFixtureEyebrowIsTaggedDebugOnly() {
+  public void testSelectedWaveChromeDoesNotRenderOpenedWaveEyebrow() {
     String html = renderSignedInPage();
-    assertTrue(
-        "Preview-fixture eyebrow must carry data-j2cl-debug-only so sidecar.css hides it (V-2 #1100)",
-        html.contains(
-            "<p class=\"sidecar-eyebrow\" data-j2cl-debug-only=\"true\">Opened wave</p>"));
+    assertFalse(
+        "Selected-wave chrome must not render the J2CL-only 'Opened wave' eyebrow",
+        html.contains("Opened wave"));
   }
 
   public void testV2PreviewFixtureStatusAndDetailAreTaggedDebugOnly() {


### PR DESCRIPTION
## Summary\n- replace the J2CL selected-wave large heading with a compact GWT-style title bar and remove the extra "Opened wave" eyebrow\n- render selected-wave participants with profile image avatars from the existing /userprofile/image endpoint\n- restyle the J2CL wave participant/action strip to match the legacy participant panel density\n\nFixes #1223\n\n## Verification\n- python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py\n- cd j2cl/lit && npm test -- --files test/wavy-wave-header-actions.test.js\n- cd j2cl/lit && npm run build\n- cd j2cl && ./mvnw -Dtest=J2clSelectedWaveViewChromeTest,J2clSelectedWaveViewServerFirstLogicTest test (Chrome DOM class compiles but skips under JVM Surefire; server-first logic ran 12/12)\n- sbt "testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellIntegrationTest"\n- bash scripts/worktree-boot.sh --shared-file-store --port 9923\n- PORT=9923 bash scripts/wave-smoke.sh check\n- curl -fsS 'http://localhost:9923/?view=j2cl-root' | grep -F 'sidecar-selected-title' >/tmp/issue1223-j2cl-root.html && ! grep -F 'Opened wave' /tmp/issue1223-j2cl-root.html\n- Browser opened http://localhost:9923/?view=j2cl-root at 1440x900 with Playwright and captured issue-1223-j2cl-root.png\n\n## Notes\n- The existing recent/next-unread toolbar tests already cover event dispatch, focus movement, and immediate mark-read behavior, so this PR leaves that wiring unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Participant avatars now display profile images with enhanced visual styling.

* **Bug Fixes**
  * Removed redundant "Opened wave" label from selected wave interface.

* **Style**
  * Updated wave header actions with improved button design and transitions.
  * Redesigned participant panel with larger profile image avatars (44px square format with white ring and drop shadow).
  * Streamlined title bar with compact styling and bottom border.
  * Improved accessibility with proper state indication for server-rendered content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->