### PR TITLE
Fix J2CL search help modal projection

### DIFF
--- a/j2cl/lit/src/elements/shell-root.js
+++ b/j2cl/lit/src/elements/shell-root.js
@@ -47,6 +47,12 @@ export class ShellRoot extends LitElement {
       min-height: 0;
     }
 
+    /* Modal overlays are fixed-position hosts. The slot only projects
+     * them through the shell shadow tree and must not create a grid item. */
+    slot[name="modal"] {
+      display: contents;
+    }
+
     /* F-4 (#1039 / R-4.7): production rail-extension landing zone. The
      * slotted <wavy-rail-panel> ships hidden on the user route. When a
      * plugin un-hides it, it lands in its own grid row beneath the
@@ -372,6 +378,7 @@ export class ShellRoot extends LitElement {
       <slot name="nav"></slot>
       <slot name="splitter"></slot>
       <slot name="main"></slot>
+      <slot name="modal"></slot>
       <slot name="rail-extension"></slot>
       <slot name="status"></slot>
     `;

--- a/j2cl/lit/test/shell-root.test.js
+++ b/j2cl/lit/test/shell-root.test.js
@@ -1,5 +1,7 @@
 import { fixture, expect, html } from "@open-wc/testing";
 import "../src/elements/shell-root.js";
+import "../src/elements/wavy-search-help.js";
+import "../src/elements/wavy-search-rail.js";
 
 describe("<shell-root>", () => {
   it("renders the signed-in layout slots", async () => {
@@ -9,6 +11,7 @@ describe("<shell-root>", () => {
     expect(el.renderRoot.querySelector("slot[name='nav']")).to.exist;
     expect(el.renderRoot.querySelector("slot[name='splitter']")).to.exist;
     expect(el.renderRoot.querySelector("slot[name='main']")).to.exist;
+    expect(el.renderRoot.querySelector("slot[name='modal']")).to.exist;
     expect(el.renderRoot.querySelector("slot[name='status']")).to.exist;
   });
 
@@ -29,6 +32,40 @@ describe("<shell-root>", () => {
       .filter((n) => n.nodeType === Node.ELEMENT_NODE)
       .map((n) => n.id);
     expect(ids).to.include("plugin-mount");
+  });
+
+  it("projects modal light-DOM children without creating a shell grid item", async () => {
+    const el = await fixture(html`
+      <shell-root>
+        <wavy-search-help slot="modal" id="wavy-search-help"></wavy-search-help>
+      </shell-root>
+    `);
+    const slot = el.renderRoot.querySelector("slot[name='modal']");
+    expect(getComputedStyle(slot).display).to.equal("contents");
+    const assigned = slot.assignedElements({ flatten: true });
+    expect(assigned.map((node) => node.id)).to.include("wavy-search-help");
+  });
+
+  it("opens the projected search-help modal from the rail help trigger", async () => {
+    const el = await fixture(html`
+      <shell-root>
+        <wavy-search-rail slot="nav"></wavy-search-rail>
+        <wavy-search-help slot="modal" id="wavy-search-help"></wavy-search-help>
+      </shell-root>
+    `);
+    const rail = el.querySelector("wavy-search-rail");
+    const help = el.querySelector("wavy-search-help");
+    await rail.updateComplete;
+    await help.updateComplete;
+
+    rail.renderRoot.querySelector(".help-trigger").click();
+    await help.updateComplete;
+
+    expect(help.open).to.equal(true);
+    const assigned = el.renderRoot
+      .querySelector("slot[name='modal']")
+      .assignedElements({ flatten: true });
+    expect(assigned).to.include(help);
   });
 
   it("projects a resize splitter between nav and main", async () => {

--- a/wave/config/changelog.d/2026-05-09-j2cl-search-help-modal.json
+++ b/wave/config/changelog.d/2026-05-09-j2cl-search-help-modal.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-09-j2cl-search-help-modal",
+  "version": "Issue #1227",
+  "date": "2026-05-09",
+  "title": "J2CL search help opens from the search rail",
+  "summary": "The J2CL search rail help button now displays the Search Help modal instead of toggling an unrendered shell child.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Render the singleton search-help modal through the J2CL shell modal slot so the help overlay appears when the search rail question-mark button is clicked."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3619,9 +3619,10 @@ public final class HtmlRenderer {
       // Single document-level <wavy-search-help> instance. The rail's
       // help-trigger emits wavy-search-help-toggle (composed +
       // bubbles); a connectedCallback-installed listener on this
-      // element flips the open attribute. Mounted as a direct child
-      // of <shell-root> (NOT inside any slot) so its open-state/CSS
-      // overlay can render above the rest of the shell.
+      // element flips the open attribute. Mounted into <shell-root>'s
+      // modal slot so the SSR'd light DOM projects through the shell
+      // shadow tree; the host remains position:fixed, so the slot is a
+      // projection target rather than a grid placement.
       appendWavySearchHelpModal(sb);
       sb.append("  <shell-main-region slot=\"main\">\n");
       sb.append("    <section id=\"j2cl-root-shell-workflow\" data-j2cl-root-shell-workflow=\"true\">\n");
@@ -4430,7 +4431,7 @@ public final class HtmlRenderer {
 
   /**
    * F-2 slice 3 (#1047): emit the singleton {@code <wavy-search-help>}
-   * modal as a direct child of {@code <shell-root>}. SSR'd inner
+   * modal into {@code <shell-root>}'s {@code modal} slot. SSR'd inner
    * light DOM contains every one of the 22 token literals (C.1–C.22)
    * the GWT search-help panel advertises today; the parser fixture
    * {@code J2clSearchHelpTokenParseTest} pins the token contract.
@@ -4442,7 +4443,7 @@ public final class HtmlRenderer {
     // browsers that have not yet executed the J2CL bundle. The Lit
     // element drops `hidden` (the `open` reflection takes over) when
     // the user toggles the modal.
-    sb.append("  <wavy-search-help id=\"wavy-search-help\" hidden>\n");
+    sb.append("  <wavy-search-help slot=\"modal\" id=\"wavy-search-help\" hidden>\n");
     sb.append("    <div class=\"sheet\" role=\"dialog\" aria-modal=\"true\">\n");
     sb.append("      <header><h2>Search Help</h2><button type=\"button\" class=\"dismiss\" aria-label=\"Close search help\">Got it</button></header>\n");
     sb.append("      <div class=\"columns\">\n");

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -107,6 +107,14 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         countOccurrences(html, "<wavy-search-rail"));
   }
 
+  public void testSearchHelpModalIsSlottedIntoShellRootModalLayer() {
+    String html = renderSignedInPage();
+    assertTrue(
+        "Search-help modal must be assigned to shell-root's modal slot so it renders"
+            + " after the Lit shadow root upgrades",
+        html.contains("<wavy-search-help slot=\"modal\" id=\"wavy-search-help\" hidden>"));
+  }
+
   public void testExactlyOneWavyWaveNavRow() {
     String html = renderSignedInPage();
     assertEquals(


### PR DESCRIPTION
Fixes #1227

## Summary
- Projects the singleton `<wavy-search-help>` through a new non-layout `modal` slot on `<shell-root>` so the J2CL search rail `?` trigger can display the modal.
- Keeps the modal as a shell-level singleton rather than duplicating it inside the rail.
- Adds Lit coverage for modal projection, non-grid slot display, and rail help-trigger click opening the projected modal.
- Adds Java renderer coverage for the SSR `slot="modal"` contract.
- Adds changelog fragment `2026-05-09-j2cl-search-help-modal`.

## Verification
- `npm run build` from `j2cl/lit`
- `npm test -- --files test/shell-root.test.js test/wavy-search-help.test.js test/wavy-search-rail.test.js` — 130 passed, 0 failed
- `sbt wave/testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellIntegrationTest` — 46 passed, 0 failed
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py && git diff --check`
- `sbt Universal/stage`
- `bash -lc 'PORT=9898 bash scripts/wave-smoke.sh start && PORT=9898 bash scripts/wave-smoke.sh check; rc=$?; PORT=9898 bash scripts/wave-smoke.sh stop || true; exit $rc'` — root, GWT, health, landing, J2CL-root, and webclient checks passed; J2CL asset check optional\n\n## Review\n- Self-review completed.\n- Claude code review round 1: no blockers; requested stale comment update and composed click coverage. Addressed.\n- Claude code review round 2: no blockers; minor Javadoc/test wording nits addressed before final verification.