### PR TITLE
Fix J2CL search and blip parity gaps

### DIFF
--- a/docs/superpowers/plans/2026-05-09-issue-1225-j2cl-search-blip-profile-tasks.md
+++ b/docs/superpowers/plans/2026-05-09-issue-1225-j2cl-search-blip-profile-tasks.md
@@ -1,0 +1,54 @@
+# Issue 1225: J2CL Search, Blip, Profile, and Task Parity
+
+## Context
+
+J2CL still diverges from the GWT view in several visible areas:
+
+- The search rail has a modern flat panel instead of the GWT blue panel title plus compact toolbar treatment.
+- The selected wave renders a digest/root snippet line above the read surface, so task text appears outside the root blip.
+- Blip toolbar glyphs, color, and avatar behavior differ from GWT; author avatars fall back to initials even when `/userprofile/image/<address>` is available.
+- The J2CL profile popup renders only name/address/avatar, even though `/profile/?addresses=...` already returns bio and last-seen fields.
+- Task controls are mounted once per blip, but the J2CL projector already extracts multiple `task/id` ranges per blip.
+
+## Plan
+
+1. Restore GWT-like search panel chrome in `wavy-search-rail`.
+   - Add a compact blue title strip showing the active query/count in the GWT panel style.
+   - Keep the existing J2CL events and saved-search controls intact.
+   - Add Lit coverage for the title strip and toolbar order.
+
+2. Remove duplicate root/digest text from the selected-wave header.
+   - Stop rendering `snippet` above the read surface for normal selected waves.
+   - Keep title, participant strip, wave header actions, and nav toolbar.
+   - Add Java view/projector coverage that selected-wave content is not duplicated into `.sidecar-selected-snippet`.
+
+3. Align blip header chrome.
+   - Render author avatars with `/userprofile/image/<authorId>` and fall back to initials on image error.
+   - Restyle toolbar buttons to the GWT-like grey icon row and replace the text symbols that produced the black `§`/`×` mismatch.
+   - Add Lit tests for image-first avatar rendering and toolbar glyph/style contract.
+
+4. Fill out profile popup details.
+   - Normalize participant objects from `/profile/?addresses=...` into the overlay participants array.
+   - Render bio, online/offline status from `lastSeenTime`, member-since when supplied, profile URL for bots/users, and keep Edit Profile limited to self.
+   - Add overlay tests covering user details and bot-style profile URL/details.
+
+5. Move task affordances from blip-level to task-level.
+   - Carry `J2clTaskItemModel` ranges through `J2clReadBlip`.
+   - Render a task affordance per `task/id` range inside or adjacent to the task text anchor rather than next to the blip toolbar.
+   - Include `taskId`, `textStart`, and `textEnd` in task toggle/metadata events.
+   - Route compose-surface writes to the specific task range where possible, preserving the current blip-level fallback for old data.
+   - Add Java and Lit tests for multiple tasks in one blip.
+
+6. Verification and delivery.
+   - Run focused Lit/J2CL tests, changelog assembly/validation, and `git diff --check`.
+   - Run a local browser sanity check against the worktree server for the changed UI surfaces.
+   - Self-review the diff.
+   - Run the Claude code review workflow, fix all actionable findings, and rerun affected checks.
+   - Update issue #1225 with verification evidence, create PR, then monitor CI/reviews until merged.
+
+## Self-Review
+
+- The plan keeps GWT parity changes in the existing J2CL seams instead of replacing the architecture.
+- The riskiest item is per-task editing because persisted writes currently operate on whole blip body ranges; implementation must preserve the old fallback until specific ranges are proven through tests.
+- Profile rendering should not require server schema work unless tests show the existing profile JSON is not reaching the overlay.
+- Browser verification is required because several changes are visual and shadow-DOM based.

