### PR TITLE
Fix J2CL root top header parity

### DIFF
--- a/j2cl/lit/src/elements/shell-header.js
+++ b/j2cl/lit/src/elements/shell-header.js
@@ -2,7 +2,8 @@ import { LitElement, css, html } from "lit";
 
 export class ShellHeader extends LitElement {
   static properties = {
-    signedIn: { type: Boolean, attribute: "signed-in", reflect: true }
+    signedIn: { type: Boolean, attribute: "signed-in", reflect: true },
+    compactGwtTopbar: { type: Boolean, attribute: "compact-gwt-topbar", reflect: true }
   };
 
   static styles = css`
@@ -17,10 +18,19 @@ export class ShellHeader extends LitElement {
       gap: var(--shell-space-inline-default, 12px);
     }
 
+    header.gwt-topbar-panel {
+      min-height: 40px;
+      gap: 8px;
+    }
+
     .brand {
       display: inline-flex;
       align-items: center;
       gap: 10px;
+    }
+
+    header.gwt-topbar-panel .brand {
+      gap: 8px;
     }
 
     .actions {
@@ -29,16 +39,26 @@ export class ShellHeader extends LitElement {
       gap: 8px;
       flex-wrap: wrap;
     }
+
+    header.gwt-topbar-panel .actions {
+      flex-wrap: nowrap;
+      gap: 6px;
+    }
   `;
 
   constructor() {
     super();
     this.signedIn = false;
+    this.compactGwtTopbar = false;
   }
 
   render() {
+    const classes = [
+      this.compactGwtTopbar ? "gwt-topbar-panel" : "",
+      this.signedIn ? "is-signed-in" : "is-signed-out"
+    ].filter(Boolean).join(" ");
     return html`
-      <header role="banner">
+      <header class=${classes} role="banner">
         <div class="brand"><slot name="brand"></slot></div>
         <div class="actions">
           ${this.signedIn

--- a/j2cl/lit/src/elements/wavy-header.js
+++ b/j2cl/lit/src/elements/wavy-header.js
@@ -16,12 +16,15 @@ import { LitElement, css, html } from "lit";
  *       NOT mounted by this slice — only the trigger is)
  *
  * Public API:
- * - signedIn      — boolean (controls visibility of A.5/A.6/A.7)
- * - locale        — current locale code (defaults to "en")
- * - address       — user's email address (data-address; reflected so
- *                   server-side templates can pass it through)
- * - userName      — display name fallback for initials (defaults to address)
- * - unreadCount   — number; A.5 dot becomes visible when > 0
+ * - signedIn          — boolean (controls visibility of A.5/A.6/A.7)
+ * - locale            — current locale code (defaults to "en")
+ * - address           — user's email address (data-address; reflected so
+ *                       server-side templates can pass it through)
+ * - userName          — display name fallback for initials (defaults to address)
+ * - unreadCount       — number; A.5 dot becomes visible when > 0
+ * - compact-gwt-topbar — boolean; activates GWT-parity compact mode: hides the
+ *                        full email span, shortens locale labels, and reduces
+ *                        icon sizing to match the 40px GWT root topbar
  *
  * Events:
  * - wavy-locale-changed     — `{detail: {locale}}` on <select> change

--- a/j2cl/lit/src/elements/wavy-header.js
+++ b/j2cl/lit/src/elements/wavy-header.js
@@ -35,6 +35,7 @@ export class WavyHeader extends LitElement {
     userName: { type: String, attribute: "user-name" },
     unreadCount: { type: Number, attribute: "unread-count" },
     basePath: { type: String, attribute: "base-path" },
+    compactGwtTopbar: { type: Boolean, attribute: "compact-gwt-topbar", reflect: true },
     // V-1 (#1099): when the host carries no-brand the inner SupaWave
     // brand link is suppressed so the J2CL root shell can render the
     // canonical brand from shell-header > [slot="brand"] without
@@ -80,6 +81,11 @@ export class WavyHeader extends LitElement {
     :host([no-brand]) .brand {
       display: none;
     }
+    :host([compact-gwt-topbar]) {
+      gap: 8px;
+      flex-wrap: nowrap;
+      color: #fff;
+    }
     .brand-dot {
       width: 8px;
       height: 8px;
@@ -95,6 +101,20 @@ export class WavyHeader extends LitElement {
       padding: var(--wavy-spacing-1, 4px) var(--wavy-spacing-2, 8px);
       font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
     }
+    :host([compact-gwt-topbar]) .locale {
+      width: 40px;
+      height: 32px;
+      min-width: 40px;
+      border: 0;
+      border-radius: 6px;
+      padding: 0 4px;
+      color: #fff;
+      background: rgba(255, 255, 255, 0.10);
+      background-image: none;
+      font-size: 10px;
+      font-weight: 700;
+      text-transform: uppercase;
+    }
     .bell,
     .mail,
     .user-menu {
@@ -108,6 +128,25 @@ export class WavyHeader extends LitElement {
       padding: var(--wavy-spacing-1, 4px) var(--wavy-spacing-2, 8px);
       border-radius: var(--wavy-radius-pill, 9999px);
       text-decoration: none;
+    }
+    :host([compact-gwt-topbar]) .bell,
+    :host([compact-gwt-topbar]) .mail,
+    :host([compact-gwt-topbar]) .user-menu {
+      width: 32px;
+      height: 32px;
+      min-width: 32px;
+      padding: 0;
+      justify-content: center;
+      color: #fff;
+      background: rgba(255, 255, 255, 0.10);
+      border-radius: 6px;
+    }
+    :host([compact-gwt-topbar]) .bell:focus-visible,
+    :host([compact-gwt-topbar]) .mail:focus-visible,
+    :host([compact-gwt-topbar]) .user-menu:focus-visible {
+      outline: 2px solid rgba(255, 255, 255, 0.95);
+      outline-offset: 2px;
+      background: rgba(255, 255, 255, 0.18);
     }
     .bell:hover,
     .bell:focus-visible,
@@ -148,6 +187,10 @@ export class WavyHeader extends LitElement {
       font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
       color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
     }
+    :host([compact-gwt-topbar]) .user-email {
+      /* GWT topbar parity: compact chrome keeps the avatar chip but hides the long email. */
+      display: none;
+    }
     @media (max-width: 600px) {
       .user-email {
         display: none;
@@ -167,6 +210,7 @@ export class WavyHeader extends LitElement {
     this.userName = "";
     this.unreadCount = 0;
     this.basePath = "/";
+    this.compactGwtTopbar = false;
     this.noBrand = false;
   }
 
@@ -238,7 +282,7 @@ export class WavyHeader extends LitElement {
         ${WavyHeader.LOCALES.map(
           (loc) =>
             html`<option value=${loc.code} ?selected=${loc.code === this.locale}>
-              ${loc.label}
+              ${this.compactGwtTopbar ? loc.code.replace("_", "-").toUpperCase() : loc.label}
             </option>`
         )}
       </select>

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -276,6 +276,48 @@ shell-header[compact-gwt-topbar] wavy-header .user-email {
   display: none;
 }
 
+/* Mirror wavy-header compact shadow-DOM styles onto SSR light-DOM children
+ * before shell.js upgrades the element.  Without these, browser-default
+ * form/link controls appear on the 40px compact bar until upgrade — the
+ * shadow rules (:host([compact-gwt-topbar]) .locale / .bell / …) only
+ * fire after customElements.define() runs. */
+shell-header[compact-gwt-topbar] wavy-header .locale {
+  box-sizing: border-box;
+  width: 40px;
+  height: 32px;
+  min-width: 40px;
+  border: 0;
+  border-radius: 6px;
+  padding: 0 4px;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.10);
+  background-image: none;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  cursor: pointer;
+  appearance: none;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .bell,
+shell-header[compact-gwt-topbar] wavy-header .mail,
+shell-header[compact-gwt-topbar] wavy-header .user-menu {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  min-width: 32px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.10);
+  cursor: pointer;
+  text-decoration: none;
+}
+
 shell-header > [slot="actions-signed-in"],
 shell-header > [slot="actions-signed-out"] {
   display: inline-flex;

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -272,7 +272,7 @@ shell-header wavy-header > .brand {
 /* Hide SSR light-DOM email span before Lit upgrade hoists the element into
  * shadow DOM; the shadow rule (:host([compact-gwt-topbar]) .user-email) only
  * applies post-upgrade, so long addresses would overflow the 40px bar. */
-shell-header[compact-gwt-topbar] wavy-header > .user-email {
+shell-header[compact-gwt-topbar] wavy-header .user-email {
   display: none;
 }
 

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -318,6 +318,13 @@ shell-header[compact-gwt-topbar] wavy-header .user-menu {
   text-decoration: none;
 }
 
+shell-header[compact-gwt-topbar] wavy-header .bell svg,
+shell-header[compact-gwt-topbar] wavy-header .mail svg {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+}
+
 shell-header > [slot="actions-signed-in"],
 shell-header > [slot="actions-signed-out"] {
   display: inline-flex;

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -186,7 +186,6 @@ shell-header {
 shell-header[compact-gwt-topbar] {
   padding: 0 12px;
   min-height: 40px;
-  height: 40px;
   background: linear-gradient(135deg, #023e6b 0%, #006b9f 62%, #0077a8 100%);
   border-bottom: none;
   box-shadow: 0 2px 8px rgba(0, 50, 100, 0.18);
@@ -267,6 +266,13 @@ shell-header[compact-gwt-topbar] > [slot="brand"] .j2cl-brand-eyebrow {
 shell-header > [slot="actions-signed-in"] > .brand,
 shell-header > [slot="actions-signed-out"] > .brand,
 shell-header wavy-header > .brand {
+  display: none;
+}
+
+/* Hide SSR light-DOM email span before Lit upgrade hoists the element into
+ * shadow DOM; the shadow rule (:host([compact-gwt-topbar]) .user-email) only
+ * applies post-upgrade, so long addresses would overflow the 40px bar. */
+shell-header[compact-gwt-topbar] wavy-header > .user-email {
   display: none;
 }
 
@@ -417,6 +423,11 @@ shell-status-strip {
   shell-header {
     align-items: flex-start;
     flex-wrap: wrap;
+  }
+
+  shell-header[compact-gwt-topbar] {
+    flex-wrap: nowrap;
+    align-items: center;
   }
 
   shell-nav-rail {

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -183,12 +183,27 @@ shell-header {
   box-sizing: border-box;
 }
 
+shell-header[compact-gwt-topbar] {
+  padding: 0 12px;
+  min-height: 40px;
+  height: 40px;
+  background: linear-gradient(135deg, #023e6b 0%, #006b9f 62%, #0077a8 100%);
+  border-bottom: none;
+  box-shadow: 0 2px 8px rgba(0, 50, 100, 0.18);
+  color: #fff;
+}
+
 shell-header > [slot="brand"] {
   display: inline-flex;
   align-items: center;
   gap: 12px;
   text-decoration: none;
   color: #0b1320;
+}
+
+shell-header[compact-gwt-topbar] > [slot="brand"] {
+  gap: 8px;
+  color: #fff;
 }
 
 shell-header > [slot="brand"] .j2cl-brand-mark {
@@ -199,10 +214,20 @@ shell-header > [slot="brand"] .j2cl-brand-mark {
   height: 36px;
 }
 
+shell-header[compact-gwt-topbar] > [slot="brand"] .j2cl-brand-mark {
+  width: 24px;
+  height: 24px;
+}
+
 shell-header > [slot="brand"] .j2cl-brand-mark svg {
   width: 36px;
   height: 36px;
   display: block;
+}
+
+shell-header[compact-gwt-topbar] > [slot="brand"] .j2cl-brand-mark svg {
+  width: 24px;
+  height: 24px;
 }
 
 shell-header > [slot="brand"] .j2cl-brand-stack {
@@ -218,12 +243,21 @@ shell-header > [slot="brand"] .j2cl-brand-name {
   color: #0b1320;
 }
 
+shell-header[compact-gwt-topbar] > [slot="brand"] .j2cl-brand-name {
+  font-size: 17px;
+  color: #fff;
+}
+
 shell-header > [slot="brand"] .j2cl-brand-eyebrow {
   font-family: Arial, Helvetica, sans-serif;
   font-size: 11px;
   letter-spacing: 0.08em;
   color: rgba(11, 19, 32, 0.55);
   margin-top: 2px;
+}
+
+shell-header[compact-gwt-topbar] > [slot="brand"] .j2cl-brand-eyebrow {
+  display: none;
 }
 
 /* The wavy-header (right cluster) renders its own brand link as part of
@@ -249,14 +283,34 @@ shell-header > [slot="actions-signed-out"] {
   box-sizing: border-box;
 }
 
+shell-header[compact-gwt-topbar] > [slot="actions-signed-in"],
+shell-header[compact-gwt-topbar] > [slot="actions-signed-out"] {
+  min-height: 32px;
+  height: 32px;
+  padding: 0 8px;
+  border-radius: 6px;
+  color: #fff;
+}
+
 shell-header > span[slot^="actions"] {
   background: var(--shell-color-surface-soft);
   color: var(--shell-color-text-muted);
 }
 
+shell-header[compact-gwt-topbar] > span[slot^="actions"] {
+  background: rgba(255, 255, 255, 0.10);
+  color: rgba(255, 255, 255, 0.9);
+}
+
 shell-header > a[slot^="actions"] {
   border: 1px solid rgba(189, 200, 202, 0.75);
   background: #fff;
+}
+
+shell-header[compact-gwt-topbar] > a[slot^="actions"] {
+  border-color: rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.10);
+  color: #fff;
 }
 
 shell-header > a[data-j2cl-root-signin="true"] {

--- a/j2cl/lit/test/shell-header.test.js
+++ b/j2cl/lit/test/shell-header.test.js
@@ -18,4 +18,13 @@ describe("<shell-header>", () => {
     expect(el.renderRoot.querySelector("slot[name='actions-signed-out']")).to.exist;
     expect(el.renderRoot.querySelector("slot[name='actions-signed-in']")).to.not.exist;
   });
+
+  it("uses compact GWT topbar layout classes", async () => {
+    const el = await fixture(html`<shell-header signed-in compact-gwt-topbar></shell-header>`);
+    const header = el.renderRoot.querySelector("header");
+
+    expect(header.classList.contains("gwt-topbar-panel")).to.be.true;
+    expect(header.classList.contains("is-signed-in")).to.be.true;
+    expect(getComputedStyle(header).minHeight).to.equal("40px");
+  });
 });

--- a/j2cl/lit/test/wavy-header.test.js
+++ b/j2cl/lit/test/wavy-header.test.js
@@ -34,6 +34,33 @@ describe("<wavy-header>", () => {
     expect(options).to.deep.equal(["en", "de", "es", "fr", "ru", "sl", "zh_TW"]);
   });
 
+  it("compact GWT topbar mode keeps locale labels short", async () => {
+    const el = await fixture(html`<wavy-header compact-gwt-topbar></wavy-header>`);
+    await el.updateComplete;
+    const labels = Array.from(el.renderRoot.querySelectorAll("select.locale option"))
+      .map((option) => option.textContent.trim());
+
+    expect(labels).to.deep.equal(["EN", "DE", "ES", "FR", "RU", "SL", "ZH-TW"]);
+  });
+
+  it("compact GWT topbar mode preserves selected locale", async () => {
+    const el = await fixture(html`<wavy-header compact-gwt-topbar locale="zh_TW"></wavy-header>`);
+    await el.updateComplete;
+    const selected = el.renderRoot.querySelector("select.locale option:checked");
+
+    expect(selected.value).to.equal("zh_TW");
+    expect(selected.textContent.trim()).to.equal("ZH-TW");
+  });
+
+  it("compact GWT topbar mode uses compact action controls", async () => {
+    const el = await fixture(html`<wavy-header compact-gwt-topbar signed-in></wavy-header>`);
+    await el.updateComplete;
+    const bell = el.renderRoot.querySelector("button.bell");
+
+    expect(getComputedStyle(bell).width).to.equal("32px");
+    expect(getComputedStyle(bell).height).to.equal("32px");
+  });
+
   it("change on locale picker emits wavy-locale-changed (A.2)", async () => {
     const el = await fixture(html`<wavy-header></wavy-header>`);
     await el.updateComplete;
@@ -104,6 +131,19 @@ describe("<wavy-header>", () => {
     const email = userMenu.querySelector(".user-email");
     expect(email).to.exist;
     expect(email.textContent.trim()).to.equal("alice.smith@example.com");
+  });
+
+  it("compact GWT topbar mode hides long email while keeping avatar initials", async () => {
+    const el = await fixture(
+      html`<wavy-header compact-gwt-topbar signed-in data-address="alice.smith@example.com"></wavy-header>`
+    );
+    await el.updateComplete;
+    const userMenu = el.renderRoot.querySelector("button.user-menu");
+    const avatar = userMenu.querySelector(".avatar");
+    const email = userMenu.querySelector(".user-email");
+
+    expect(avatar.textContent.trim()).to.equal("AS");
+    expect(getComputedStyle(email).display).to.equal("none");
   });
 
   it("user-menu click emits wavy-user-menu-requested with the address (A.7)", async () => {

--- a/wave/config/changelog.d/2026-05-09-j2cl-root-topbar-parity.json
+++ b/wave/config/changelog.d/2026-05-09-j2cl-root-topbar-parity.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-09-j2cl-root-topbar-parity",
+  "version": "Issue #1223",
+  "date": "2026-05-09",
+  "title": "J2CL root header now matches the compact legacy SupaWave top bar.",
+  "summary": "The J2CL root shell uses the same compact blue header treatment as the GWT client and no longer shows a J2CL route eyebrow next to the SupaWave brand.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Restyles the J2CL root-shell header as a compact GWT-style top bar.",
+        "Removes the visible J2CL route eyebrow from the SupaWave brand area."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3563,11 +3563,9 @@ public final class HtmlRenderer {
       sb.append("  <shell-skip-link slot=\"skip-link\" target=\"#j2cl-root-shell-workflow\" label=\"Skip to main content\">")
           .append("<a href=\"#j2cl-root-shell-workflow\">Skip to main content</a>")
           .append("</shell-skip-link>\n");
-      sb.append("  <shell-header slot=\"header\" signed-in>\n");
-      // V-1 (#1099): brand block matches 01-shell-inbox-with-waves.svg —
-      // 36px circular SupaWave mark + bold name + subtle eyebrow. The
-      // SVG mark mirrors the mockup symbol (<symbol id="supawave-mark">)
-      // inline so no asset bump is required for visual parity.
+      sb.append("  <shell-header slot=\"header\" signed-in compact-gwt-topbar>\n");
+      // Compact GWT parity: keep the SupaWave brand in the root shell header
+      // without exposing the J2CL route/debug eyebrow in the user chrome.
       sb.append("    <a slot=\"brand\" id=\"j2cl-root-brand-link\" href=\"")
           .append(safeResolvedReturnTarget)
           .append("\" aria-label=\"SupaWave\">\n");
@@ -3579,7 +3577,6 @@ public final class HtmlRenderer {
           .append("</svg></span>\n");
       sb.append("      <span class=\"j2cl-brand-stack\">")
           .append("<span class=\"j2cl-brand-name\">SupaWave</span>")
-          .append("<span class=\"j2cl-brand-eyebrow\">J2CL · ").append(safeResolvedBasePath).append("?view=j2cl-root</span>")
           .append("</span>\n");
       sb.append("    </a>\n");
       // F-2 slice 3 (#1047): wavy header chrome (A.1, A.2, A.5, A.6,
@@ -3593,7 +3590,9 @@ public final class HtmlRenderer {
       // <wavy-blip-card> server-render contract). The raw address is
       // passed through alongside the safe (HTML-escaped) form so
       // computeUserInitials can run on the unescaped local part.
-      appendWavyHeaderActionsSlot(sb, address, safeAddress, safeResolvedReturnTarget, safeResolvedBasePath, safeHtmlLang);
+      appendWavyHeaderActionsSlot(
+          sb, address, safeAddress, safeResolvedReturnTarget, safeResolvedBasePath, safeHtmlLang,
+          true);
       // The legacy inline Admin and Sign out links are PRESERVED until
       // the F-0 user-menu sheet ships (A.7 only mounts the trigger;
       // A.8–A.18 are F-0). Removing them now would orphan affordances
@@ -3695,9 +3694,9 @@ public final class HtmlRenderer {
       sb.append("  <shell-skip-link slot=\"skip-link\" target=\"#j2cl-root-shell-workflow\" label=\"Skip to main content\">")
           .append("<a href=\"#j2cl-root-shell-workflow\">Skip to main content</a>")
           .append("</shell-skip-link>\n");
-      sb.append("  <shell-header slot=\"header\">\n");
-      // V-1 (#1099): brand block matches 01-shell-inbox-with-waves.svg
-      // (mirrored from the signed-in branch above).
+      sb.append("  <shell-header slot=\"header\" compact-gwt-topbar>\n");
+      // Compact GWT parity: mirror the signed-in brand treatment without
+      // exposing the J2CL route/debug eyebrow.
       sb.append("    <a slot=\"brand\" id=\"j2cl-root-brand-link\" href=\"")
           .append(safeResolvedReturnTarget)
           .append("\" aria-label=\"SupaWave\">\n");
@@ -3709,7 +3708,6 @@ public final class HtmlRenderer {
           .append("</svg></span>\n");
       sb.append("      <span class=\"j2cl-brand-stack\">")
           .append("<span class=\"j2cl-brand-name\">SupaWave</span>")
-          .append("<span class=\"j2cl-brand-eyebrow\">J2CL · ").append(safeResolvedBasePath).append("?view=j2cl-root</span>")
           .append("</span>\n");
       sb.append("    </a>\n");
       sb.append("    <span slot=\"actions-signed-out\">Signed out</span>\n");
@@ -3871,7 +3869,7 @@ public final class HtmlRenderer {
     sb.append("      <span aria-hidden=\"true\">J2</span><span>SupaWave Read Surface Preview</span>\n");
     sb.append("    </a>\n");
     appendWavyHeaderActionsSlot(
-        sb, resolvedAddress, safeAddress, safeResolvedReturnTarget, safeResolvedBasePath, "en");
+        sb, resolvedAddress, safeAddress, safeResolvedReturnTarget, safeResolvedBasePath, "en", false);
     sb.append("  </shell-header>\n");
     sb.append("  <shell-nav-rail slot=\"nav\" label=\"Primary\">\n");
     appendWavySearchRail(sb, safeInitialQuery, false, false);
@@ -4228,7 +4226,8 @@ public final class HtmlRenderer {
    */
   private static void appendWavyHeaderActionsSlot(
       StringBuilder sb, String rawAddress, String safeAddress,
-      String safeResolvedReturnTarget, String safeBasePath, String safeHtmlLang) {
+      String safeResolvedReturnTarget, String safeBasePath, String safeHtmlLang,
+      boolean compactGwtTopbar) {
     String escapedAddress = safeAddress == null ? "" : safeAddress;
     // computeUserInitials runs on the RAW address so the local-part
     // splitting matches the JS Lit element exactly (the Lit element
@@ -4243,7 +4242,11 @@ public final class HtmlRenderer {
     // still emitted below (parity contract); the shadow render skips
     // it post-upgrade and a CSS rule in shell-tokens.css hides the
     // SSR copy pre-upgrade.
-    sb.append("    <wavy-header slot=\"actions-signed-in\" signed-in no-brand locale=\"")
+    sb.append("    <wavy-header slot=\"actions-signed-in\" signed-in no-brand");
+    if (compactGwtTopbar) {
+      sb.append(" compact-gwt-topbar");
+    }
+    sb.append(" locale=\"")
         .append(selectedLocaleOpt)
         .append("\" data-address=\"")
         .append(escapedAddress)
@@ -4258,13 +4261,13 @@ public final class HtmlRenderer {
         .append("<span class=\"brand-dot\" aria-hidden=\"true\"></span>")
         .append("<span class=\"brand-text\">SupaWave</span></a>\n");
     sb.append("      <select class=\"locale\" aria-label=\"Language\">\n");
-    sb.append("        <option value=\"en\"").append("en".equals(selectedLocaleOpt) ? " selected" : "").append(">English</option>\n");
-    sb.append("        <option value=\"de\"").append("de".equals(selectedLocaleOpt) ? " selected" : "").append(">Deutsch</option>\n");
-    sb.append("        <option value=\"es\"").append("es".equals(selectedLocaleOpt) ? " selected" : "").append(">Español</option>\n");
-    sb.append("        <option value=\"fr\"").append("fr".equals(selectedLocaleOpt) ? " selected" : "").append(">Français</option>\n");
-    sb.append("        <option value=\"ru\"").append("ru".equals(selectedLocaleOpt) ? " selected" : "").append(">Русский</option>\n");
-    sb.append("        <option value=\"sl\"").append("sl".equals(selectedLocaleOpt) ? " selected" : "").append(">Slovenščina</option>\n");
-    sb.append("        <option value=\"zh_TW\"").append("zh_TW".equals(selectedLocaleOpt) ? " selected" : "").append(">繁體中文</option>\n");
+    appendLocaleOption(sb, "en", "English", selectedLocaleOpt, compactGwtTopbar);
+    appendLocaleOption(sb, "de", "Deutsch", selectedLocaleOpt, compactGwtTopbar);
+    appendLocaleOption(sb, "es", "Español", selectedLocaleOpt, compactGwtTopbar);
+    appendLocaleOption(sb, "fr", "Français", selectedLocaleOpt, compactGwtTopbar);
+    appendLocaleOption(sb, "ru", "Русский", selectedLocaleOpt, compactGwtTopbar);
+    appendLocaleOption(sb, "sl", "Slovenščina", selectedLocaleOpt, compactGwtTopbar);
+    appendLocaleOption(sb, "zh_TW", "繁體中文", selectedLocaleOpt, compactGwtTopbar);
     sb.append("      </select>\n");
     // A.5 notifications bell — server-renders the same SVG glyph the
     // Lit element renders so the icon does not appear empty pre-upgrade.
@@ -4288,6 +4291,23 @@ public final class HtmlRenderer {
         .append(escapedAddress)
         .append("</span></button>\n");
     sb.append("    </wavy-header>\n");
+  }
+
+  private static void appendLocaleOption(
+      StringBuilder sb, String value, String fullLabel, String selectedLocaleOpt,
+      boolean compactGwtTopbar) {
+    String label = compactGwtTopbar ? compactLocaleLabel(value) : fullLabel;
+    sb.append("        <option value=\"")
+        .append(value)
+        .append("\"")
+        .append(value.equals(selectedLocaleOpt) ? " selected" : "")
+        .append(">")
+        .append(label)
+        .append("</option>\n");
+  }
+
+  private static String compactLocaleLabel(String value) {
+    return value.replace('_', '-').toUpperCase(Locale.ROOT);
   }
 
   /**

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
@@ -49,6 +49,20 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
     assertTrue(html.contains("window.__j2clRootShellStat"));
   }
 
+  public void testSignedInTopHeaderUsesGwtCompactChrome() {
+    JSONObject session = new JSONObject();
+    session.put("address", "alice@example.com");
+    session.put("role", "admin");
+
+    String html = HtmlRenderer.renderJ2clRootShellPage(
+        session, "", "commit", 0L, "rel", "/?view=j2cl-root", "ws.example:443");
+
+    assertTrue(html.contains("<shell-header slot=\"header\" signed-in compact-gwt-topbar"));
+    assertTrue(html.contains("<wavy-header slot=\"actions-signed-in\" signed-in no-brand compact-gwt-topbar"));
+    assertFalse(html.contains("j2cl-brand-eyebrow"));
+    assertFalse(html.contains("J2CL ·"));
+  }
+
   public void testSignedOutPageUsesSignedOutRoot() {
     JSONObject session = new JSONObject();
 
@@ -57,6 +71,29 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
 
     assertTrue(html.contains("<shell-root-signed-out"));
     assertFalse(html.contains("<shell-root data-j2cl-root-shell"));
+  }
+
+  public void testSignedOutTopHeaderUsesGwtCompactChrome() {
+    JSONObject session = new JSONObject();
+
+    String html = HtmlRenderer.renderJ2clRootShellPage(
+        session, "", "commit", 0L, "rel", "/?view=j2cl-root", "ws.example:443");
+
+    assertTrue(html.contains("<shell-header slot=\"header\" compact-gwt-topbar"));
+    assertTrue(html.contains("<span slot=\"actions-signed-out\">Signed out</span>"));
+    assertTrue(html.contains("<a slot=\"actions-signed-out\""));
+    assertTrue(html.contains("Sign in"));
+    assertFalse(html.contains("j2cl-brand-eyebrow"));
+    assertFalse(html.contains("J2CL ·"));
+  }
+
+  public void testReadSurfacePreviewKeepsPreviewHeaderChrome() {
+    String html = HtmlRenderer.renderJ2clReadSurfacePreviewPage(
+        "", "commit", 0L, "rel", "alice@example.com", "ws.example:443");
+
+    assertTrue(html.contains("SupaWave Read Surface Preview"));
+    assertTrue(html.contains(">English</option>"));
+    assertFalse(html.contains("compact-gwt-topbar"));
   }
 
   public void testLegacyShellClassesAreNoLongerEmitted() {

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
@@ -57,8 +57,20 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
     String html = HtmlRenderer.renderJ2clRootShellPage(
         session, "", "commit", 0L, "rel", "/?view=j2cl-root", "ws.example:443");
 
-    assertTrue(html.contains("<shell-header slot=\"header\" signed-in compact-gwt-topbar"));
-    assertTrue(html.contains("<wavy-header slot=\"actions-signed-in\" signed-in no-brand compact-gwt-topbar"));
+    int shIdx = html.indexOf("<shell-header");
+    int shEnd = html.indexOf('>', shIdx);
+    String shTag = html.substring(shIdx, shEnd);
+    assertTrue("shell-header must have slot=\"header\"", shTag.contains("slot=\"header\""));
+    assertTrue("shell-header must carry signed-in", shTag.contains("signed-in"));
+    assertTrue("shell-header must carry compact-gwt-topbar", shTag.contains("compact-gwt-topbar"));
+
+    int whIdx = html.indexOf("<wavy-header");
+    int whEnd = html.indexOf('>', whIdx);
+    String whTag = html.substring(whIdx, whEnd);
+    assertTrue("wavy-header must have slot=\"actions-signed-in\"", whTag.contains("slot=\"actions-signed-in\""));
+    assertTrue("wavy-header must carry signed-in", whTag.contains("signed-in"));
+    assertTrue("wavy-header must carry no-brand", whTag.contains("no-brand"));
+    assertTrue("wavy-header must carry compact-gwt-topbar", whTag.contains("compact-gwt-topbar"));
     assertFalse(html.contains("j2cl-brand-eyebrow"));
     assertFalse(html.contains("J2CL ·"));
   }
@@ -79,7 +91,11 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
     String html = HtmlRenderer.renderJ2clRootShellPage(
         session, "", "commit", 0L, "rel", "/?view=j2cl-root", "ws.example:443");
 
-    assertTrue(html.contains("<shell-header slot=\"header\" compact-gwt-topbar"));
+    int shIdx2 = html.indexOf("<shell-header");
+    int shEnd2 = html.indexOf('>', shIdx2);
+    String shTag2 = html.substring(shIdx2, shEnd2);
+    assertTrue("shell-header must have slot=\"header\"", shTag2.contains("slot=\"header\""));
+    assertTrue("shell-header must carry compact-gwt-topbar", shTag2.contains("compact-gwt-topbar"));
     assertTrue(html.contains("<span slot=\"actions-signed-out\">Signed out</span>"));
     assertTrue(html.contains("<a slot=\"actions-signed-out\""));
     assertTrue(html.contains("Sign in"));


### PR DESCRIPTION
## Summary
- Restyles the J2CL root-shell top header with compact GWT-style blue chrome.
- Removes the visible J2CL route/debug eyebrow from signed-in and signed-out root headers.
- Keeps signed-in actions reachable with compact locale/action controls and preserves non-root preview chrome.
- Adds focused Java/Lit regression coverage and a changelog fragment.

Refs #1223

## Verification
- `python3 scripts/validate-changelog.py` — passed
- `cd j2cl/lit && npm test -- --files test/shell-header.test.js test/wavy-header.test.js` — 22 passed, 0 failed
- `cd j2cl/lit && npm run build` — passed
- `sbt "testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellTest org.waveprotocol.box.server.rpc.HtmlRendererTopBarTest"` — 52 passed, 0 failed
- `git diff --check` — passed
- `WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 bash scripts/worktree-boot.sh --port 9928` — staged assets ready
- `PORT=9928 bash scripts/wave-smoke.sh check` — ROOT/GWT/HEALTH/LANDING/J2CL_ROOT/WEBCLIENT 200, root shell present; optional J2CL index/sidecar endpoints 404 in this staged setup
- Playwright loaded `http://127.0.0.1:9928/?view=j2cl-root` and captured the rendered header; only console error was the existing optional staged `sidecar.css` MIME/404 path

## Review
- Self-review: no out-of-scope changes found; final diff is scoped to root header renderer, Lit header components, focused tests, and changelog.
- Claude review round 1: no blockers; addressed shadow CSS placement, signed-out coverage, locale-selected coverage, contrast/focus concerns.
- Claude review round 2: no blockers; verified sidecar-eyebrow scope concern was a false positive for this diff and addressed remaining useful hardening items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a compact header display mode with condensed spacing and streamlined navigation layout
  * In compact mode: locale options display abbreviated codes (e.g., ZH-TW), header controls render as smaller icons, and user email is hidden while avatar chip remains visible
  * Header styling now aligns with legacy top bar design standards

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1229)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->