### PR TITLE
Stabilize GWT task overlay parity selector

### DIFF
--- a/wave/src/e2e/j2cl-gwt-parity/tests/helpers/visualRegions.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/helpers/visualRegions.ts
@@ -110,9 +110,6 @@ export function taskOverlayRegionJ2cl(page: Page): Locator {
 }
 
 export function taskOverlayRegionGwt(page: Page): Locator {
-  // GWT renderer: TaskMetadataPopup inside DesktopUniversalPopup chrome.
-  return page
-    .getByText("Task details", { exact: true })
-    .last()
-    .locator("xpath=ancestor::*[.//select and .//*[normalize-space()='Due date']][1]");
+  // GWT renderer: TaskMetadataPopup panel inside DesktopUniversalPopup chrome.
+  return page.locator("[data-e2e='gwt-task-metadata-popup']:visible").last();
 }

--- a/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TaskMetadataPopup.java
+++ b/wave/src/main/java/org/waveprotocol/wave/client/wavepanel/impl/edit/TaskMetadataPopup.java
@@ -134,6 +134,7 @@ public final class TaskMetadataPopup extends Composite {
 
     FlowPanel panel = new FlowPanel();
     panel.addStyleName(style.self());
+    panel.getElement().setAttribute("data-e2e", "gwt-task-metadata-popup");
 
     titleLabel = new Label("Task details");
     titleLabel.addStyleName(style.title());


### PR DESCRIPTION
## Summary
- fix-forward after #1230 left only the task overlay visual parity check failing
- add a stable `data-e2e="gwt-task-metadata-popup"` hook to the GWT task metadata popup panel
- update the parity helper to target that hook instead of the broad text/ancestor XPath

## Verification
- git diff --check origin/main...HEAD
- cd wave/src/e2e/j2cl-gwt-parity && npm test -- --list (blocked locally: missing @playwright/test in this worktree; CI parity job is the verifier)
- Claude review: no blockers

Refs #1225. Follow-up to #1226 and #1230.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced task metadata popup element detection in end-to-end tests for improved reliability and consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1231)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->