### PR TITLE
Fix J2CL task parity follow-up

### DIFF
--- a/j2cl/lit/src/elements/task-metadata-popover.js
+++ b/j2cl/lit/src/elements/task-metadata-popover.js
@@ -20,8 +20,6 @@ export class TaskMetadataPopover extends LitElement {
     }
 
     .dialog {
-      display: grid;
-      gap: 10px;
       width: 320px;
       max-width: 92vw;
       border: 0;
@@ -36,7 +34,7 @@ export class TaskMetadataPopover extends LitElement {
 
     h2 {
       display: block;
-      margin: 0 0 5px;
+      margin: 0 0 14px;
       font-size: 18px;
       font-weight: 600;
       line-height: 1.2;
@@ -44,9 +42,8 @@ export class TaskMetadataPopover extends LitElement {
     }
 
     label {
-      display: grid;
-      gap: 6px;
-      margin: 2px 0;
+      display: block;
+      margin: 12px 0 6px;
       color: #5f6368;
       font-size: 12px;
       font-weight: 600;
@@ -68,6 +65,12 @@ export class TaskMetadataPopover extends LitElement {
       font-weight: 400;
     }
 
+    select,
+    input {
+      display: block;
+      width: 100%;
+    }
+
     select:focus,
     input:focus,
     button:focus {
@@ -77,13 +80,12 @@ export class TaskMetadataPopover extends LitElement {
     }
 
     .actions {
-      display: flex;
-      gap: 8px;
-      justify-content: flex-end;
-      margin-top: 8px;
+      margin-top: 18px;
+      text-align: right;
     }
 
     button[type="button"] {
+      margin-right: 8px;
       padding: 8px 12px;
       background: #ffffff;
       color: #3c4043;

--- a/j2cl/lit/test/task-metadata-popover.test.js
+++ b/j2cl/lit/test/task-metadata-popover.test.js
@@ -45,8 +45,12 @@ describe("<task-metadata-popover>", () => {
     expect(getComputedStyle(title).fontSize).to.equal("18px");
     expect(getComputedStyle(label).textTransform).to.equal("uppercase");
     expect(getComputedStyle(input).borderRadius).to.equal("8px");
+    expect(getComputedStyle(input).width).to.equal("284px");
+    expect(input.getBoundingClientRect().top).to.be.greaterThan(label.getBoundingClientRect().top);
     expect(getComputedStyle(cancel).backgroundColor).to.equal("rgb(255, 255, 255)");
     expect(getComputedStyle(save).backgroundColor).to.equal("rgb(26, 115, 232)");
+    expect(getComputedStyle(cancel).width).to.not.equal("284px");
+    expect(cancel.getBoundingClientRect().top).to.equal(save.getBoundingClientRect().top);
   });
 
   it("generates unique heading ids for multiple task dialogs", async () => {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -400,25 +400,26 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
             String hostWaveId = contentList.getAttribute("data-wave-id");
             waveId = hostWaveId == null ? "" : hostWaveId;
           }
-          renderer.noteOptimisticTaskState(waveId, blipId, completed);
-          applyOptimisticTaskHostState(evt, blipId, taskId, completed);
+          boolean allTasksCompleted =
+              applyOptimisticTaskHostState(evt, blipId, taskId, completed);
+          renderer.noteOptimisticTaskState(waveId, blipId, allTasksCompleted);
         });
   }
 
-  static void applyOptimisticTaskHostState(
+  static boolean applyOptimisticTaskHostState(
       Event evt, String blipId, String taskId, boolean completed) {
     if (evt == null || !(evt.target instanceof Element)) {
-      return;
+      return completed;
     }
     Element source = (Element) evt.target;
     Element host = source.closest("wave-blip");
     if (!(host instanceof HTMLElement)) {
-      return;
+      return completed;
     }
     HTMLElement blip = (HTMLElement) host;
     String hostBlipId = blip.getAttribute("data-blip-id");
     if (blipId == null || blipId.isEmpty() || !blipId.equals(hostBlipId)) {
-      return;
+      return completed;
     }
 
     boolean allCompleted = true;
@@ -453,6 +454,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     } else {
       blip.removeAttribute("data-task-completed");
     }
+    return allCompleted;
   }
 
   private void bindSelectedWaveRefreshListener(HTMLElement card) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -5,9 +5,12 @@ import elemental2.core.JsDate;
 import elemental2.dom.CustomEvent;
 import elemental2.dom.CustomEventInit;
 import elemental2.dom.DomGlobal;
+import elemental2.dom.Element;
+import elemental2.dom.Event;
 import elemental2.dom.Element.FocusOptionsType;
 import elemental2.dom.HTMLDivElement;
 import elemental2.dom.HTMLElement;
+import elemental2.dom.NodeList;
 import elemental2.dom.ScrollIntoViewOptions;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -382,6 +385,8 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
           } else {
             completed = "true".equals(String.valueOf(completedValue));
           }
+          Object taskIdValue = jsinterop.base.Js.asPropertyMap(detail).get("taskId");
+          String taskId = taskIdValue == null ? "" : String.valueOf(taskIdValue);
           // PR #1097 review (codex P2): namespace the optimistic-toggle
           // entry by wave id so a stale entry from one wave does not
           // bleed onto another wave that reuses the same blip id.
@@ -396,7 +401,58 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
             waveId = hostWaveId == null ? "" : hostWaveId;
           }
           renderer.noteOptimisticTaskState(waveId, blipId, completed);
+          applyOptimisticTaskHostState(evt, blipId, taskId, completed);
         });