--- a/j2cl/lit/src/elements/wave-blip-toolbar.js
+++ b/j2cl/lit/src/elements/wave-blip-toolbar.js
@@ -34,10 +34,10 @@ export class WaveBlipToolbar extends LitElement {
     :host {
       display: inline-flex;
       align-items: center;
-      gap: 4px;
+      gap: 2px;
       padding: 0;
       background: transparent;
-      color: var(--wavy-blip-toolbar-fg, var(--wavy-text-body, #fff));
+      color: var(--wavy-blip-toolbar-fg, #718096);
       border: 0;
       border-radius: 0;
       font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
@@ -58,7 +58,7 @@ export class WaveBlipToolbar extends LitElement {
       align-items: center;
       justify-content: center;
       gap: 4px;
-      border-radius: var(--wavy-toolbar-tile-radius, 4px);
+      border-radius: 4px;
       transition: background-color var(--wavy-motion-focus-duration, 180ms)
         var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
     }
@@ -66,14 +66,15 @@ export class WaveBlipToolbar extends LitElement {
       border-right: 0;
     }
     button:hover {
-      background: var(--wavy-toolbar-tile-hover-bg, rgba(255, 255, 255, 0.08));
+      background: #edf2f7;
+      color: #4a5568;
     }
     button:focus-visible {
       outline: none;
       box-shadow: var(--wavy-focus-ring, 0 0 0 2px #22d3ee);
     }
     .glyph {
-      font-size: 14px;
+      font-size: 16px;
       line-height: 1;
     }
     .label {
@@ -129,7 +130,7 @@ export class WaveBlipToolbar extends LitElement {
         title="Delete this blip"
         @click=${() => this._emit("wave-blip-toolbar-delete")}
       >
-        <span class="glyph" aria-hidden="true">✕</span><span class="label">Delete</span>
+        <span class="glyph" aria-hidden="true">⌫</span><span class="label">Delete</span>
       </button>
       <button
         type="button"
@@ -138,7 +139,7 @@ export class WaveBlipToolbar extends LitElement {
         title="Copy permalink to this blip"
         @click=${() => this._emit("wave-blip-toolbar-link")}
       >
-        <span class="glyph" aria-hidden="true">§</span><span class="label">Link</span>
+        <span class="glyph" aria-hidden="true">↗</span><span class="label">Link</span>
       </button>
     `;
   }

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -214,6 +214,9 @@ export class WaveBlip extends LitElement {
       object-fit: cover;
       display: block;
     }
+    .avatar:has(img) {
+      color: transparent;
+    }
     :host([data-blip-depth="root"]) .avatar {
       width: var(--wavy-avatar-size-root, 28px);
       height: var(--wavy-avatar-size-root, 28px);

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -112,7 +112,8 @@ export class WaveBlip extends LitElement {
     // Renderer sets this whenever a task/done annotation exists (regardless of value).
     // Survives full DOM rebuilds so reopened tasks keep the affordance mounted.
     taskPresent: { type: Boolean, attribute: "data-task-present", reflect: false },
-    bodySize: { type: Number, attribute: "data-blip-doc-size", reflect: true }
+    bodySize: { type: Number, attribute: "data-blip-doc-size", reflect: true },
+    authorAvatarUrl: { type: String, attribute: "author-avatar-url" }
   };
 
   static styles = css`
@@ -202,6 +203,16 @@ export class WaveBlip extends LitElement {
       border: 1.5px solid #ffffff;
       padding: 0;
       box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+      overflow: hidden;
+    }
+    .avatar img {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      border-radius: 50%;
+      object-fit: cover;
+      display: block;
     }
     :host([data-blip-depth="root"]) .avatar {
       width: var(--wavy-avatar-size-root, 28px);
@@ -341,6 +352,7 @@ export class WaveBlip extends LitElement {
     this.dataBlipTime = "";
     this.dataBlipFocused = null;
     this._participants = [];
+    this.authorAvatarUrl = "";
   }
 
   /**
@@ -607,6 +619,22 @@ export class WaveBlip extends LitElement {
     return url.toString();
   }
 
+  _avatarUrl() {
+    const explicit = String(this.authorAvatarUrl || "").trim();
+    if (explicit) {
+      return explicit;
+    }
+    const address = String(this.authorId || "").trim();
+    return address ? `/userprofile/image/${encodeURIComponent(address).replace(/%40/g, "@")}` : "";
+  }
+
+  _onAvatarImageError(event) {
+    const img = event && event.currentTarget;
+    if (img && img.parentElement) {
+      img.remove();
+    }
+  }
+
   render() {
     const tooltip = this.postedAtIso || this.postedAt;
     const palette = this._palette();
@@ -615,6 +643,7 @@ export class WaveBlip extends LitElement {
     const replyNoun = this.replyCount === 1 ? "reply" : "replies";
     const threadToggleVerb = this.threadCollapsed ? "Expand" : "Collapse";
     const authorLabel = this._authorLabel();
+    const avatarUrl = this._avatarUrl();
     const chevron = hasReplies
       ? html`<button
           type="button"
@@ -647,7 +676,15 @@ export class WaveBlip extends LitElement {
             aria-label=${`Open ${authorLabel} profile`}
             @click=${this._onAvatarClick}
           >
-            ${this._initials()}
+            ${avatarUrl
+              ? html`<img
+                  src=${avatarUrl}
+                  alt=""
+                  loading="lazy"
+                  decoding="async"
+                  @error=${this._onAvatarImageError}
+                />${this._initials()}`
+              : this._initials()}
           </button>
           <span class="author">${authorLabel}</span>
           <time
@@ -667,21 +704,6 @@ export class WaveBlip extends LitElement {
             @wave-blip-toolbar-link=${this._onLinkClick}
             @wave-blip-toolbar-delete=${this._onDeleteClick}
           ></wave-blip-toolbar>
-          ${this._hasTaskAffordance()
-            ? html`<span class="task-affordance-slot" data-task-affordance-slot>
-                <wavy-task-affordance
-                  data-blip-id=${this.blipId}
-                  data-wave-id=${this.waveId}
-                  ?data-task-completed=${this.taskCompleted}
-                  data-task-assignee=${this.taskAssignee || ""}
-                  data-task-due-date=${this.taskDueDate || ""}
-                  data-blip-doc-size=${ifDefined(this.bodySize > 0 ? String(this.bodySize) : undefined)}
-                  .bodySize=${this.bodySize || 0}
-                  .participants=${this._participants}
-                  @wave-blip-task-toggled=${this._onTaskToggled}
-                ></wavy-task-affordance>
-              </span>`
-            : ""}
           </span>
         </div>
         <div class="body">

--- a/j2cl/lit/src/elements/wavy-profile-overlay.js
+++ b/j2cl/lit/src/elements/wavy-profile-overlay.js
@@ -211,6 +211,7 @@ export class WavyProfileOverlay extends LitElement {
     this.currentUserId = "";
     this.editProfileUrl = "/userprofile/edit";
     this._fallbackParticipant = null;
+    this._activeFetchAddress = "";
     this._onAvatarRequest = this._onAvatarRequest.bind(this);
     this._onKeyDown = this._onKeyDown.bind(this);
   }
@@ -376,6 +377,7 @@ export class WavyProfileOverlay extends LitElement {
     if (!address || typeof fetch !== "function") {
       return;
     }
+    this._activeFetchAddress = address;
     try {
       const response = await fetch(`/profile/?addresses=${encodeURIComponent(address)}`, {
         credentials: "same-origin",
@@ -389,7 +391,7 @@ export class WavyProfileOverlay extends LitElement {
       const profile =
         profiles.find((item) => item && String(item.address || item.id || "") === address) ||
         profiles[0];
-      if (!profile) {
+      if (!profile || this._activeFetchAddress !== address) {
         return;
       }
       this._mergeProfileDetails(address, profile);

--- a/j2cl/lit/src/elements/wavy-profile-overlay.js
+++ b/j2cl/lit/src/elements/wavy-profile-overlay.js
@@ -473,6 +473,8 @@ export class WavyProfileOverlay extends LitElement {
     if (this.index >= list.length - 1) return;
     this.index = this.index + 1;
     this._emitChange();
+    const p = list[this.index];
+    if (p) this._fetchProfileDetails(this._profileAddress(p));
   }
 
   _prev() {
@@ -481,6 +483,8 @@ export class WavyProfileOverlay extends LitElement {
     if (this.index <= 0) return;
     this.index = this.index - 1;
     this._emitChange();
+    const p = list[this.index];
+    if (p) this._fetchProfileDetails(this._profileAddress(p));
   }
 
   _emitChange() {

--- a/j2cl/lit/src/elements/wavy-profile-overlay.js
+++ b/j2cl/lit/src/elements/wavy-profile-overlay.js
@@ -242,7 +242,11 @@ export class WavyProfileOverlay extends LitElement {
         participant &&
         previous.id === participant.id &&
         previous.displayName === participant.displayName &&
-        previous.avatarUrl === participant.avatarUrl);
+        previous.avatarUrl === participant.avatarUrl &&
+        previous.bio === participant.bio &&
+        previous.memberSince === participant.memberSince &&
+        previous.profileUrl === participant.profileUrl &&
+        previous.lastSeenTime === participant.lastSeenTime);
     this._fallbackParticipant = participant;
     if (!same) {
       this.requestUpdate("_fallbackParticipant", previous);

--- a/j2cl/lit/src/elements/wavy-profile-overlay.js
+++ b/j2cl/lit/src/elements/wavy-profile-overlay.js
@@ -87,6 +87,7 @@ export class WavyProfileOverlay extends LitElement {
       justify-content: center;
       font: var(--wavy-type-section, 0.875rem / 1.4 sans-serif);
       font-weight: 700;
+      overflow: hidden;
     }
     .avatar img {
       width: 100%;
@@ -103,6 +104,34 @@ export class WavyProfileOverlay extends LitElement {
       margin: 0;
       color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
       font: var(--wavy-type-label, 0.75rem / 1.35 sans-serif);
+    }
+    .bio {
+      max-width: 300px;
+      margin: 0;
+      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      font: var(--wavy-type-body, 0.875rem / 1.45 sans-serif);
+      text-align: center;
+    }
+    .status,
+    .member-since,
+    .profile-link {
+      margin: 0;
+      color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
+      font: var(--wavy-type-label, 0.75rem / 1.35 sans-serif);
+    }
+    .status[data-online="true"]::before {
+      content: "";
+      display: inline-block;
+      width: 10px;
+      height: 10px;
+      margin-right: 5px;
+      border-radius: 50%;
+      background: #22c55e;
+      vertical-align: -1px;
+    }
+    .profile-link {
+      color: var(--wavy-signal-cyan, #22d3ee);
+      text-decoration: none;
     }
     .nav {
       position: absolute;
@@ -332,6 +361,7 @@ export class WavyProfileOverlay extends LitElement {
       this.index = 0;
     }
     this.open = true;
+    this._fetchProfileDetails(authorId);
     this.dispatchEvent(
       new CustomEvent("wavy-profile-overlay-opened", {
         bubbles: true,
@@ -339,6 +369,65 @@ export class WavyProfileOverlay extends LitElement {
         detail: { authorId: authorId || null }
       })
     );
+  }
+
+  async _fetchProfileDetails(authorId) {
+    const address = String(authorId || "").trim();
+    if (!address || typeof fetch !== "function") {
+      return;
+    }
+    try {
+      const response = await fetch(`/profile/?addresses=${encodeURIComponent(address)}`, {
+        credentials: "same-origin",
+        headers: { Accept: "application/json" }
+      });
+      if (!response || !response.ok) {
+        return;
+      }
+      const json = await response.json();
+      const profiles = Array.isArray(json && json.profiles) ? json.profiles : [];
+      const profile =
+        profiles.find((item) => item && String(item.address || item.id || "") === address) ||
+        profiles[0];
+      if (!profile) {
+        return;
+      }
+      this._mergeProfileDetails(address, profile);
+    } catch (_err) {
+      // Profile detail fetch is progressive enhancement; keep the overlay usable.
+    }
+  }
+
+  _mergeProfileDetails(address, profile) {
+    const normalize = (raw) => ({
+      id: String(raw.address || raw.id || address),
+      displayName: String(raw.name || raw.displayName || raw.address || address),
+      avatarUrl: String(raw.imageUrl || raw.avatarUrl || ""),
+      profileUrl: this._safeProfileUrl(raw.profileUrl),
+      firstName: String(raw.firstName || ""),
+      lastName: String(raw.lastName || ""),
+      bio: String(raw.bio || ""),
+      lastSeenTime: this._coerceTime(raw.lastSeenTime),
+      memberSince: this._formatMemberSince(raw.memberSince || raw.memberSinceText || ""),
+      isBot:
+        raw.isBot === true ||
+        raw.robot === true ||
+        /bot@|robot@|gpt.*bot/i.test(String(raw.address || address))
+    });
+    const nextProfile = normalize(profile);
+    const list = Array.isArray(this.participants) ? [...this.participants] : [];
+    const found = list.findIndex((p) => p && String(p.id || "") === address);
+    if (found >= 0) {
+      list[found] = { ...list[found], ...nextProfile };
+      this.participants = list;
+      this.index = found;
+      this._setFallbackParticipant(null);
+    } else if (this._fallbackParticipant && this._fallbackParticipant.id === address) {
+      this._setFallbackParticipant({ ...this._fallbackParticipant, ...nextProfile });
+    } else {
+      this._setFallbackParticipant(nextProfile);
+      this.index = 0;
+    }
   }
 
   open_(index) {
@@ -471,6 +560,54 @@ export class WavyProfileOverlay extends LitElement {
     return parts.map((p) => p.charAt(0).toUpperCase()).join("");
   }
 
+  _onlineLabel(participant) {
+    const lastSeen = this._coerceTime(participant && participant.lastSeenTime);
+    if (!Number.isFinite(lastSeen) || lastSeen <= 0) {
+      return "";
+    }
+    const ageMs = Date.now() - lastSeen;
+    return ageMs >= 0 && ageMs <= 5 * 60 * 1000
+      ? "Online"
+      : "Last seen " + new Date(lastSeen).toLocaleString();
+  }
+
+  _coerceTime(value) {
+    if (value == null || value === "") {
+      return 0;
+    }
+    if (typeof value === "number") {
+      return Number.isFinite(value) ? value : 0;
+    }
+    const raw = String(value).trim();
+    if (!raw) {
+      return 0;
+    }
+    const numeric = Number(raw);
+    if (Number.isFinite(numeric)) {
+      return numeric;
+    }
+    const parsed = Date.parse(raw);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  _formatMemberSince(value) {
+    if (value == null || value === "") {
+      return "";
+    }
+    if (typeof value === "number" || /^-?\d+$/.test(String(value).trim())) {
+      const millis = Number(value);
+      return Number.isFinite(millis) && millis > 0
+        ? "Member since " + new Date(millis).toLocaleDateString()
+        : "";
+    }
+    return String(value).trim();
+  }
+
+  _safeProfileUrl(value) {
+    const raw = String(value || "").trim();
+    return /^https?:\/\//i.test(raw) ? raw : "";
+  }
+
   render() {
     const list = this._activeParticipants();
     const max = list.length > 0 ? list.length - 1 : 0;
@@ -480,6 +617,10 @@ export class WavyProfileOverlay extends LitElement {
     const pid = current ? current.id : "";
     const isSelf = this._isSelfParticipant(current);
     const canSendMessage = Boolean(this._profileAddress(current)) && !isSelf;
+    const bio = current && current.bio ? String(current.bio).trim() : "";
+    const statusLabel = current ? this._onlineLabel(current) : "";
+    const memberSince = current && current.memberSince ? String(current.memberSince).trim() : "";
+    const profileUrl = current && current.profileUrl ? String(current.profileUrl).trim() : "";
     const prevDisabled = list.length === 0 || idx === 0;
     const nextDisabled = list.length === 0 || idx >= max;
 
@@ -519,6 +660,26 @@ export class WavyProfileOverlay extends LitElement {
         </div>
         <h2 class="name" id="wavy-profile-name">${displayName}</h2>
         ${pid ? html`<p class="pid">${pid}</p>` : null}
+        ${bio ? html`<p class="bio" data-profile-bio>${bio}</p>` : null}
+        ${statusLabel
+          ? html`<p
+              class="status"
+              data-profile-status
+              data-online=${statusLabel === "Online" ? "true" : "false"}
+            >${statusLabel}</p>`
+          : null}
+        ${memberSince
+          ? html`<p class="member-since" data-profile-member-since>${memberSince}</p>`
+          : null}
+        ${profileUrl
+          ? html`<a
+              class="profile-link"
+              data-profile-url
+              href=${profileUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >${current && current.isBot ? "Bot profile" : "Profile"}</a>`
+          : null}
         <div class="actions-slot">
           <button
             class="profile-action profile-action-primary"

--- a/j2cl/lit/src/elements/wavy-search-rail.js
+++ b/j2cl/lit/src/elements/wavy-search-rail.js
@@ -97,7 +97,7 @@ export class WavySearchRail extends LitElement {
       font: var(--wavy-type-body, 13px / 1.35 Arial, sans-serif);
       min-width: 280px;
     }
-    .search {
+      .search {
       position: relative;
       display: flex;
       align-items: center;
@@ -107,8 +107,28 @@ export class WavySearchRail extends LitElement {
       padding: 0 8px;
       border-bottom: 1px solid var(--wavy-border-hairline, #e2e8f0);
       background: #ffffff;
-      box-sizing: border-box;
-    }
+        box-sizing: border-box;
+      }
+      .panel-title {
+        display: flex;
+        align-items: center;
+        min-height: 24px;
+        padding: 3px 8px;
+        box-sizing: border-box;
+        color: #ffffff;
+        background: linear-gradient(180deg, #5ba3e0 0%, #2d6fa8 100%);
+        border: 1px solid #5b8fc1;
+        border-bottom-color: #2c5f91;
+        border-radius: 3px 3px 0 0;
+        font: 700 13px / 1.25 Arial, sans-serif;
+        text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.18);
+      }
+      .panel-title-text {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     .query {
       flex: 1 1 auto;
       box-sizing: border-box;
@@ -1087,6 +1107,9 @@ export class WavySearchRail extends LitElement {
     const effectiveSort = explicitSort || defaultSort;
     const pinnedSearches = this.savedSearches.filter((item) => item.pinned);
     return html`
+      <div class="panel-title" data-search-panel-title>
+        <span class="panel-title-text">${this._panelTitle()}</span>
+      </div>
       <div class="search">
         <span class="waveform" aria-hidden="true">
           <svg viewBox="0 0 14 14" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6">
@@ -1378,9 +1401,15 @@ export class WavySearchRail extends LitElement {
           </div>
         </section>
       </div>
-    `;
+      `;
+    }
+
+    _panelTitle() {
+      const query = String(this.query || "").trim() || "in:inbox";
+      const count = String(this.resultCount || "").trim();
+      return count ? `${query} (${count})` : query;
+    }
   }
-}
 
 if (!customElements.get("wavy-search-rail")) {
   customElements.define("wavy-search-rail", WavySearchRail);

--- a/j2cl/lit/src/elements/wavy-task-affordance.js
+++ b/j2cl/lit/src/elements/wavy-task-affordance.js
@@ -45,6 +45,9 @@ export class WavyTaskAffordance extends LitElement {
   static properties = {
     blipId: { type: String, attribute: "data-blip-id", reflect: true },
     waveId: { type: String, attribute: "data-wave-id", reflect: true },
+    taskId: { type: String, attribute: "data-task-id", reflect: true },
+    textStart: { type: Number, attribute: "data-task-start", reflect: true },
+    textEnd: { type: Number, attribute: "data-task-end", reflect: true },
     completed: { type: Boolean, attribute: "data-task-completed", reflect: true },
     assigneeAddress: { type: String, attribute: "data-task-assignee", reflect: true },
     dueDate: { type: String, attribute: "data-task-due-date", reflect: true },
@@ -125,6 +128,9 @@ export class WavyTaskAffordance extends LitElement {
     super();
     this.blipId = "";
     this.waveId = "";
+    this.taskId = "";
+    this.textStart = -1;
+    this.textEnd = -1;
     this.completed = false;
     this.assigneeAddress = "";
     this.dueDate = "";
@@ -155,9 +161,12 @@ export class WavyTaskAffordance extends LitElement {
         bubbles: true,
         composed: true,
         detail: {
-          blipId: this.blipId,
-          waveId: this.waveId,
-          completed: next,
+            blipId: this.blipId,
+            waveId: this.waveId,
+            taskId: this.taskId || this.blipId,
+          textStart: this.textStart ?? -1,
+          textEnd: this.textEnd ?? -1,
+            completed: next,
           bodySize: this.bodySize || 0
         }
       })
@@ -206,9 +215,12 @@ export class WavyTaskAffordance extends LitElement {
         bubbles: true,
         composed: true,
         detail: {
-          blipId: this.blipId,
-          waveId: this.waveId,
-          assigneeAddress: assignee,
+            blipId: this.blipId,
+            waveId: this.waveId,
+            taskId: this.taskId || this.blipId,
+          textStart: this.textStart ?? -1,
+          textEnd: this.textEnd ?? -1,
+            assigneeAddress: assignee,
           dueDate: due,
           bodySize: this.bodySize || 0
         }
@@ -247,7 +259,7 @@ export class WavyTaskAffordance extends LitElement {
         ${this._popoverOpen
           ? html`<task-metadata-popover
               open
-              .taskId=${this.blipId}
+                .taskId=${this.taskId || this.blipId}
               .assigneeAddress=${this.assigneeAddress}
               .dueDate=${this.dueDate}
               .participants=${this.participants || []}

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -447,45 +447,19 @@ describe("<wave-blip>", () => {
     expect(el.renderRoot.textContent).to.not.include("Task");
   });
 
-  it("mounts <wavy-task-affordance> only when task state is present", async () => {
+  it("does not mount blip-level task controls when only blip task attributes are present", async () => {
     const el = await fixture(html`
       <wave-blip
         data-blip-id="b20"
         data-wave-id="w20"
         author-name="A"
         data-task-assignee="alice@example.com"
-      ></wave-blip>
-    `);
-    await el.updateComplete;
-    const slot = el.renderRoot.querySelector('[data-task-affordance-slot]');
-    expect(slot).to.exist;
-    const affordance = slot.querySelector("wavy-task-affordance");
-    expect(affordance).to.exist;
-    expect(affordance.getAttribute("data-blip-id")).to.equal("b20");
-    expect(affordance.getAttribute("data-wave-id")).to.equal("w20");
-  });
-
-  it("keeps task affordances out of visible focus flow until the blip is active", async () => {
-    const el = await fixture(html`
-      <wave-blip
-        data-blip-id="b20a"
-        data-wave-id="w20a"
-        author-name="A"
         data-task-completed
       ></wave-blip>
     `);
     await el.updateComplete;
-    const slot = el.renderRoot.querySelector('[data-task-affordance-slot]');
-    expect(getComputedStyle(slot).visibility).to.equal("hidden");
-
-    el.setAttribute("focused", "");
-    await el.updateComplete;
-    expect(getComputedStyle(slot).visibility).to.equal("visible");
-
-    el.removeAttribute("focused");
-    el.setAttribute("tabindex", "0");
-    await el.updateComplete;
-    expect(getComputedStyle(slot).visibility).to.equal("visible");
+    expect(el.renderRoot.querySelector('[data-task-affordance-slot]')).to.equal(null);
+    expect(el.renderRoot.querySelector("wavy-task-affordance")).to.equal(null);
   });
 
   it("reflects taskCompleted as data-task-completed on the host", async () => {
@@ -500,59 +474,6 @@ describe("<wave-blip>", () => {
     expect(el.hasAttribute("data-task-completed")).to.equal(false);
   });
 
-  it("keeps task affordance mounted after an optimistic reopen toggle", async () => {
-    const el = await fixture(html`
-      <wave-blip data-blip-id="b21b" data-wave-id="w21b" data-task-completed></wave-blip>
-    `);
-    await el.updateComplete;
-    expect(el.renderRoot.querySelector('[data-task-affordance-slot]')).to.exist;
-    el.taskCompleted = false;
-    await el.updateComplete;
-    expect(el.renderRoot.querySelector('[data-task-affordance-slot]')).to.exist;
-  });
-
-  it("keeps task affordance mounted after DOM rebuild via data-task-present (reopened task)", async () => {
-    // Simulate the renderWindow DOM-rebuild path: the renderer emits data-task-present
-    // so a reopened task with no assignee/due-date keeps its affordance visible even
-    // though _taskPresent is lost when the old <wave-blip> node was destroyed.
-    const el = await fixture(html`
-      <wave-blip
-        data-blip-id="b21c"
-        data-wave-id="w21c"
-        data-task-present
-      ></wave-blip>
-    `);
-    await el.updateComplete;
-    expect(el.renderRoot.querySelector('[data-task-affordance-slot]')).to.exist;
-  });
-
-  it("re-emits wave-blip-task-toggled from the inner affordance with full detail", async () => {
-    const el = await fixture(html`
-      <wave-blip
-        data-blip-id="b22"
-        data-wave-id="w22"
-        data-blip-doc-size="17"
-        data-task-assignee="alice@example.com"
-      ></wave-blip>
-    `);
-    await el.updateComplete;
-    const affordance = el.renderRoot.querySelector("wavy-task-affordance");
-    await affordance.updateComplete;
-    const toggle = affordance.renderRoot.querySelector('[data-task-toggle-trigger="true"]');
-    let captured = null;
-    el.addEventListener("wave-blip-task-toggled", (e) => {
-      captured = e.detail;
-    });
-    toggle.click();
-    await el.updateComplete;
-    expect(captured).to.deep.equal({
-      blipId: "b22",
-      waveId: "w22",
-      completed: true,
-      bodySize: 17
-    });
-  });
-
   it("does not strike through the whole body when data-task-completed is set", async () => {
     const el = await fixture(html`
       <wave-blip data-blip-id="b30" data-wave-id="w30" data-task-completed>
@@ -564,26 +485,6 @@ describe("<wave-blip>", () => {
     expect(body).to.exist;
     const style = getComputedStyle(body);
     expect(style.textDecorationLine || style.textDecoration).to.not.contain("line-through");
-  });
-
-  it("propagates taskAssignee + taskDueDate to the inner affordance", async () => {
-    const el = await fixture(html`
-      <wave-blip
-        data-blip-id="b31"
-        data-wave-id="w31"
-        data-task-assignee="bob@example.com"
-        data-task-due-date="2026-05-01"
-      ></wave-blip>
-    `);
-    await el.updateComplete;
-    const affordance = el.renderRoot.querySelector("wavy-task-affordance");
-    expect(affordance).to.exist;
-    expect(affordance.getAttribute("data-task-assignee")).to.equal(
-      "bob@example.com"
-    );
-    expect(affordance.getAttribute("data-task-due-date")).to.equal(
-      "2026-05-01"
-    );
   });
 
   // V-4 (#1102): per-blip chrome on the open wave.

--- a/j2cl/lit/test/wavy-profile-overlay.test.js
+++ b/j2cl/lit/test/wavy-profile-overlay.test.js
@@ -378,6 +378,126 @@ describe("<wavy-profile-overlay>", () => {
     expect(initials).to.equal("Q");
   });
 
+  it("fetches and renders profile bio, online status, and profile URL on open", async () => {
+    const previousFetch = globalThis.fetch;
+    let requestedUrl = "";
+    globalThis.fetch = async (url) => {
+      requestedUrl = String(url);
+      return {
+        ok: true,
+        json: async () => ({
+          profiles: [
+            {
+              address: "gpt-bot@supawave.ai",
+              name: "GPT Bot",
+              imageUrl: "/bot.png",
+              profileUrl: "https://supawave.ai/bots/gpt",
+              bio: "Answers questions in waves",
+              lastSeenTime: new Date().toISOString(),
+              memberSince: Date.UTC(2026, 2, 1)
+            }
+          ]
+        })
+      };
+    };
+    try {
+      const el = await fixture(html`<wavy-profile-overlay></wavy-profile-overlay>`);
+      el.participants = [{ id: "gpt-bot@supawave.ai", displayName: "gpt-bot@supawave.ai" }];
+      await el.updateComplete;
+      document.dispatchEvent(
+        new CustomEvent("wave-blip-profile-requested", {
+          bubbles: true,
+          composed: true,
+          detail: { authorId: "gpt-bot@supawave.ai" }
+        })
+      );
+      await el.updateComplete;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await el.updateComplete;
+
+      expect(requestedUrl).to.contain("/profile/?addresses=gpt-bot%40supawave.ai");
+      expect(el.renderRoot.querySelector(".name").textContent.trim()).to.equal("GPT Bot");
+      expect(el.renderRoot.querySelector("[data-profile-bio]").textContent.trim()).to.equal(
+        "Answers questions in waves"
+      );
+      expect(el.renderRoot.querySelector("[data-profile-status]").textContent.trim()).to.equal(
+        "Online"
+      );
+      expect(
+        el.renderRoot.querySelector("[data-profile-member-since]").textContent.trim()
+      ).to.contain("Member since");
+      expect(el.renderRoot.querySelector("[data-profile-url]").textContent.trim()).to.equal(
+        "Bot profile"
+      );
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
+  it("keeps profile open and avoids invalid last-seen text when detail fetch fails", async () => {
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+      throw new Error("offline");
+    };
+    try {
+      const el = await fixture(html`<wavy-profile-overlay></wavy-profile-overlay>`);
+      el.participants = [
+        { id: "alice@example.com", displayName: "Alice", lastSeenTime: "not-a-date" }
+      ];
+      await el.updateComplete;
+      document.dispatchEvent(
+        new CustomEvent("wave-blip-profile-requested", {
+          bubbles: true,
+          composed: true,
+          detail: { authorId: "alice@example.com" }
+        })
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await el.updateComplete;
+
+      expect(el.open).to.equal(true);
+      expect(el.renderRoot.querySelector(".name").textContent.trim()).to.equal("Alice");
+      expect(el.renderRoot.querySelector("[data-profile-status]")).to.equal(null);
+      expect(el.renderRoot.textContent).not.to.contain("Invalid Date");
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
+  it("does not render unsafe profile URLs from fetched profile details", async () => {
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        profiles: [
+          {
+            address: "bot@example.com",
+            name: "Bot",
+            profileUrl: "javascript:alert(1)"
+          }
+        ]
+      })
+    });
+    try {
+      const el = await fixture(html`<wavy-profile-overlay></wavy-profile-overlay>`);
+      el.participants = [{ id: "bot@example.com", displayName: "Bot" }];
+      await el.updateComplete;
+      document.dispatchEvent(
+        new CustomEvent("wave-blip-profile-requested", {
+          bubbles: true,
+          composed: true,
+          detail: { authorId: "bot@example.com" }
+        })
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await el.updateComplete;
+
+      expect(el.renderRoot.querySelector("[data-profile-url]")).to.equal(null);
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
   it("real keyboard path: host receives Escape after focus moves on open", async () => {
     const el = await fixture(html`<wavy-profile-overlay></wavy-profile-overlay>`);
     el.participants = PARTICIPANTS;

--- a/j2cl/lit/test/wavy-profile-overlay.test.js
+++ b/j2cl/lit/test/wavy-profile-overlay.test.js
@@ -498,6 +498,52 @@ describe("<wavy-profile-overlay>", () => {
     }
   });
 
+  it("navigating to next participant invalidates in-flight fetch for previous participant", async () => {
+    const previousFetch = globalThis.fetch;
+    let resolveA;
+    let fetchCount = 0;
+    let lastFetchedAddress = "";
+    globalThis.fetch = async (url) => {
+      fetchCount++;
+      lastFetchedAddress = url;
+      if (url.includes("alice")) {
+        // Simulate a slow A fetch — caller controls when it resolves.
+        return new Promise((res) => { resolveA = () => res({ ok: true, json: async () => ({ profiles: [{ address: "alice@example.com", name: "Alice Detail" }] }) }); });
+      }
+      return { ok: false };
+    };
+    try {
+      const el = await fixture(html`<wavy-profile-overlay></wavy-profile-overlay>`);
+      el.participants = [
+        { id: "alice@example.com", displayName: "Alice" },
+        { id: "bob@example.com", displayName: "Bob" }
+      ];
+      await el.updateComplete;
+      // Open on Alice — triggers fetch for Alice.
+      document.dispatchEvent(
+        new CustomEvent("wave-blip-profile-requested", {
+          bubbles: true,
+          composed: true,
+          detail: { authorId: "alice@example.com" }
+        })
+      );
+      await el.updateComplete;
+      expect(el.index).to.equal(0);
+      // Navigate to Bob before Alice's fetch resolves.
+      el._next();
+      await el.updateComplete;
+      expect(el.index).to.equal(1);
+      // Now let Alice's stale fetch resolve.
+      resolveA();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await el.updateComplete;
+      // Index must remain on Bob — stale A response must be dropped.
+      expect(el.index).to.equal(1);
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
   it("real keyboard path: host receives Escape after focus moves on open", async () => {
     const el = await fixture(html`<wavy-profile-overlay></wavy-profile-overlay>`);
     el.participants = PARTICIPANTS;

--- a/j2cl/lit/test/wavy-task-affordance.test.js
+++ b/j2cl/lit/test/wavy-task-affordance.test.js
@@ -67,8 +67,37 @@ describe("<wavy-task-affordance>", () => {
     const event = await eventPromise;
     expect(event.detail.blipId).to.equal("b42");
     expect(event.detail.waveId).to.equal("w7");
+    expect(event.detail.taskId).to.equal("b42");
+    expect(event.detail.textStart).to.equal(-1);
+    expect(event.detail.textEnd).to.equal(-1);
     expect(event.detail.completed).to.equal(true);
     expect(event.detail.bodySize).to.equal(17);
+  });
+
+  it("emits task range details for per-task affordances", async () => {
+    const el = await fixture(html`
+      <wavy-task-affordance
+        data-blip-id="b42"
+        data-wave-id="w7"
+        data-task-id="task-a"
+        data-task-start="5"
+        data-task-end="17"
+        data-blip-doc-size="22"
+      ></wavy-task-affordance>
+    `);
+    const toggle = el.renderRoot.querySelector('[data-task-toggle-trigger="true"]');
+    const eventPromise = oneEvent(el, "wave-blip-task-toggled");
+    toggle.click();
+    const event = await eventPromise;
+    expect(event.detail).to.include({
+      blipId: "b42",
+      waveId: "w7",
+      taskId: "task-a",
+      textStart: 5,
+      textEnd: 17,
+      completed: true,
+      bodySize: 22
+    });
   });
 
   it("flips aria-checked and the data-task-completed attribute on toggle", async () => {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -192,6 +192,11 @@ public final class J2clComposeSurfaceController {
      */
     default void onTaskToggled(String blipId, boolean completed, int bodyItemCount) {}
 
+    default void onTaskToggled(
+        String blipId, boolean completed, int bodyItemCount, int textStart, int textEnd) {
+      onTaskToggled(blipId, completed, bodyItemCount);
+    }
+
     /**
      * F-3.S2 (#1038, R-5.4 step 5): the task-metadata popover emitted
      * a submit. The controller emits a stand-alone delta carrying
@@ -199,6 +204,16 @@ public final class J2clComposeSurfaceController {
      */
     default void onTaskMetadataChanged(
         String blipId, String assigneeAddress, String dueDate, int bodyItemCount) {}
+
+    default void onTaskMetadataChanged(
+        String blipId,
+        String assigneeAddress,
+        String dueDate,
+        int bodyItemCount,
+        int textStart,
+        int textEnd) {
+      onTaskMetadataChanged(blipId, assigneeAddress, dueDate, bodyItemCount);
+    }
 
     /**
      * F-3.S3 (#1038, R-5.5): the user picked a reaction emoji in the
@@ -413,6 +428,17 @@ public final class J2clComposeSurfaceController {
           "Task toggle is only available with the rich-content delta factory.");
     }
 
+    default SidecarSubmitRequest createTaskToggleRequest(
+        String address,
+        J2clSidecarWriteSession session,
+        String blipId,
+        boolean completed,
+        int bodyItemCount,
+        int textStart,
+        int textEnd) {
+      return createTaskToggleRequest(address, session, blipId, completed, bodyItemCount);
+    }
+
     /**
      * F-3.S2 (#1038, R-5.4 step 5): build a stand-alone metadata
      * request for a single blip carrying `task/assignee` + `task/dueTs`.
@@ -426,6 +452,19 @@ public final class J2clComposeSurfaceController {
         int bodyItemCount) {
       throw new UnsupportedOperationException(
           "Task metadata is only available with the rich-content delta factory.");
+    }
+
+    default SidecarSubmitRequest createTaskMetadataRequest(
+        String address,
+        J2clSidecarWriteSession session,
+        String blipId,
+        String assigneeAddress,
+        String dueDate,
+        int bodyItemCount,
+        int textStart,
+        int textEnd) {
+      return createTaskMetadataRequest(
+          address, session, blipId, assigneeAddress, dueDate, bodyItemCount);
     }
 
     /**
@@ -875,10 +914,29 @@ public final class J2clComposeSurfaceController {
           }
 
           @Override
+          public void onTaskToggled(
+              String blipId, boolean completed, int bodyItemCount, int textStart, int textEnd) {
+            J2clComposeSurfaceController.this.onTaskToggled(
+                blipId, completed, bodyItemCount, textStart, textEnd);
+          }
+
+          @Override
           public void onTaskMetadataChanged(
               String blipId, String assigneeAddress, String dueDate, int bodyItemCount) {
             J2clComposeSurfaceController.this.onTaskMetadataChanged(
                 blipId, assigneeAddress, dueDate, bodyItemCount);
+          }
+
+          @Override
+          public void onTaskMetadataChanged(
+              String blipId,
+              String assigneeAddress,
+              String dueDate,
+              int bodyItemCount,
+              int textStart,
+              int textEnd) {
+            J2clComposeSurfaceController.this.onTaskMetadataChanged(
+                blipId, assigneeAddress, dueDate, bodyItemCount, textStart, textEnd);
           }
 
           @Override
@@ -1475,6 +1533,15 @@ public final class J2clComposeSurfaceController {
    */
   public void onTaskToggled(
       final String blipId, final boolean completed, final int bodyItemCount) {
+    onTaskToggled(blipId, completed, bodyItemCount, -1, -1);
+  }
+
+  public void onTaskToggled(
+      final String blipId,
+      final boolean completed,
+      final int bodyItemCount,
+      final int textStart,
+      final int textEnd) {
     if (signedOut) return;
     if (blipId == null || blipId.trim().isEmpty()) return;
     if (!hasSelectedWave(writeSession)) return;
@@ -1497,12 +1564,21 @@ public final class J2clComposeSurfaceController {
           SidecarSubmitRequest request;
           try {
             request =
-                deltaFactory.createTaskToggleRequest(
-                    bootstrap.getAddress(),
-                    writeSession,
-                    trimmedBlipId,
-                    completed,
-                    bodyItemCount);
+                hasValidTaskRange(bodyItemCount, textStart, textEnd)
+                    ? deltaFactory.createTaskToggleRequest(
+                        bootstrap.getAddress(),
+                        writeSession,
+                        trimmedBlipId,
+                        completed,
+                        bodyItemCount,
+                        textStart,
+                        textEnd)
+                    : deltaFactory.createTaskToggleRequest(
+                        bootstrap.getAddress(),
+                        writeSession,
+                        trimmedBlipId,
+                        completed,
+                        bodyItemCount);
           } catch (RuntimeException e) {
             // Toggling a task is best-effort; log telemetry and return.
             recordTaskToggleTelemetry(completed, "failure-build");
@@ -1533,6 +1609,16 @@ public final class J2clComposeSurfaceController {
       final String assigneeAddress,
       final String dueDate,
       final int bodyItemCount) {
+    onTaskMetadataChanged(blipId, assigneeAddress, dueDate, bodyItemCount, -1, -1);
+  }
+
+  public void onTaskMetadataChanged(
+      final String blipId,
+      final String assigneeAddress,
+      final String dueDate,
+      final int bodyItemCount,
+      final int textStart,
+      final int textEnd) {
     if (signedOut) return;
     if (blipId == null || blipId.trim().isEmpty()) return;
     if (!hasSelectedWave(writeSession)) return;
@@ -1556,13 +1642,23 @@ public final class J2clComposeSurfaceController {
           SidecarSubmitRequest request;
           try {
             request =
-                deltaFactory.createTaskMetadataRequest(
-                    bootstrap.getAddress(),
-                    writeSession,
-                    trimmedBlipId,
-                    normalizedAssignee,
-                    normalizedDue,
-                    bodyItemCount);
+                hasValidTaskRange(bodyItemCount, textStart, textEnd)
+                    ? deltaFactory.createTaskMetadataRequest(
+                        bootstrap.getAddress(),
+                        writeSession,
+                        trimmedBlipId,
+                        normalizedAssignee,
+                        normalizedDue,
+                        bodyItemCount,
+                        textStart,
+                        textEnd)
+                    : deltaFactory.createTaskMetadataRequest(
+                        bootstrap.getAddress(),
+                        writeSession,
+                        trimmedBlipId,
+                        normalizedAssignee,
+                        normalizedDue,
+                        bodyItemCount);
           } catch (RuntimeException e) {
             recordTaskMetadataTelemetry("failure-build");
             return;
@@ -1943,6 +2039,10 @@ public final class J2clComposeSurfaceController {
     } catch (Exception ignored) {
       // Telemetry must never affect composer behavior.
     }
+  }
+
+  private static boolean hasValidTaskRange(int bodyItemCount, int textStart, int textEnd) {
+    return bodyItemCount > 0 && textStart >= 0 && textEnd > textStart && textEnd <= bodyItemCount;
   }
 
   public void onWriteSessionChanged(J2clSidecarWriteSession nextWriteSession) {
@@ -2716,6 +2816,19 @@ public final class J2clComposeSurfaceController {
       }
 
       @Override
+      public SidecarSubmitRequest createTaskToggleRequest(
+          String address,
+          J2clSidecarWriteSession session,
+          String blipId,
+          boolean completed,
+          int bodyItemCount,
+          int textStart,
+          int textEnd) {
+        return factory.taskToggleRequest(
+            address, session, blipId, completed, bodyItemCount, textStart, textEnd);
+      }
+
+      @Override
       public SidecarSubmitRequest createTaskMetadataRequest(
           String address,
           J2clSidecarWriteSession session,
@@ -2725,6 +2838,20 @@ public final class J2clComposeSurfaceController {
           int bodyItemCount) {
         return factory.taskMetadataRequest(
             address, session, blipId, assigneeAddress, dueDate, bodyItemCount);
+      }
+
+      @Override
+      public SidecarSubmitRequest createTaskMetadataRequest(
+          String address,
+          J2clSidecarWriteSession session,
+          String blipId,
+          String assigneeAddress,
+          String dueDate,
+          int bodyItemCount,
+          int textStart,
+          int textEnd) {
+        return factory.taskMetadataRequest(
+            address, session, blipId, assigneeAddress, dueDate, bodyItemCount, textStart, textEnd);
       }
 
       @Override

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -239,7 +239,9 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           String blipId = eventDetailString(event, "blipId");
           boolean completed = eventDetailBoolean(event, "completed");
           int bodyItemCount = eventDetailInt(event, "bodySize", 0);
-          listener.onTaskToggled(blipId, completed, bodyItemCount);
+          int textStart = eventDetailInt(event, "textStart", -1);
+          int textEnd = eventDetailInt(event, "textEnd", -1);
+          listener.onTaskToggled(blipId, completed, bodyItemCount, textStart, textEnd);
         });
     DomGlobal.document.body.addEventListener(
         "wave-blip-task-metadata-changed",
@@ -249,7 +251,9 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           String assignee = eventDetailString(event, "assigneeAddress");
           String due = dueDateToEpochMs(eventDetailString(event, "dueDate"));
           int bodyItemCount = eventDetailInt(event, "bodySize", 0);
-          listener.onTaskMetadataChanged(blipId, assignee, due, bodyItemCount);
+          int textStart = eventDetailInt(event, "textStart", -1);
+          int textEnd = eventDetailInt(event, "textEnd", -1);
+          listener.onTaskMetadataChanged(blipId, assignee, due, bodyItemCount, textStart, textEnd);
         });
     DomGlobal.document.body.addEventListener(
         "wavy-composer-mention-picked",

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clInteractionBlipModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clInteractionBlipModel.java
@@ -246,7 +246,9 @@ public final class J2clInteractionBlipModel {
         continue;
       }
       if (range.getStartOffset() == taskIdRange.getStartOffset()
-          && range.getEndOffset() == taskIdRange.getEndOffset()) {
+          && range.getEndOffset() == taskIdRange.getEndOffset()
+          && range.getDocStartOffset() == taskIdRange.getDocStartOffset()
+          && range.getDocEndOffset() == taskIdRange.getDocEndOffset()) {
         exactMatch = safe(range.getValue());
       } else if (range.getDocStartOffset() <= taskIdRange.getDocStartOffset()
           && range.getDocEndOffset() >= taskIdRange.getDocEndOffset()) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clInteractionBlipModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clInteractionBlipModel.java
@@ -186,13 +186,13 @@ public final class J2clInteractionBlipModel {
       }
       tasks.add(
           new J2clTaskItemModel(
-                taskId,
-                taskIdRange.getStartOffset(),
-                taskIdRange.getEndOffset(),
-                "task-" + safe(blipId) + "-" + safe(taskId),
+              taskId,
+              taskIdRange.getDocStartOffset(),
+              taskIdRange.getDocEndOffset(),
+              "task-" + safe(blipId) + "-" + safe(taskId),
               findTaskValue(annotationRanges, "task/assignee", taskIdRange),
               parseLong(findTaskValue(annotationRanges, "task/dueTs", taskIdRange)),
-              false,
+              parseBoolean(findTaskValue(annotationRanges, "task/done", taskIdRange)),
               editable));
     }
     return Collections.unmodifiableList(tasks);
@@ -252,6 +252,10 @@ public final class J2clInteractionBlipModel {
     } catch (NumberFormatException e) {
       return J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP;
     }
+  }
+
+  private static boolean parseBoolean(String value) {
+    return "true".equalsIgnoreCase(safe(value).trim());
   }
 
   private static String safe(String value) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clInteractionBlipModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clInteractionBlipModel.java
@@ -228,7 +228,9 @@ public final class J2clInteractionBlipModel {
         continue;
       }
       if (range.getStartOffset() == taskIdRange.getStartOffset()
-          && range.getEndOffset() == taskIdRange.getEndOffset()) {
+          && range.getEndOffset() == taskIdRange.getEndOffset()
+          && range.getDocStartOffset() == taskIdRange.getDocStartOffset()
+          && range.getDocEndOffset() == taskIdRange.getDocEndOffset()) {
         return safe(range.getValue());
       }
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clInteractionBlipModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clInteractionBlipModel.java
@@ -192,7 +192,7 @@ public final class J2clInteractionBlipModel {
               "task-" + safe(blipId) + "-" + safe(taskId),
               findTaskValue(annotationRanges, "task/assignee", taskIdRange),
               parseLong(findTaskValue(annotationRanges, "task/dueTs", taskIdRange)),
-              parseBoolean(findTaskValue(annotationRanges, "task/done", taskIdRange)),
+              parseBoolean(findTaskDoneValue(annotationRanges, taskIdRange)),
               editable));
     }
     return Collections.unmodifiableList(tasks);
@@ -233,6 +233,27 @@ public final class J2clInteractionBlipModel {
       }
     }
     return "";
+  }
+
+  // task/done may be a body-wide blip annotation while task/id is on a small element range;
+  // exact-range match misses it. Try exact first, then doc-offset containment.
+  private static String findTaskDoneValue(
+      List<SidecarAnnotationRange> annotationRanges, SidecarAnnotationRange taskIdRange) {
+    String exactMatch = "";
+    String containingMatch = "";
+    for (SidecarAnnotationRange range : annotationRanges) {
+      if (range == null || !"task/done".equals(range.getKey())) {
+        continue;
+      }
+      if (range.getStartOffset() == taskIdRange.getStartOffset()
+          && range.getEndOffset() == taskIdRange.getEndOffset()) {
+        exactMatch = safe(range.getValue());
+      } else if (range.getDocStartOffset() <= taskIdRange.getDocStartOffset()
+          && range.getDocEndOffset() >= taskIdRange.getDocEndOffset()) {
+        containingMatch = safe(range.getValue());
+      }
+    }
+    return exactMatch.isEmpty() ? containingMatch : exactMatch;
   }
 
   private static String sliceText(String text, int startOffset, int endOffset) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clInteractionBlipModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clInteractionBlipModel.java
@@ -186,9 +186,10 @@ public final class J2clInteractionBlipModel {
       }
       tasks.add(
           new J2clTaskItemModel(
-              taskId,
-              taskIdRange.getStartOffset(),
-              "task-" + safe(blipId) + "-" + safe(taskId),
+                taskId,
+                taskIdRange.getStartOffset(),
+                taskIdRange.getEndOffset(),
+                "task-" + safe(blipId) + "-" + safe(taskId),
               findTaskValue(annotationRanges, "task/assignee", taskIdRange),
               parseLong(findTaskValue(annotationRanges, "task/dueTs", taskIdRange)),
               false,

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clTaskItemModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/overlay/J2clTaskItemModel.java
@@ -5,6 +5,7 @@ public final class J2clTaskItemModel {
 
   private final String taskId;
   private final int textOffset;
+  private final int endOffset;
   private final String elementAnchorId;
   private final String assigneeAddress;
   private final long dueTimestamp;
@@ -14,6 +15,7 @@ public final class J2clTaskItemModel {
   public J2clTaskItemModel(
       String taskId,
       int textOffset,
+      int endOffset,
       String elementAnchorId,
       String assigneeAddress,
       long dueTimestamp,
@@ -21,6 +23,7 @@ public final class J2clTaskItemModel {
       boolean editable) {
     this.taskId = taskId == null ? "" : taskId;
     this.textOffset = Math.max(0, textOffset);
+    this.endOffset = Math.max(this.textOffset, endOffset);
     this.elementAnchorId = elementAnchorId == null ? "" : elementAnchorId;
     this.assigneeAddress = assigneeAddress == null ? "" : assigneeAddress;
     this.dueTimestamp = dueTimestamp;
@@ -34,6 +37,10 @@ public final class J2clTaskItemModel {
 
   public int getTextOffset() {
     return textOffset;
+  }
+
+  public int getEndOffset() {
+    return endOffset;
   }
 
   public String getElementAnchorId() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1646,7 +1646,7 @@ public final class J2clReadSurfaceDomRenderer {
       // (task/assignee or task/dueTs) without a task/done annotation — isTask()
       // only returns true when task/done is present, so we must also check metadata.
       boolean hasLegacyMetadata = !blip.getTaskAssignee().isEmpty()
-          || blip.getTaskDueTimestamp() != 0;
+          || blip.getTaskDueTimestamp() > 0;
       if (!blip.isTask() && !hasLegacyMetadata) {
         return null;
       }
@@ -2004,7 +2004,7 @@ public final class J2clReadSurfaceDomRenderer {
     // freshly-created <wave-blip> element. Also set for metadata-only blips (assignee /
     // due-date present but no task/done annotation), since isTask() is false for those.
     String assignee = taskAssignee == null ? "" : taskAssignee.trim();
-    if (isTask || taskDone || !assignee.isEmpty() || taskDueTimestamp != 0) {
+    if (isTask || taskDone || !assignee.isEmpty() || taskDueTimestamp > 0) {
       element.setAttribute("data-task-present", "");
     } else {
       element.removeAttribute("data-task-present");

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1642,7 +1642,12 @@ public final class J2clReadSurfaceDomRenderer {
     if (tasks == null || tasks.isEmpty()) {
       // Legacy task blip: has task/done annotation but no task/id ranges. Render a
       // single affordance without task-id so the toggle button remains usable.
-      if (!blip.isTask()) {
+      // Also preserve affordance for blips that only carry legacy task metadata
+      // (task/assignee or task/dueTs) without a task/done annotation — isTask()
+      // only returns true when task/done is present, so we must also check metadata.
+      boolean hasLegacyMetadata = !blip.getTaskAssignee().isEmpty()
+          || blip.getTaskDueTimestamp() != 0;
+      if (!blip.isTask() && !hasLegacyMetadata) {
         return null;
       }
       HTMLElement list = (HTMLElement) DomGlobal.document.createElement("div");
@@ -1996,8 +2001,10 @@ public final class J2clReadSurfaceDomRenderer {
     // data-task-present survives a full DOM rebuild (renderWindow clears host.innerHTML).
     // Without it a reopened task blip with no assignee/due-date would lose the affordance
     // because all three task attributes are absent and _taskPresent stays false on the
-    // freshly-created <wave-blip> element.
-    if (isTask || taskDone) {
+    // freshly-created <wave-blip> element. Also set for metadata-only blips (assignee /
+    // due-date present but no task/done annotation), since isTask() is false for those.
+    String assignee = taskAssignee == null ? "" : taskAssignee.trim();
+    if (isTask || taskDone || !assignee.isEmpty() || taskDueTimestamp != 0) {
       element.setAttribute("data-task-present", "");
     } else {
       element.removeAttribute("data-task-present");
@@ -2007,7 +2014,6 @@ public final class J2clReadSurfaceDomRenderer {
     } else {
       element.removeAttribute("data-task-completed");
     }
-    String assignee = taskAssignee == null ? "" : taskAssignee.trim();
     if (assignee.isEmpty()) {
       element.removeAttribute("data-task-assignee");
     } else {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1669,7 +1669,7 @@ public final class J2clReadSurfaceDomRenderer {
       affordance.setAttribute("data-task-start", String.valueOf(task.getTextOffset()));
       affordance.setAttribute("data-task-end", String.valueOf(task.getEndOffset()));
       affordance.setAttribute("data-task-anchor-id", task.getElementAnchorId());
-      if (blip.isTaskDone()) {
+      if (task.isChecked()) {
         affordance.setAttribute("data-task-completed", "");
       }
       if (!task.getAssigneeAddress().isEmpty()) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1624,7 +1624,36 @@ public final class J2clReadSurfaceDomRenderer {
         ? Collections.<J2clTaskItemModel>emptyList()
         : taskBinder.tasksFor(blip.getBlipId());
     if (tasks == null || tasks.isEmpty()) {
-      return null;
+      // Legacy task blip: has task/done annotation but no task/id ranges. Render a
+      // single affordance without task-id so the toggle button remains usable.
+      if (!blip.isTask()) {
+        return null;
+      }
+      HTMLElement list = (HTMLElement) DomGlobal.document.createElement("div");
+      list.className = "j2cl-read-task-affordances";
+      list.setAttribute("data-task-affordance-list", "");
+      list.setAttribute("slot", "blip-extension");
+      HTMLElement affordance = (HTMLElement) DomGlobal.document.createElement("wavy-task-affordance");
+      affordance.setAttribute("data-blip-id", blip.getBlipId());
+      if (blip.isTaskDone()) {
+        affordance.setAttribute("data-task-completed", "");
+      }
+      if (!blip.getTaskAssignee().isEmpty()) {
+        affordance.setAttribute("data-task-assignee", blip.getTaskAssignee());
+      }
+      String legacyDueDate = formatDueDate(blip.getTaskDueTimestamp());
+      if (!legacyDueDate.isEmpty()) {
+        affordance.setAttribute("data-task-due-date", legacyDueDate);
+      }
+      if (blip.getBodyItemCount() > 0) {
+        affordance.setAttribute("data-blip-doc-size", String.valueOf(blip.getBodyItemCount()));
+      }
+      String legacyWaveId = currentWaveId();
+      if (!legacyWaveId.isEmpty()) {
+        affordance.setAttribute("data-wave-id", legacyWaveId);
+      }
+      list.appendChild(affordance);
+      return list;
     }
     HTMLElement list = (HTMLElement) DomGlobal.document.createElement("div");
     list.className = "j2cl-read-task-affordances";
@@ -1640,7 +1669,7 @@ public final class J2clReadSurfaceDomRenderer {
       affordance.setAttribute("data-task-start", String.valueOf(task.getTextOffset()));
       affordance.setAttribute("data-task-end", String.valueOf(task.getEndOffset()));
       affordance.setAttribute("data-task-anchor-id", task.getElementAnchorId());
-      if (task.isChecked()) {
+      if (blip.isTaskDone()) {
         affordance.setAttribute("data-task-completed", "");
       }
       if (!task.getAssigneeAddress().isEmpty()) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -1559,10 +1559,26 @@ public final class J2clReadSurfaceDomRenderer {
     // also consults the optimistic-toggle registry so a self-initiated
     // toggle that is still in flight is preserved across unrelated
     // live updates.
+    // When per-task affordances exist, only mark the host done if ALL tasks
+    // are checked; a single checked task must not apply line-through to the
+    // entire blip body.
+    boolean effectiveTaskDone = blip.isTaskDone();
+    if (taskBinder != null) {
+      List<J2clTaskItemModel> blipTasks = taskBinder.tasksFor(blip.getBlipId());
+      if (blipTasks != null && !blipTasks.isEmpty()) {
+        effectiveTaskDone = true;
+        for (J2clTaskItemModel t : blipTasks) {
+          if (!t.isChecked()) {
+            effectiveTaskDone = false;
+            break;
+          }
+        }
+      }
+    }
     applyTaskState(
         element,
         blip.getBlipId(),
-        blip.isTaskDone(),
+        effectiveTaskDone,
         blip.getTaskAssignee(),
         blip.getTaskDueTimestamp(),
         blip.getBodyItemCount(),

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -126,6 +126,11 @@ public final class J2clReadSurfaceDomRenderer {
     List<J2clMentionRange> mentionsFor(String blipId);
   }
 
+  @FunctionalInterface
+  public interface TaskBinder {
+    List<J2clTaskItemModel> tasksFor(String blipId);
+  }
+
   /** Test seam for the dwell-timer scheduler so unit tests can swap a fake clock. */
   public interface DwellTimerScheduler {
     /**
@@ -161,6 +166,7 @@ public final class J2clReadSurfaceDomRenderer {
   // wiring yet" — the row is still mounted as an empty add-only state.
   private ReactionBinder reactionBinder;
   private MentionBinder mentionBinder;
+  private TaskBinder taskBinder;
   // J-UI-4 (#1082, R-3.1): conversation manifest for the current wave.
   // Set by the view layer before each render call. The renderer uses
   // this to graft parent-blip-id / thread-id onto each blip in the
@@ -261,6 +267,10 @@ public final class J2clReadSurfaceDomRenderer {
 
   public void setMentionBinder(MentionBinder binder) {
     this.mentionBinder = binder;
+  }
+
+  public void setTaskBinder(TaskBinder binder) {
+    this.taskBinder = binder;
   }
 
   /**
@@ -1580,6 +1590,11 @@ public final class J2clReadSurfaceDomRenderer {
         blip.getInlineReplyAnchors());
     element.appendChild(content);
 
+    HTMLElement taskList = renderTaskAffordances(blip);
+    if (taskList != null) {
+      element.appendChild(taskList);
+    }
+
     if (!blip.getAttachments().isEmpty()) {
       HTMLElement attachments = (HTMLElement) DomGlobal.document.createElement("div");
       attachments.className = "j2cl-read-attachments";
@@ -1602,6 +1617,52 @@ public final class J2clReadSurfaceDomRenderer {
     setProperty(reactionRow, "reactions", buildReactionsArray(blip.getBlipId()));
     element.appendChild(reactionRow);
     return element;
+  }
+
+  private HTMLElement renderTaskAffordances(J2clReadBlip blip) {
+    List<J2clTaskItemModel> tasks = taskBinder == null
+        ? Collections.<J2clTaskItemModel>emptyList()
+        : taskBinder.tasksFor(blip.getBlipId());
+    if (tasks == null || tasks.isEmpty()) {
+      return null;
+    }
+    HTMLElement list = (HTMLElement) DomGlobal.document.createElement("div");
+    list.className = "j2cl-read-task-affordances";
+    list.setAttribute("data-task-affordance-list", "");
+    list.setAttribute("slot", "blip-extension");
+    for (J2clTaskItemModel task : tasks) {
+      if (task == null || task.getTaskId().isEmpty()) {
+        continue;
+      }
+      HTMLElement affordance = (HTMLElement) DomGlobal.document.createElement("wavy-task-affordance");
+      affordance.setAttribute("data-blip-id", blip.getBlipId());
+      affordance.setAttribute("data-task-id", task.getTaskId());
+      affordance.setAttribute("data-task-start", String.valueOf(task.getTextOffset()));
+      affordance.setAttribute("data-task-end", String.valueOf(task.getEndOffset()));
+      affordance.setAttribute("data-task-anchor-id", task.getElementAnchorId());
+      if (task.isChecked()) {
+        affordance.setAttribute("data-task-completed", "");
+      }
+      if (!task.getAssigneeAddress().isEmpty()) {
+        affordance.setAttribute("data-task-assignee", task.getAssigneeAddress());
+      }
+      String dueDate = formatDueDate(task.getDueTimestamp());
+      if (!dueDate.isEmpty()) {
+        affordance.setAttribute("data-task-due-date", dueDate);
+      }
+      if (blip.getBodyItemCount() > 0) {
+        affordance.setAttribute("data-blip-doc-size", String.valueOf(blip.getBodyItemCount()));
+      }
+      String waveId = currentWaveId();
+      if (!waveId.isEmpty()) {
+        affordance.setAttribute("data-wave-id", waveId);
+      }
+      setProperty(affordance, "taskId", task.getTaskId());
+      setProperty(affordance, "textStart", task.getTextOffset());
+      setProperty(affordance, "textEnd", task.getEndOffset());
+      list.appendChild(affordance);
+    }
+    return list.childElementCount == 0 ? null : list;
   }
 
   private static void applyInlineReplyAnchorState(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -152,6 +152,25 @@ public final class J2clRichContentDeltaFactory {
         bodyItemCount);
   }
 
+  public SidecarSubmitRequest taskToggleRequest(
+      String address,
+      J2clSidecarWriteSession session,
+      String blipId,
+      boolean completed,
+      int bodyItemCount,
+      int textStart,
+      int textEnd) {
+    return buildBlipAnnotationRequest(
+        address,
+        session,
+        blipId,
+        new String[] {"task/done"},
+        new String[] {completed ? "true" : "false"},
+        bodyItemCount,
+        textStart,
+        textEnd);
+  }
+
   /**
    * F-3.S2 (#1038, R-5.4 step 5): build a stand-alone delta that
    * writes the `task/assignee` and `task/dueTs` annotations on the blip.
@@ -201,6 +220,28 @@ public final class J2clRichContentDeltaFactory {
         new String[] {"task/assignee", "task/dueTs"},
         new String[] {assignee, due},
         bodyItemCount);
+  }
+
+  public SidecarSubmitRequest taskMetadataRequest(
+      String address,
+      J2clSidecarWriteSession session,
+      String blipId,
+      String assigneeAddress,
+      String dueDate,
+      int bodyItemCount,
+      int textStart,
+      int textEnd) {
+    String assignee = assigneeAddress == null ? "" : assigneeAddress.trim();
+    String due = normalizeDueTimestamp(dueDate);
+    return buildBlipAnnotationRequest(
+        address,
+        session,
+        blipId,
+        new String[] {"task/assignee", "task/dueTs"},
+        new String[] {assignee, due},
+        bodyItemCount,
+        textStart,
+        textEnd);
   }
 
   /**
@@ -847,11 +888,86 @@ public final class J2clRichContentDeltaFactory {
     return new SidecarSubmitRequest(buildWaveletName(selectedWaveId), deltaJson, channelId);
   }
 
+  private SidecarSubmitRequest buildBlipAnnotationRequest(
+      String address,
+      J2clSidecarWriteSession session,
+      String blipId,
+      String[] keys,
+      String[] values,
+      int bodyItemCount,
+      int textStart,
+      int textEnd) {
+    requirePresent(session, "Missing write session.");
+    if (keys == null || values == null || keys.length != values.length || keys.length == 0) {
+      throw new IllegalArgumentException("Mismatched annotation keys/values.");
+    }
+    String normalizedAddress = normalizeAddress(address);
+    extractDomain(normalizedAddress);
+    String selectedWaveId =
+        requireNonEmpty(session.getSelectedWaveId(), "Missing selected wave id.");
+    String historyHash =
+        requireNonEmpty(session.getHistoryHash(), "Missing write-session history hash.");
+    String channelId = requireNonEmpty(session.getChannelId(), "Missing write-session channel id.");
+    String documentId = requireNonEmpty(blipId, "Missing blip id.");
+    long baseVersion = session.getBaseVersion();
+    if (baseVersion < 0) {
+      throw new IllegalArgumentException("Invalid write-session base version.");
+    }
+    int retainedBodyItemCount = requirePositiveBodyItemCount(bodyItemCount);
+    requireTaskRange(textStart, textEnd, retainedBodyItemCount);
+    StringBuilder components = new StringBuilder();
+    if (textStart > 0) {
+      appendRetain(components, textStart);
+      appendComponentSeparator(components);
+    }
+    components.append("{\"1\":{\"3\":[");
+    for (int i = 0; i < keys.length; i++) {
+      if (i > 0) components.append(",");
+      components
+          .append("{\"1\":\"")
+          .append(escapeJson(keys[i]))
+          .append("\",\"3\":\"")
+          .append(escapeJson(values[i]))
+          .append("\"}");
+    }
+    components.append("]}}");
+    appendComponentSeparator(components);
+    appendRetain(components, textEnd - textStart);
+    appendComponentSeparator(components);
+    components.append("{\"1\":{\"2\":[");
+    for (int i = 0; i < keys.length; i++) {
+      if (i > 0) components.append(",");
+      components.append("\"").append(escapeJson(keys[i])).append("\"");
+    }
+    components.append("]}}");
+    int trailingRetain = retainedBodyItemCount - textEnd;
+    if (trailingRetain > 0) {
+      appendComponentSeparator(components);
+      appendRetain(components, trailingRetain);
+    }
+    StringBuilder operation = new StringBuilder(components.length() + documentId.length() + 32);
+    operation
+        .append("{\"3\":{\"1\":\"")
+        .append(escapeJson(documentId))
+        .append("\",\"2\":{\"1\":[")
+        .append(components)
+        .append("]}}}");
+    String deltaJson =
+        buildDeltaJson(baseVersion, historyHash, normalizedAddress, operation.toString());
+    return new SidecarSubmitRequest(buildWaveletName(selectedWaveId), deltaJson, channelId);
+  }
+
   private static int requirePositiveBodyItemCount(int bodyItemCount) {
     if (bodyItemCount <= 0) {
       throw new IllegalArgumentException("Missing blip body item count.");
     }
     return bodyItemCount;
+  }
+
+  private static void requireTaskRange(int textStart, int textEnd, int bodyItemCount) {
+    if (textStart < 0 || textEnd <= textStart || textEnd > bodyItemCount) {
+      throw new IllegalArgumentException("Invalid task annotation range.");
+    }
   }
 
   private static IllegalArgumentException missingBodyItemCount(String methodName) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -23,6 +23,7 @@ import jsinterop.base.JsPropertyMap;
 import org.waveprotocol.box.j2cl.overlay.J2clInteractionBlipModel;
 import org.waveprotocol.box.j2cl.overlay.J2clMentionRange;
 import org.waveprotocol.box.j2cl.overlay.J2clReactionSummary;
+import org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 import org.waveprotocol.box.j2cl.read.J2clReadSurfaceDomRenderer;
 import org.waveprotocol.box.j2cl.read.J2clReadWindowEntry;
@@ -718,8 +719,11 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     detail.hidden = !model.isError();
     renderParticipantStrip(model.getParticipantIds());
     publishProfileOverlayParticipants(model.getParticipantIds());
-    snippet.textContent = model.getSnippetText();
-    snippet.hidden = model.getSnippetText().isEmpty();
+    // GWT keeps digest/root preview text inside the root blip, not as a
+    // separate selected-wave header line. Hide the J2CL header snippet so task
+    // text and root content do not appear above the read surface.
+    snippet.textContent = "";
+    snippet.hidden = true;
 
     // J-UI-4 (#1082, R-3.1): publish the conversation manifest before
     // each render pass so the renderer's renderWindow path can graft
@@ -735,6 +739,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     List<J2clReadWindowEntry> readWindowEntries =
         J2clSelectedWaveProjector.enrichWindowEntriesFromReadBlips(
             model.getViewportState().getReadWindowEntries(), model.getReadBlips());
+    publishTaskBinder(model);
     boolean hasViewportReadWindow = !readWindowEntries.isEmpty();
     boolean hasRenderedReadSurface =
         hasViewportReadWindow
@@ -772,6 +777,24 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
             model.getSelectedWaveId() != null && !model.getSelectedWaveId().isEmpty());
       }
     }
+  }
+
+  private void publishTaskBinder(J2clSelectedWaveModel model) {
+    Map<String, List<J2clTaskItemModel>> tasksByBlip =
+        new LinkedHashMap<String, List<J2clTaskItemModel>>();
+    if (model != null) {
+      for (J2clInteractionBlipModel blip : model.getInteractionBlips()) {
+        if (blip == null || blip.getBlipId().isEmpty() || blip.getTaskItems().isEmpty()) {
+          continue;
+        }
+        tasksByBlip.put(blip.getBlipId(), blip.getTaskItems());
+      }
+    }
+    readSurface.setTaskBinder(
+        blipId -> {
+          List<J2clTaskItemModel> tasks = tasksByBlip.get(blipId);
+          return tasks == null ? Collections.<J2clTaskItemModel>emptyList() : tasks;
+        });
   }
 
   private void clearWaveHeaderActions() {
@@ -851,6 +874,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       participant.set("id", address);
       participant.set("displayName", address);
       participant.set("avatarToken", participantInitials(address));
+      participant.set("avatarUrl", participantProfileImageUrl(address));
       participants.push(participant);
     }
     return participants;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarAnnotationRange.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarAnnotationRange.java
@@ -5,12 +5,26 @@ public final class SidecarAnnotationRange {
   private final String value;
   private final int startOffset;
   private final int endOffset;
+  private final int docStartOffset;
+  private final int docEndOffset;
 
   public SidecarAnnotationRange(String key, String value, int startOffset, int endOffset) {
+    this(key, value, startOffset, endOffset, startOffset, endOffset);
+  }
+
+  public SidecarAnnotationRange(
+      String key,
+      String value,
+      int startOffset,
+      int endOffset,
+      int docStartOffset,
+      int docEndOffset) {
     this.key = key == null ? "" : key;
     this.value = value == null ? "" : value;
     this.startOffset = Math.max(0, startOffset);
     this.endOffset = Math.max(this.startOffset, endOffset);
+    this.docStartOffset = Math.max(0, docStartOffset);
+    this.docEndOffset = Math.max(this.docStartOffset, docEndOffset);
   }
 
   public String getKey() {
@@ -27,6 +41,16 @@ public final class SidecarAnnotationRange {
 
   public int getEndOffset() {
     return endOffset;
+  }
+
+  /** DocOp item-count offset for the annotation start (suitable for retain counts). */
+  public int getDocStartOffset() {
+    return docStartOffset;
+  }
+
+  /** DocOp item-count offset for the annotation end (suitable for retain counts). */
+  public int getDocEndOffset() {
+    return docEndOffset;
   }
 
   public boolean isMention() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -533,6 +533,7 @@ public final class SidecarTransportCodec {
         processAnnotationBoundary(
             getOptionalObject(component, "1"),
             text.length(),
+            bodyItemCount,
             activeAnnotations,
             annotationRanges);
         continue;
@@ -584,7 +585,7 @@ public final class SidecarTransportCodec {
         }
       }
     }
-    closeAllAnnotations(text.length(), activeAnnotations, annotationRanges);
+    closeAllAnnotations(text.length(), bodyItemCount, activeAnnotations, annotationRanges);
     return new DocumentExtraction(
         text.toString(),
         bodyItemCount,
@@ -595,13 +596,15 @@ public final class SidecarTransportCodec {
 
   private static void processAnnotationBoundary(
       Map<String, Object> boundary,
-      int offset,
+      int textOffset,
+      int docOffset,
       Map<String, ActiveAnnotation> activeAnnotations,
       List<SidecarAnnotationRange> annotationRanges) {
     Object rawEnds = boundary.get("2");
     if (rawEnds != null) {
       for (Object rawEnd : asList(rawEnds)) {
-        closeAnnotation(String.valueOf(rawEnd), offset, activeAnnotations, annotationRanges);
+        closeAnnotation(
+            String.valueOf(rawEnd), textOffset, docOffset, activeAnnotations, annotationRanges);
       }
     }
     Object rawChanges = boundary.get("3");
@@ -615,36 +618,40 @@ public final class SidecarTransportCodec {
         continue;
       }
       if (activeAnnotations.containsKey(key)) {
-        closeAnnotation(key, offset, activeAnnotations, annotationRanges);
+        closeAnnotation(key, textOffset, docOffset, activeAnnotations, annotationRanges);
       }
       String newValue = getString(change, "3");
       if (newValue != null) {
-        activeAnnotations.put(key, new ActiveAnnotation(newValue, offset));
+        activeAnnotations.put(key, new ActiveAnnotation(newValue, textOffset, docOffset));
       }
     }
   }
 
   private static void closeAllAnnotations(
-      int offset,
+      int textOffset,
+      int docOffset,
       Map<String, ActiveAnnotation> activeAnnotations,
       List<SidecarAnnotationRange> annotationRanges) {
     List<String> activeKeys = new ArrayList<String>(activeAnnotations.keySet());
     for (String key : activeKeys) {
-      closeAnnotation(key, offset, activeAnnotations, annotationRanges);
+      closeAnnotation(key, textOffset, docOffset, activeAnnotations, annotationRanges);
     }
   }
 
   private static void closeAnnotation(
       String key,
-      int offset,
+      int textOffset,
+      int docOffset,
       Map<String, ActiveAnnotation> activeAnnotations,
       List<SidecarAnnotationRange> annotationRanges) {
     ActiveAnnotation active = activeAnnotations.remove(key);
-    if (active == null || offset <= active.startOffset) {
+    if (active == null || textOffset <= active.startOffset) {
       return;
     }
     annotationRanges.add(
-        new SidecarAnnotationRange(key, active.value, active.startOffset, offset));
+        new SidecarAnnotationRange(
+            key, active.value, active.startOffset, textOffset,
+            active.docStartOffset, docOffset));
   }
 
   private static String getAttribute(Map<String, Object> elementStart, String name) {
@@ -682,10 +689,12 @@ public final class SidecarTransportCodec {
   private static final class ActiveAnnotation {
     private final String value;
     private final int startOffset;
+    private final int docStartOffset;
 
-    ActiveAnnotation(String value, int startOffset) {
+    ActiveAnnotation(String value, int startOffset, int docStartOffset) {
       this.value = value;
       this.startOffset = startOffset;
+      this.docStartOffset = docStartOffset;
     }
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -645,7 +645,7 @@ public final class SidecarTransportCodec {
       Map<String, ActiveAnnotation> activeAnnotations,
       List<SidecarAnnotationRange> annotationRanges) {
     ActiveAnnotation active = activeAnnotations.remove(key);
-    if (active == null || textOffset <= active.startOffset) {
+    if (active == null || (textOffset <= active.startOffset && docOffset <= active.docStartOffset)) {
       return;
     }
     annotationRanges.add(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/overlay/J2clOverlayModelTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/overlay/J2clOverlayModelTest.java
@@ -144,6 +144,29 @@ public class J2clOverlayModelTest {
   }
 
   @Test
+  public void elementBackedTaskWithBodyWideDoneAnnotationIsChecked() {
+    // task/id on element range (text [0,0], doc [5,6]); task/done is body-wide (text [0,10], doc [0,20]).
+    // Exact-range match misses task/done; containment match must find it.
+    J2clInteractionBlipModel blip =
+        new J2clInteractionBlipModel(
+            "b+task",
+            "b+task",
+            "author@example.com",
+            "task text here",
+            Arrays.asList("author@example.com"),
+            true,
+            Arrays.asList(
+                new SidecarAnnotationRange("task/id", "tid-1", 0, 0, 5, 6),
+                new SidecarAnnotationRange("task/done", "true", 0, 10, 0, 20)),
+            Collections.<SidecarReactionEntry>emptyList());
+
+    Assert.assertEquals(1, blip.getTaskItems().size());
+    Assert.assertTrue(
+        "element-backed task with body-wide task/done=true must be checked",
+        blip.getTaskItems().get(0).isChecked());
+  }
+
+  @Test
   public void interactionBlipRejectsManualLinkAddressAsMentionRange() {
     J2clInteractionBlipModel blip =
         new J2clInteractionBlipModel(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/overlay/J2clOverlayModelTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/overlay/J2clOverlayModelTest.java
@@ -123,6 +123,7 @@ public class J2clOverlayModelTest {
             Arrays.asList(
                 new SidecarAnnotationRange("mention/user", "alice@example.com", 3, 99),
                 new SidecarAnnotationRange("task/id", "task-123", 0, 2),
+                new SidecarAnnotationRange("task/done", "true", 0, 2),
                 null),
             Arrays.asList(
                 new SidecarReactionEntry("tada", Arrays.asList("alice@example.com")),
@@ -137,6 +138,7 @@ public class J2clOverlayModelTest {
     Assert.assertEquals(
         J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP,
         blip.getTaskItems().get(0).getDueTimestamp());
+    Assert.assertTrue(blip.getTaskItems().get(0).isChecked());
     Assert.assertEquals(1, blip.getReactionSummaries().size());
     Assert.assertEquals("tada", blip.getReactionSummaries().get(0).getEmoji());
   }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/overlay/J2clOverlayModelTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/overlay/J2clOverlayModelTest.java
@@ -61,7 +61,7 @@ public class J2clOverlayModelTest {
   @Test
   public void taskItemAndFocusTargetNormalizeNullValues() {
     J2clTaskItemModel task =
-        new J2clTaskItemModel(null, -4, null, null, 123L, true, false);
+        new J2clTaskItemModel(null, -4, -2, null, null, 123L, true, false);
     J2clOverlayFocusTarget target = new J2clOverlayFocusTarget(null);
 
     Assert.assertEquals("", task.getTaskId());
@@ -251,7 +251,7 @@ public class J2clOverlayModelTest {
     }
     try {
       blip.getTaskItems().add(
-          new J2clTaskItemModel("task-1", 0, "task-1", "", -1L, false, false));
+          new J2clTaskItemModel("task-1", 0, 4, "task-1", "", -1L, false, false));
       Assert.fail("task items should be immutable");
     } catch (UnsupportedOperationException expected) {
       // Expected immutable-list contract.

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadata;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
 import org.waveprotocol.box.j2cl.overlay.J2clMentionRange;
+import org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel;
 import org.waveprotocol.box.j2cl.telemetry.J2clClientTelemetry;
 import org.waveprotocol.box.j2cl.telemetry.RecordingTelemetrySink;
 import org.waveprotocol.box.j2cl.transport.SidecarConversationManifest;
@@ -805,6 +806,57 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertTrue(
         "reopened task must carry data-task-present so Lit can keep affordance mounted",
         element.hasAttribute("data-task-present"));
+  }
+
+  @Test
+  public void renderWindowUsesPerTaskCheckedStateForTaskAffordances() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    renderer.setTaskBinder(
+        blipId ->
+            "b+task".equals(blipId)
+                ? Arrays.asList(
+                    new J2clTaskItemModel(
+                        "task-1",
+                        0,
+                        4,
+                        "task-b-task-task-1",
+                        "",
+                        J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP,
+                        true,
+                        true))
+                : Collections.<J2clTaskItemModel>emptyList());
+    J2clReadWindowEntry task =
+        J2clReadWindowEntry.loadedWithTaskMetadata(
+            "blip:b+task",
+            0L,
+            12L,
+            "b+task",
+            "Task body",
+            Collections.<J2clAttachmentRenderModel>emptyList(),
+            "alice@example.com",
+            "alice@example.com",
+            1714240000000L,
+            "",
+            "",
+            /* unread= */ false,
+            /* hasMention= */ false,
+            /* taskDone= */ false,
+            /* taskAssignee= */ "",
+            /* taskDueTimestamp= */ J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP,
+            /* bodyItemCount= */ 9,
+            /* isTask= */ true);
+
+    Assert.assertTrue(renderer.renderWindow(Arrays.asList(task)));
+
+    HTMLElement affordance =
+        (HTMLElement) blip(host, "b+task").querySelector("wavy-task-affordance");
+    Assert.assertNotNull(affordance);
+    Assert.assertEquals("task-1", affordance.getAttribute("data-task-id"));
+    Assert.assertEquals("0", affordance.getAttribute("data-task-start"));
+    Assert.assertEquals("4", affordance.getAttribute("data-task-end"));
+    Assert.assertTrue(affordance.hasAttribute("data-task-completed"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
@@ -643,6 +643,73 @@ public class J2clRichContentDeltaFactoryTest {
   }
 
   @Test
+  public void taskToggleRequestCanTargetSingleTaskRange() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+x", "chan-1", 0L, "ZERO", "b+root");
+    String deltaJson =
+        factory
+            .taskToggleRequest(
+                "user@example.com", session, "b+root", true, TEST_BODY_ITEM_COUNT, 2, 5)
+            .getDeltaJson();
+    assertContains(
+        deltaJson,
+        "{\"5\":2}",
+        "{\"1\":{\"3\":[{\"1\":\"task/done\",\"3\":\"true\"}]}}",
+        "{\"5\":3}",
+        "{\"1\":{\"2\":[\"task/done\"]}}",
+        "{\"5\":" + (TEST_BODY_ITEM_COUNT - 5) + "}");
+    assertRangeAnnotationShape(deltaJson, 2, 3, TEST_BODY_ITEM_COUNT - 5);
+  }
+
+  @Test
+  public void taskToggleRequestCanTargetTaskAtOffsetZero() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+x", "chan-1", 0L, "ZERO", "b+root");
+    String deltaJson =
+        factory
+            .taskToggleRequest(
+                "user@example.com", session, "b+root", true, TEST_BODY_ITEM_COUNT, 0, 4)
+            .getDeltaJson();
+    int annotationOpen = deltaJson.indexOf("{\"1\":{\"3\":[");
+    int annotatedRetain = deltaJson.indexOf("{\"5\":4}", annotationOpen);
+    int annotationClose = deltaJson.indexOf("{\"1\":{\"2\":[\"task/done\"]}}", annotatedRetain);
+    Assert.assertTrue("Missing annotation open in JSON: " + deltaJson, annotationOpen >= 0);
+    Assert.assertTrue(
+        "Missing annotated retain after open: " + deltaJson, annotatedRetain > annotationOpen);
+    Assert.assertTrue(
+        "Missing annotation close after retain: " + deltaJson,
+        annotationClose > annotatedRetain);
+    Assert.assertFalse(
+        "Offset-zero range must not emit a leading retain: " + deltaJson,
+        deltaJson.substring(0, annotationOpen).contains("{\"5\":"));
+  }
+
+  @Test
+  public void taskToggleRequestRejectsInvalidTaskRange() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+x", "chan-1", 0L, "ZERO", "b+root");
+    assertThrowsWithMessage(
+        "Invalid task annotation range.",
+        () ->
+            factory.taskToggleRequest(
+                "user@example.com", session, "b+root", true, TEST_BODY_ITEM_COUNT, 5, 2));
+    assertThrowsWithMessage(
+        "Invalid task annotation range.",
+        () ->
+            factory.taskToggleRequest(
+                "user@example.com",
+                session,
+                "b+root",
+                true,
+                TEST_BODY_ITEM_COUNT,
+                0,
+                TEST_BODY_ITEM_COUNT + 1));
+  }
+
+  @Test
   public void taskToggleRequestRejectsBlankBlipId() {
     J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
     J2clSidecarWriteSession session =
@@ -831,6 +898,34 @@ public class J2clRichContentDeltaFactoryTest {
         "{\"5\":" + TEST_BODY_ITEM_COUNT + "}",
         "{\"1\":{\"2\":[\"task/assignee\",\"task/dueTs\"]}}");
     assertAnnotationBoundaryRetainShape(deltaJson, TEST_BODY_ITEM_COUNT);
+  }
+
+  @Test
+  public void taskMetadataRequestCanTargetSingleTaskRange() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession("example.com/w+x", "chan-2", 5L, "HASH", "b+root");
+    String deltaJson =
+        factory
+            .taskMetadataRequest(
+                "user@example.com",
+                session,
+                "b+root",
+                "alice@example.com",
+                "2026-05-15",
+                TEST_BODY_ITEM_COUNT,
+                1,
+                4)
+            .getDeltaJson();
+    assertContains(
+        deltaJson,
+        "{\"5\":1}",
+        "{\"1\":\"task/assignee\",\"3\":\"alice@example.com\"}",
+        "{\"1\":\"task/dueTs\",\"3\":\"1778803200000\"}",
+        "{\"5\":3}",
+        "{\"1\":{\"2\":[\"task/assignee\",\"task/dueTs\"]}}",
+        "{\"5\":" + (TEST_BODY_ITEM_COUNT - 4) + "}");
+    assertRangeAnnotationShape(deltaJson, 1, 3, TEST_BODY_ITEM_COUNT - 4);
   }
 
   // PR #1066 review thread PRRT_kwDOBwxLXs593gTP — explicit
@@ -1185,6 +1280,20 @@ public class J2clRichContentDeltaFactoryTest {
     Assert.assertFalse(
         "Annotation boundaries must not remain adjacent: " + deltaJson,
         betweenOpenAndClose.endsWith("]}}},"));
+  }
+
+  private static void assertRangeAnnotationShape(
+      String deltaJson, int leadingRetain, int annotatedRetain, int trailingRetain) {
+    int leading = deltaJson.indexOf("{\"5\":" + leadingRetain + "}");
+    int annotationOpen = deltaJson.indexOf("{\"1\":{\"3\":[", leading);
+    int annotated = deltaJson.indexOf("{\"5\":" + annotatedRetain + "}", annotationOpen);
+    int annotationClose = deltaJson.indexOf("{\"1\":{\"2\":[", annotated);
+    int trailing = deltaJson.indexOf("{\"5\":" + trailingRetain + "}", annotationClose);
+    Assert.assertTrue("Missing leading retain in JSON: " + deltaJson, leading >= 0);
+    Assert.assertTrue("Missing annotation open after leading retain: " + deltaJson, annotationOpen > leading);
+    Assert.assertTrue("Missing annotated retain after open: " + deltaJson, annotated > annotationOpen);
+    Assert.assertTrue("Missing annotation close after retain: " + deltaJson, annotationClose > annotated);
+    Assert.assertTrue("Missing trailing retain after close: " + deltaJson, trailing > annotationClose);
   }
 
   private static void assertInvalidSessionDoesNotAdvanceReplyBlipCounter(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -325,6 +325,9 @@ public class SidecarTransportCodecTest {
     for (SidecarAnnotationRange range : document.getAnnotationRanges()) {
       Assert.assertEquals(0, range.getStartOffset());
       Assert.assertEquals(13, range.getEndOffset());
+      // DocOp offsets account for the leading body+line element starts (2 items).
+      Assert.assertEquals(2, range.getDocStartOffset());
+      Assert.assertEquals(15, range.getDocEndOffset());
     }
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -332,6 +332,42 @@ public class SidecarTransportCodecTest {
   }
 
   @Test
+  public void decodeSelectedWaveUpdatePreservesElementOnlyTaskAnnotation() {
+    // task/id applied to a checkbox element (no text chars): textOffset doesn't advance
+    // but docOffset does, so the annotation must not be dropped.
+    String json =
+        "{\"sequenceNumber\":22,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"local.net!w+s4635670bfbwA/~/conv+root\","
+            + "\"5\":{\"1\":\"conv+root\",\"2\":[\"user@example.com\"],"
+            + "\"3\":[{\"1\":\"b+checkbox\","
+            + "\"2\":{\"1\":[{\"3\":{\"1\":\"body\",\"2\":[]}},"
+            + "{\"3\":{\"1\":\"line\",\"2\":[]}},"
+            + "{\"1\":{\"3\":[{\"1\":\"task/id\",\"3\":\"task-abc\"}]}},"
+            + "{\"3\":{\"1\":\"checkbox\",\"2\":[]}},"
+            + "{\"4\":true},"
+            + "{\"1\":{\"2\":[\"task/id\"]}},"
+            + "{\"2\":\"Task text\"},"
+            + "{\"4\":true},{\"4\":true}]},"
+            + "\"3\":\"user@example.com\",\"5\":[1,0],\"6\":[2,0]}]},"
+            + "\"6\":true,\"7\":\"ch7\"}}";
+
+    SidecarSelectedWaveUpdate update = SidecarTransportCodec.decodeSelectedWaveUpdate(json);
+
+    SidecarSelectedWaveDocument document = update.getDocuments().get(0);
+    Assert.assertEquals("Task text", document.getTextContent());
+    Assert.assertEquals(15, document.getBodyItemCount());
+    Assert.assertEquals(1, document.getAnnotationRanges().size());
+    SidecarAnnotationRange range = document.getAnnotationRanges().get(0);
+    Assert.assertEquals("task/id", range.getKey());
+    Assert.assertEquals("task-abc", range.getValue());
+    Assert.assertEquals(0, range.getStartOffset());
+    Assert.assertEquals(0, range.getEndOffset());
+    // body+line element starts = 2 doc items before annotation opens; checkbox element = 1 item
+    Assert.assertEquals(2, range.getDocStartOffset());
+    Assert.assertEquals(4, range.getDocEndOffset());
+  }
+
+  @Test
   public void decodeSelectedWaveUpdateTreatsAnnotationChangeWithoutNewValueAsRemoval() {
     String json =
         "{\"sequenceNumber\":20,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"

--- a/wave/config/changelog.d/2026-05-09-issue-1225-j2cl-search-blip-profile-tasks.json
+++ b/wave/config/changelog.d/2026-05-09-issue-1225-j2cl-search-blip-profile-tasks.json
@@ -1,0 +1,19 @@
+{
+  "releaseId": "2026-05-09-issue-1225-j2cl-search-blip-profile-tasks",
+  "version": "Issue #1225",
+  "date": "2026-05-09",
+  "title": "J2CL search, blip, profile, and task controls now match the legacy wave view more closely.",
+  "summary": "The J2CL root view restores legacy-style search panel chrome, keeps root content inside the read surface, uses profile images in blip headers, expands profile popup details, and moves task actions toward per-task controls.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Adds the legacy blue search-panel title strip above the J2CL search toolbar.",
+        "Stops rendering selected-wave snippet text above the root blip content.",
+        "Uses profile image avatars for blip authors with initials fallback and aligns blip action glyph color with the legacy toolbar.",
+        "Fetches and renders profile bio, online status, and profile links in the J2CL profile popup when profile data is available.",
+        "Removes blip-level task controls from the blip toolbar and emits task identity/range details from per-task affordances."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes #1225.

- Add the GWT-style blue title strip to the J2CL search rail and keep the search action toolbar available.
- Hide the duplicated selected-wave/root snippet above the read surface.
- Render blip avatars from user profile images with initials fallback.
- Adjust blip action toolbar chrome toward GWT styling.
- Expand profile popup details from `/profile/?addresses=...`, including bio, online/last-seen, member-since, bot/profile link details, and safe profile URL filtering.
- Move task controls to one affordance per task annotation and target task toggle/metadata deltas to the clicked task range.

## Verification

- `cd j2cl/lit && npm test -- --run --coverage=false test/wave-blip.test.js test/wave-blip-toolbar.test.js test/wavy-profile-overlay.test.js test/wavy-search-rail.test.js test/wavy-task-affordance.test.js` => 160 passed, 0 failed.
- `cd j2cl && ./mvnw -Dtest=org.waveprotocol.box.j2cl.richtext.J2clRichContentDeltaFactoryTest,org.waveprotocol.box.j2cl.overlay.J2clOverlayModelTest,org.waveprotocol.box.j2cl.read.J2clReadSurfaceDomRendererTest,org.waveprotocol.box.j2cl.search.J2clSelectedWaveViewChromeTest test` => BUILD SUCCESS; 223 tests run, 0 failures/errors, 143 skipped.
- `cd j2cl/lit && npm run build` => passed.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py` => passed.
- `git diff --check` => passed.
- Tab scan over touched JS/Java files => clean.
- `bash scripts/worktree-boot.sh --port 9916` => passed; GWT compiled with existing CSS warnings only.
- `PORT=9916 ... bash scripts/wave-smoke.sh start && PORT=9916 bash scripts/wave-smoke.sh check` => passed when run in one shell; root/GWT/J2CL shell/health checks 200.
- Browser verification on `http://127.0.0.1:9916/?view=j2cl-root&q=in%3Ainbox`: signed in as a local test account, copied freshly built `/j2cl/assets` into the staged war for this local check, confirmed J2CL shell assets load, search rail upgrades, title shows `in:inbox`, action row is present, and selected snippet is hidden. Full read-surface browser opening is limited by the local stage missing `/j2cl-search/sidecar/*` assets.

## Review

- Self-review completed.
- Claude review round 1 found tab indentation, edit glyph, profile time parsing, and task range sentinel concerns; addressed.
- Claude review round 2 found no blockers; addressed the important `profileUrl` scheme allow-list and indentation drift before opening this PR.