+  }
+
+  static void applyOptimisticTaskHostState(
+      Event evt, String blipId, String taskId, boolean completed) {
+    if (evt == null || !(evt.target instanceof Element)) {
+      return;
+    }
+    Element source = (Element) evt.target;
+    Element host = source.closest("wave-blip");
+    if (!(host instanceof HTMLElement)) {
+      return;
+    }
+    HTMLElement blip = (HTMLElement) host;
+    String hostBlipId = blip.getAttribute("data-blip-id");
+    if (blipId == null || blipId.isEmpty() || !blipId.equals(hostBlipId)) {
+      return;
+    }
+
+    boolean allCompleted = true;
+    boolean matchedToggledAffordance = false;
+    String normalizedTaskId = taskId == null ? "" : taskId;
+    NodeList<Element> affordances = blip.querySelectorAll("wavy-task-affordance");
+    for (int index = 0; index < affordances.length; index++) {
+      Element affordance = affordances.item(index);
+      if (affordance == null) {
+        continue;
+      }
+      String affordanceTaskId = affordance.getAttribute("data-task-id");
+      boolean isToggledAffordance =
+          affordance == source
+              || (!normalizedTaskId.isEmpty() && normalizedTaskId.equals(affordanceTaskId));
+      if (isToggledAffordance) {
+        matchedToggledAffordance = true;
+      }
+      boolean affordanceCompleted =
+          isToggledAffordance ? completed : affordance.hasAttribute("data-task-completed");
+      if (!affordanceCompleted) {
+        allCompleted = false;
+        break;
+      }
+    }
+    if (affordances.length == 0 || (!matchedToggledAffordance && affordances.length == 1)) {
+      allCompleted = completed;
+    }
+    blip.setAttribute("data-task-present", "");
+    if (allCompleted) {
+      blip.setAttribute("data-task-completed", "");
+    } else {
+      blip.removeAttribute("data-task-completed");
+    }
   }
 
   private void bindSelectedWaveRefreshListener(HTMLElement card) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -810,6 +810,56 @@ public class J2clSelectedWaveViewChromeTest {
   }
 
   @Test
+  public void optimisticTaskToggleImmediatelyMarksSingleTaskBlipDone() {
+    assumeBrowserDom();
+    HTMLElement blip = taskBlip("b+task");
+    HTMLElement affordance = taskAffordance("b+task", false);
+    affordance.setAttribute("data-task-id", "task-1");
+    blip.appendChild(affordance);
+
+    dispatchTaskToggle(affordance, "b+task", "task-1", true);
+
+    Assert.assertTrue(blip.hasAttribute("data-task-present"));
+    Assert.assertTrue(blip.hasAttribute("data-task-completed"));
+  }
+
+  @Test
+  public void optimisticTaskToggleOnlyMarksMultiTaskBlipDoneWhenAllTasksDone() {
+    assumeBrowserDom();
+    HTMLElement blip = taskBlip("b+task");
+    HTMLElement first = taskAffordance("b+task", false);
+    HTMLElement second = taskAffordance("b+task", false);
+    first.setAttribute("data-task-id", "task-1");
+    second.setAttribute("data-task-id", "task-2");
+    blip.appendChild(first);
+    blip.appendChild(second);
+
+    dispatchTaskToggle(first, "b+task", "task-1", true);
+    Assert.assertFalse(
+        "A single completed task must not mark the whole multi-task blip done",
+        blip.hasAttribute("data-task-completed"));
+
+    second.setAttribute("data-task-completed", "");
+    dispatchTaskToggle(first, "b+task", "task-1", true);
+    Assert.assertTrue(blip.hasAttribute("data-task-completed"));
+  }
+
+  @Test
+  public void optimisticTaskToggleCanClearCompletedHostState() {
+    assumeBrowserDom();
+    HTMLElement blip = taskBlip("b+task");
+    blip.setAttribute("data-task-completed", "");
+    HTMLElement affordance = taskAffordance("b+task", true);
+    affordance.setAttribute("data-task-id", "task-1");
+    blip.appendChild(affordance);
+
+    dispatchTaskToggle(affordance, "b+task", "task-1", false);
+
+    Assert.assertTrue(blip.hasAttribute("data-task-present"));
+    Assert.assertFalse(blip.hasAttribute("data-task-completed"));
+  }
+
+  @Test
   public void depthNavEventsEmitTelemetry() {
     assumeBrowserDom();
     HTMLElement host = createHost();
@@ -1049,6 +1099,39 @@ public class J2clSelectedWaveViewChromeTest {
     init.setBubbles(true);
     init.setComposed(true);
     target.dispatchEvent(new elemental2.dom.CustomEvent<Object>(eventName, init));
+  }
+
+  private static HTMLElement taskBlip(String blipId) {
+    HTMLElement blip = (HTMLElement) DomGlobal.document.createElement("wave-blip");
+    blip.setAttribute("data-blip-id", blipId);
+    return blip;
+  }
+
+  private static HTMLElement taskAffordance(String blipId, boolean completed) {
+    HTMLElement affordance =
+        (HTMLElement) DomGlobal.document.createElement("wavy-task-affordance");
+    affordance.setAttribute("data-blip-id", blipId);
+    if (completed) {
+      affordance.setAttribute("data-task-completed", "");
+    }
+    return affordance;
+  }
+
+  private static void dispatchTaskToggle(
+      HTMLElement affordance, String blipId, String taskId, boolean completed) {
+    elemental2.dom.CustomEventInit<Object> init = elemental2.dom.CustomEventInit.create();
+    init.setBubbles(true);
+    init.setComposed(true);
+    jsinterop.base.JsPropertyMap<Object> detail = jsinterop.base.JsPropertyMap.of();
+    detail.set("blipId", blipId);
+    detail.set("taskId", taskId);
+    detail.set("completed", completed);
+    init.setDetail(detail);
+    affordance.addEventListener(
+        "wave-blip-task-toggled",
+        evt -> J2clSelectedWaveView.applyOptimisticTaskHostState(evt, blipId, taskId, completed));
+    affordance.dispatchEvent(
+        new elemental2.dom.CustomEvent<Object>("wave-blip-task-toggled", init));
   }
 
   private static void assumeBrowserDom() {

--- a/wave/config/changelog.d/2026-05-09-issue-1225-j2cl-task-parity-followup.json
+++ b/wave/config/changelog.d/2026-05-09-issue-1225-j2cl-task-parity-followup.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-09-issue-1225-j2cl-task-parity-followup",
+  "version": "Issue #1225",
+  "date": "2026-05-09",
+  "title": "J2CL task controls keep completion state and task details aligned with the legacy wave view.",
+  "summary": "The J2CL read surface now updates task completion state immediately when a task is toggled and tightens the task details dialog layout toward the legacy GWT popup.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Keeps the parent blip's task-completed marker in sync with per-task toggles while preserving multi-task blip behavior.",
+        "Adjusts the J2CL task details dialog spacing and controls to better match the GWT task metadata popup."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- fix-forward after #1226 merged before parity E2E completed
- immediately sync parent wave-blip task-completed state from per-task toggles while preserving multi-task semantics
- align the J2CL task details popup spacing with the GWT popup and keep action buttons inline
- add focused Java/Lit regression coverage and changelog fragment

## Verification
- cd j2cl/lit && npm test -- --run --coverage=false test/task-metadata-popover.test.js test/wavy-task-affordance.test.js
- cd j2cl && ./mvnw -Dtest=org.waveprotocol.box.j2cl.search.J2clSelectedWaveViewChromeTest,org.waveprotocol.box.j2cl.read.J2clReadSurfaceDomRendererTest,org.waveprotocol.box.j2cl.overlay.J2clOverlayModelTest test
- cd j2cl/lit && npm run build
- python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py
- git diff --check origin/main...HEAD

Fixes follow-up parity failures from #1226.
Refs #1225.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task-completed marker synchronization on blips to correctly reflect when all associated tasks are completed.
  * Improved task toggle handling to accurately track completion state across individual tasks.

* **Style**
  * Refined task metadata dialog layout with improved spacing for typography and controls.
  * Enhanced button alignment and margins for better visual organization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1230)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->