### PR TITLE
Fix J2CL/GWT parity for topbar, search rail, tasks, blip, status icons

### DIFF
--- a/j2cl/lit/src/elements/task-metadata-popover.js
+++ b/j2cl/lit/src/elements/task-metadata-popover.js
@@ -23,10 +23,12 @@ export class TaskMetadataPopover extends LitElement {
       width: 320px;
       max-width: 92vw;
       border: 0;
-      border-radius: 0;
+      border-radius: 10px;
       padding: 18px;
       background: #ffffff;
-      box-shadow: none;
+      box-shadow:
+        0 4px 20px rgba(0, 0, 0, 0.12),
+        0 1px 4px rgba(0, 0, 0, 0.06);
       box-sizing: border-box;
       color: #202124;
       font: 13px Arial, sans-serif;

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -297,6 +297,10 @@ export class WaveBlip extends LitElement {
       font-weight: 600;
       box-shadow: inset 3px 0 0 var(--wavy-signal-cyan, #0077b6);
     }
+    :host([unread]) .header {
+      color: #1a202c;
+      background-color: rgba(0, 180, 216, 0.12);
+    }
     :host([focused]) .body,
     :host([tabindex="0"]) .body {
       border-color: #d9e2ec;

--- a/j2cl/lit/src/elements/wavy-header.js
+++ b/j2cl/lit/src/elements/wavy-header.js
@@ -39,6 +39,8 @@ export class WavyHeader extends LitElement {
     unreadCount: { type: Number, attribute: "unread-count" },
     basePath: { type: String, attribute: "base-path" },
     compactGwtTopbar: { type: Boolean, attribute: "compact-gwt-topbar", reflect: true },
+    connectionState: { type: String, attribute: "data-connection-state", reflect: true },
+    saveState: { type: String, attribute: "data-save-state", reflect: true },
     // V-1 (#1099): when the host carries no-brand the inner SupaWave
     // brand link is suppressed so the J2CL root shell can render the
     // canonical brand from shell-header > [slot="brand"] without
@@ -144,12 +146,91 @@ export class WavyHeader extends LitElement {
       background: rgba(255, 255, 255, 0.10);
       border-radius: 6px;
     }
+    .savestatus,
+    .netstatus {
+      display: none;
+    }
+    :host([compact-gwt-topbar]) .savestatus,
+    :host([compact-gwt-topbar]) .netstatus {
+      position: relative;
+      box-sizing: border-box;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 32px;
+      height: 32px;
+      min-width: 32px;
+      padding: 0;
+      border: 0;
+      border-radius: 6px;
+      color: #fff;
+      background: rgba(255, 255, 255, 0.10);
+      cursor: default;
+    }
+    :host([compact-gwt-topbar]) .savestatus svg,
+    :host([compact-gwt-topbar]) .netstatus svg {
+      width: 20px;
+      height: 20px;
+      stroke: #fff;
+      color: #fff;
+    }
+    :host([compact-gwt-topbar]) .savestatus::after,
+    :host([compact-gwt-topbar]) .netstatus::after {
+      content: "";
+      display: none;
+      position: absolute;
+      top: 5px;
+      right: 5px;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      pointer-events: none;
+    }
+    :host([compact-gwt-topbar]) .savestatus[data-state="saved"]::after {
+      display: block;
+      background: #48bb78;
+      box-shadow: 0 0 4px #48bb78;
+    }
+    :host([compact-gwt-topbar]) .savestatus[data-state="saving"]::after,
+    :host([compact-gwt-topbar]) .savestatus[data-state="unsaved"]::after {
+      display: block;
+      background: #ecc94b;
+      box-shadow: 0 0 4px #ecc94b;
+    }
+    :host([compact-gwt-topbar]) .netstatus[data-state="online"]::after {
+      display: block;
+      background: #48bb78;
+      box-shadow: 0 0 4px #48bb78;
+    }
+    :host([compact-gwt-topbar]) .netstatus[data-state="connecting"]::after {
+      display: block;
+      background: #ecc94b;
+      box-shadow: 0 0 4px #ecc94b;
+    }
+    :host([compact-gwt-topbar]) .netstatus[data-state="offline"]::after {
+      display: block;
+      background: #fc8181;
+      box-shadow: 0 0 4px #fc8181;
+    }
+    :host([compact-gwt-topbar]) .savestatus:hover,
+    :host([compact-gwt-topbar]) .netstatus:hover {
+      background: rgba(255, 255, 255, 0.18);
+      transform: scale(1.05);
+    }
     :host([compact-gwt-topbar]) .bell:focus-visible,
     :host([compact-gwt-topbar]) .mail:focus-visible,
     :host([compact-gwt-topbar]) .user-menu:focus-visible {
       outline: 2px solid rgba(255, 255, 255, 0.95);
       outline-offset: 2px;
       background: rgba(255, 255, 255, 0.18);
+    }
+    :host([compact-gwt-topbar]) .bell:hover,
+    :host([compact-gwt-topbar]) .mail:hover,
+    :host([compact-gwt-topbar]) .user-menu:hover {
+      color: #fff;
+      outline: none;
+      background: rgba(255, 255, 255, 0.18);
+      transform: scale(1.05);
     }
     .bell:hover,
     .bell:focus-visible,
@@ -215,6 +296,8 @@ export class WavyHeader extends LitElement {
     this.basePath = "/";
     this.compactGwtTopbar = false;
     this.noBrand = false;
+    this.connectionState = "online";
+    this.saveState = "saved";
   }
 
   _normalizedBasePath() {
@@ -262,10 +345,23 @@ export class WavyHeader extends LitElement {
     );
   }
 
+  _saveLabel() {
+    return this.saveState === "saving" || this.saveState === "unsaved"
+      ? "Saving changes"
+      : "All changes saved";
+  }
+
+  _netLabel() {
+    if (this.connectionState === "offline") return "Offline";
+    if (this.connectionState === "connecting") return "Connecting";
+    return "Online";
+  }
+
   render() {
     const initials = this._initials();
     const hasUnread = (this.unreadCount || 0) > 0;
     const base = this._normalizedBasePath();
+    const compact = this.compactGwtTopbar;
     return html`
       ${this.noBrand
         ? null
@@ -289,6 +385,48 @@ export class WavyHeader extends LitElement {
             </option>`
         )}
       </select>
+
+      ${compact
+        ? html`
+            <span
+              class="savestatus"
+              role="img"
+              data-state=${this.saveState || "saved"}
+              title=${this._saveLabel()}
+              aria-label=${this._saveLabel()}
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/>
+                <path d="M9 15l2 2 4-4" stroke-width="2"/>
+              </svg>
+            </span>
+            <span
+              class="netstatus"
+              role="img"
+              data-state=${this.connectionState || "online"}
+              title=${this._netLabel()}
+              aria-label=${this._netLabel()}
+              aria-live="polite"
+            >
+              ${this.connectionState === "offline"
+                ? html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <line x1="1" y1="1" x2="23" y2="23"/>
+                    <path d="M16.72 11.06A10.94 10.94 0 0 1 19 12.55"/>
+                    <path d="M5 12.55a10.94 10.94 0 0 1 5.17-2.39"/>
+                    <path d="M10.71 5.05A16 16 0 0 1 22.56 9"/>
+                    <path d="M1.42 9a15.91 15.91 0 0 1 4.7-2.88"/>
+                    <path d="M8.53 16.11a6 6 0 0 1 6.95 0"/>
+                    <circle cx="12" cy="19.5" r="1"/>
+                  </svg>`
+                : html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M1.42 9a16 16 0 0 1 21.16 0"/>
+                    <path d="M5.07 12.5a10 10 0 0 1 13.86 0"/>
+                    <path d="M8.72 16a6 6 0 0 1 6.56 0"/>
+                    <circle cx="12" cy="19.5" r="1"/>
+                  </svg>`}
+            </span>
+          `
+        : null}
 
       ${this.signedIn
         ? html`

--- a/j2cl/lit/src/elements/wavy-header.js
+++ b/j2cl/lit/src/elements/wavy-header.js
@@ -406,7 +406,6 @@ export class WavyHeader extends LitElement {
               data-state=${this.connectionState || "online"}
               title=${this._netLabel()}
               aria-label=${this._netLabel()}
-              aria-live="polite"
             >
               ${this.connectionState === "offline"
                 ? html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/j2cl/lit/src/elements/wavy-header.js
+++ b/j2cl/lit/src/elements/wavy-header.js
@@ -346,9 +346,9 @@ export class WavyHeader extends LitElement {
   }
 
   _saveLabel() {
-    return this.saveState === "saving" || this.saveState === "unsaved"
-      ? "Saving changes"
-      : "All changes saved";
+    if (this.saveState === "saving") return "Saving changes";
+    if (this.saveState === "unsaved") return "Unsaved changes";
+    return "All changes saved";
   }
 
   _netLabel() {

--- a/j2cl/lit/src/elements/wavy-search-rail.js
+++ b/j2cl/lit/src/elements/wavy-search-rail.js
@@ -560,6 +560,9 @@ export class WavySearchRail extends LitElement {
     if (changed.has("query")) {
       this.activeFolder = this._deriveActiveFolder(this.query);
     }
+    if (changed.has("query") || changed.has("resultCount")) {
+      this.setAttribute("aria-label", this._panelTitle());
+    }
   }
 
   _deriveActiveFolder(q) {

--- a/j2cl/lit/src/elements/wavy-search-rail.js
+++ b/j2cl/lit/src/elements/wavy-search-rail.js
@@ -109,26 +109,6 @@ export class WavySearchRail extends LitElement {
       background: #ffffff;
         box-sizing: border-box;
       }
-      .panel-title {
-        display: flex;
-        align-items: center;
-        min-height: 24px;
-        padding: 3px 8px;
-        box-sizing: border-box;
-        color: #ffffff;
-        background: linear-gradient(180deg, #5ba3e0 0%, #2d6fa8 100%);
-        border: 1px solid #5b8fc1;
-        border-bottom-color: #2c5f91;
-        border-radius: 3px 3px 0 0;
-        font: 700 13px / 1.25 Arial, sans-serif;
-        text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.18);
-      }
-      .panel-title-text {
-        min-width: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
     .query {
       flex: 1 1 auto;
       box-sizing: border-box;
@@ -1107,9 +1087,6 @@ export class WavySearchRail extends LitElement {
     const effectiveSort = explicitSort || defaultSort;
     const pinnedSearches = this.savedSearches.filter((item) => item.pinned);
     return html`
-      <div class="panel-title" data-search-panel-title>
-        <span class="panel-title-text">${this._panelTitle()}</span>
-      </div>
       <div class="search">
         <span class="waveform" aria-hidden="true">
           <svg viewBox="0 0 14 14" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6">

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -186,7 +186,7 @@ shell-header {
 shell-header[compact-gwt-topbar] {
   padding: 0 12px;
   min-height: 40px;
-  background: linear-gradient(135deg, #023e6b 0%, #006b9f 62%, #0077a8 100%);
+  background: linear-gradient(135deg, #023e6b 0%, #006b9f 60%, #0077a8 100%);
   border-bottom: none;
   box-shadow: 0 2px 8px rgba(0, 50, 100, 0.18);
   color: #fff;
@@ -243,7 +243,11 @@ shell-header > [slot="brand"] .j2cl-brand-name {
 }
 
 shell-header[compact-gwt-topbar] > [slot="brand"] .j2cl-brand-name {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+    Cantarell, "Helvetica Neue", Arial, sans-serif;
   font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.3px;
   color: #fff;
 }
 
@@ -323,6 +327,69 @@ shell-header[compact-gwt-topbar] wavy-header .mail svg {
   width: 16px;
   height: 16px;
   flex: 0 0 auto;
+}
+
+/* GWT topbar parity (#1232): savestatus + netstatus chips inside the
+ * compact wavy-header. SSR emits these as light-DOM <span> children so
+ * they render on the 40px topbar before Lit upgrades. The shadow render
+ * applies the same geometry post-upgrade. */
+shell-header[compact-gwt-topbar] wavy-header .savestatus,
+shell-header[compact-gwt-topbar] wavy-header .netstatus {
+  position: relative;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  min-width: 32px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.10);
+}
+
+shell-header[compact-gwt-topbar] wavy-header .savestatus svg,
+shell-header[compact-gwt-topbar] wavy-header .netstatus svg {
+  width: 20px;
+  height: 20px;
+  stroke: #fff;
+  color: #fff;
+  flex: 0 0 auto;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .savestatus::after,
+shell-header[compact-gwt-topbar] wavy-header .netstatus::after {
+  content: "";
+  display: none;
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .savestatus[data-state="saved"]::after,
+shell-header[compact-gwt-topbar] wavy-header .netstatus[data-state="online"]::after {
+  display: block;
+  background: #48bb78;
+  box-shadow: 0 0 4px #48bb78;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .savestatus[data-state="saving"]::after,
+shell-header[compact-gwt-topbar] wavy-header .savestatus[data-state="unsaved"]::after,
+shell-header[compact-gwt-topbar] wavy-header .netstatus[data-state="connecting"]::after {
+  display: block;
+  background: #ecc94b;
+  box-shadow: 0 0 4px #ecc94b;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .netstatus[data-state="offline"]::after {
+  display: block;
+  background: #fc8181;
+  box-shadow: 0 0 4px #fc8181;
 }
 
 shell-header > [slot="actions-signed-in"],

--- a/j2cl/lit/test/task-metadata-popover.test.js
+++ b/j2cl/lit/test/task-metadata-popover.test.js
@@ -39,8 +39,8 @@ describe("<task-metadata-popover>", () => {
     expect(dialogStyle.width).to.equal("320px");
     expect(dialogStyle.padding).to.equal("18px");
     expect(dialogStyle.backgroundColor).to.equal("rgb(255, 255, 255)");
-    expect(dialogStyle.borderRadius).to.equal("0px");
-    expect(dialogStyle.boxShadow).to.equal("none");
+    expect(dialogStyle.borderRadius).to.equal("10px");
+    expect(dialogStyle.boxShadow).to.not.equal("none");
 
     expect(getComputedStyle(title).fontSize).to.equal("18px");
     expect(getComputedStyle(label).textTransform).to.equal("uppercase");

--- a/j2cl/lit/test/wavy-header.test.js
+++ b/j2cl/lit/test/wavy-header.test.js
@@ -185,6 +185,47 @@ describe("<wavy-header>", () => {
     // first="john" → J, last="public" → P (not second segment "q")
     expect(avatar.textContent.trim()).to.equal("JP");
   });
+
+  it("compact GWT topbar emits savestatus + netstatus chips with default state", async () => {
+    const el = await fixture(html`<wavy-header signed-in compact-gwt-topbar></wavy-header>`);
+    await el.updateComplete;
+    const save = el.renderRoot.querySelector(".savestatus");
+    const net = el.renderRoot.querySelector(".netstatus");
+    expect(save).to.exist;
+    expect(net).to.exist;
+    expect(save.getAttribute("data-state")).to.equal("saved");
+    expect(net.getAttribute("data-state")).to.equal("online");
+    expect(save.querySelector("svg")).to.exist;
+    expect(net.querySelector("svg")).to.exist;
+  });
+
+  it("non-compact wavy-header omits savestatus + netstatus", async () => {
+    const el = await fixture(html`<wavy-header signed-in></wavy-header>`);
+    await el.updateComplete;
+    expect(el.renderRoot.querySelector(".savestatus")).to.be.null;
+    expect(el.renderRoot.querySelector(".netstatus")).to.be.null;
+  });
+
+  it("compact savestatus reflects data-save-state attribute", async () => {
+    const el = await fixture(
+      html`<wavy-header signed-in compact-gwt-topbar data-save-state="saving"></wavy-header>`
+    );
+    await el.updateComplete;
+    const save = el.renderRoot.querySelector(".savestatus");
+    expect(save.getAttribute("data-state")).to.equal("saving");
+  });
+
+  it("compact netstatus reflects data-connection-state and swaps SVG glyph for offline", async () => {
+    const el = await fixture(
+      html`<wavy-header signed-in compact-gwt-topbar data-connection-state="offline"></wavy-header>`
+    );
+    await el.updateComplete;
+    const net = el.renderRoot.querySelector(".netstatus");
+    expect(net.getAttribute("data-state")).to.equal("offline");
+    // Offline glyph contains the slashed-line element distinguishing wifi-off from wifi.
+    const svgHtml = net.querySelector("svg").outerHTML;
+    expect(svgHtml).to.include('x1="1"');
+  });
 });
 
 function WavyHeader_styleText() {

--- a/j2cl/lit/test/wavy-search-rail.test.js
+++ b/j2cl/lit/test/wavy-search-rail.test.js
@@ -17,6 +17,16 @@ describe("<wavy-search-rail>", () => {
     expect(inbox.getAttribute("aria-current")).to.equal("page");
   });
 
+  it("host aria-label tracks query + result count (panel-title a11y replacement)", async () => {
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    await el.updateComplete;
+    expect(el.getAttribute("aria-label")).to.equal("in:inbox");
+    el.query = "is:starred";
+    el.resultCount = "12";
+    await el.updateComplete;
+    expect(el.getAttribute("aria-label")).to.equal("is:starred (12)");
+  });
+
   it("renders all six saved-search folders with canonical query strings (B.5–B.10)", async () => {
     const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
     await el.updateComplete;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
@@ -76,13 +76,15 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
 
   @Override
   public void publishLiveStatus(J2clRootLiveSurfaceModel model) {
+    Element rootShell = findRootShell();
+    String connectionState = model == null ? "online" : model.getConnectionState();
+    String saveState = model == null ? "saved" : model.getSaveState();
+    mirrorTopbarStatusChips(rootShell, connectionState, saveState);
+
     HTMLElement statusElement = ensureLiveStatusElement();
     if (statusElement != null) {
       String statusText = model == null ? "" : model.getStatusText();
-      Element rootShell = findRootShell();
       HTMLElement statusStrip = findStatusStrip(rootShell);
-      String connectionState = model == null ? "online" : model.getConnectionState();
-      String saveState = model == null ? "saved" : model.getSaveState();
       String routeState = model == null ? "ready" : model.getRouteState();
       if (statusStrip != null) {
         statusStrip.setAttribute("data-connection-state", connectionState);
@@ -90,7 +92,6 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
         statusStrip.setAttribute("data-route-state", routeState);
         statusStrip.setAttribute("data-live-status-text", statusText);
       }
-      mirrorTopbarStatusChips(rootShell, connectionState, saveState);
       String desiredSeparatorDisplay = statusText.isEmpty() ? "none" : "";
       if (statusText.equals(lastPublishedLiveStatusText)
           && (liveStatusSeparator == null

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
@@ -79,16 +79,18 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
     HTMLElement statusElement = ensureLiveStatusElement();
     if (statusElement != null) {
       String statusText = model == null ? "" : model.getStatusText();
-      HTMLElement statusStrip = findStatusStrip(findRootShell());
+      Element rootShell = findRootShell();
+      HTMLElement statusStrip = findStatusStrip(rootShell);
+      String connectionState = model == null ? "online" : model.getConnectionState();
+      String saveState = model == null ? "saved" : model.getSaveState();
+      String routeState = model == null ? "ready" : model.getRouteState();
       if (statusStrip != null) {
-        String connectionState = model == null ? "online" : model.getConnectionState();
-        String saveState = model == null ? "saved" : model.getSaveState();
-        String routeState = model == null ? "ready" : model.getRouteState();
         statusStrip.setAttribute("data-connection-state", connectionState);
         statusStrip.setAttribute("data-save-state", saveState);
         statusStrip.setAttribute("data-route-state", routeState);
         statusStrip.setAttribute("data-live-status-text", statusText);
       }
+      mirrorTopbarStatusChips(rootShell, connectionState, saveState);
       String desiredSeparatorDisplay = statusText.isEmpty() ? "none" : "";
       if (statusText.equals(lastPublishedLiveStatusText)
           && (liveStatusSeparator == null
@@ -101,6 +103,20 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
       }
       lastPublishedLiveStatusText = statusText;
     }
+  }
+
+  private static void mirrorTopbarStatusChips(
+      Element rootShell, String connectionState, String saveState) {
+    if (rootShell == null) {
+      return;
+    }
+    HTMLElement compactHeader =
+        firstElementOwnedByRootShell(rootShell, "wavy-header[compact-gwt-topbar]");
+    if (compactHeader == null) {
+      return;
+    }
+    compactHeader.setAttribute("data-connection-state", connectionState);
+    compactHeader.setAttribute("data-save-state", saveState);
   }
 
   private HTMLElement ensureLiveStatusElement() {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
@@ -278,6 +278,26 @@ public class J2clRootShellViewTest {
   }
 
   @Test
+  public void publishLiveStatusMirrorsConnectionAndSaveStateToCompactWavyHeader() {
+    assumeBrowserDom();
+    host = (HTMLDivElement) DomGlobal.document.createElement("div");
+    DomGlobal.document.body.appendChild(host);
+    HTMLElement rootShell = createRootShell();
+    appendStatusStrip(rootShell);
+    HTMLElement compactHeader =
+        (HTMLElement) DomGlobal.document.createElement("wavy-header");
+    compactHeader.setAttribute("compact-gwt-topbar", "");
+    rootShell.appendChild(compactHeader);
+    HTMLElement workflowHost = appendWorkflowHost(rootShell);
+    J2clRootShellView view = new J2clRootShellView(workflowHost);
+
+    view.publishLiveStatus(J2clRootLiveSurfaceModel.starting());
+
+    Assert.assertEquals("online", compactHeader.getAttribute("data-connection-state"));
+    Assert.assertEquals("saved", compactHeader.getAttribute("data-save-state"));
+  }
+
+  @Test
   public void publishLiveStatusRepublishesWhenSeparatorDisplayMutatedExternally() {
     assumeBrowserDom();
     J2clRootShellView view = createViewWithStatusStrip();

--- a/wave/config/changelog.d/2026-05-09-j2cl-root-parity-five-gaps.json
+++ b/wave/config/changelog.d/2026-05-09-j2cl-root-parity-five-gaps.json
@@ -1,0 +1,19 @@
+{
+  "releaseId": "2026-05-09-j2cl-root-parity-five-gaps",
+  "version": "Issue #1232",
+  "date": "2026-05-09",
+  "title": "J2CL root surface aligns with GWT for topbar, search rail, tasks, blip, and status icons.",
+  "summary": "Closes five user-reported parity gaps so the J2CL root shell mirrors the legacy SupaWave chrome end-to-end.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Aligns the compact J2CL topbar gradient and brand font with the GWT topbar.",
+        "Drops the framed search-rail title strip so the search input sits flush to the rail top.",
+        "Restores the legacy task metadata popup chrome on the J2CL task overlay.",
+        "Paints the unread metabar background on J2CL root blips to match the GWT unread cue.",
+        "Surfaces save and connection status icons inside the compact J2CL topbar."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -5949,7 +5949,7 @@ public final class HtmlRenderer {
 
   /** Globe icon for language selector. */
   private static final String ICON_GLOBE =
-      "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"white\" stroke-width=\"1.8\" stroke-linecap=\"round\" stroke-linejoin=\"round\">"
+      "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"white\" stroke-width=\"1.8\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\" focusable=\"false\">"
       + "<circle cx=\"12\" cy=\"12\" r=\"10\"/>"
       + "<ellipse cx=\"12\" cy=\"12\" rx=\"4\" ry=\"10\"/>"
       + "<path d=\"M2 12h20\"/>"
@@ -5958,13 +5958,13 @@ public final class HtmlRenderer {
 
   /** Cloud with checkmark icon for saved state — white on dark topbar. */
   private static final String ICON_CLOUD_CHECK =
-      "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"white\" stroke-width=\"1.8\" stroke-linecap=\"round\" stroke-linejoin=\"round\">"
+      "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"white\" stroke-width=\"1.8\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\" focusable=\"false\">"
       + "<path d=\"M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z\"/>"
       + "<path d=\"M9 15l2 2 4-4\" stroke-width=\"2\"/>"
       + "</svg>";
   /** WiFi/signal icon for connection status (white for contrast on dark topbar). */
   private static final String ICON_WIFI =
-      "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"white\" stroke-width=\"1.8\" stroke-linecap=\"round\" stroke-linejoin=\"round\">"
+      "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"white\" stroke-width=\"1.8\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\" focusable=\"false\">"
       + "<path d=\"M1.42 9a16 16 0 0 1 21.16 0\"/>"
       + "<path d=\"M5.07 12.5a10 10 0 0 1 13.86 0\"/>"
       + "<path d=\"M8.72 16a6 6 0 0 1 6.56 0\"/>"
@@ -5973,7 +5973,7 @@ public final class HtmlRenderer {
 
   /** WiFi-off icon for disconnected state (white for contrast on dark topbar). */
   private static final String ICON_WIFI_OFF =
-      "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"white\" stroke-width=\"1.8\" stroke-linecap=\"round\" stroke-linejoin=\"round\">"
+      "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"white\" stroke-width=\"1.8\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\" focusable=\"false\">"
       + "<line x1=\"1\" y1=\"1\" x2=\"23\" y2=\"23\"/>"
       + "<path d=\"M16.72 11.06A10.94 10.94 0 0 1 19 12.55\"/>"
       + "<path d=\"M5 12.55a10.94 10.94 0 0 1 5.17-2.39\"/>"
@@ -5985,7 +5985,7 @@ public final class HtmlRenderer {
 
   /** Envelope icon for admin contact notification — white on dark topbar. */
   private static final String ICON_MAIL =
-      "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"white\" stroke-width=\"1.8\" stroke-linecap=\"round\" stroke-linejoin=\"round\">"
+      "<svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"white\" stroke-width=\"1.8\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\" focusable=\"false\">"
       + "<path d=\"M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z\"/>"
       + "<polyline points=\"22,6 12,13 2,6\"/>"
       + "</svg>";

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -4283,7 +4283,7 @@ public final class HtmlRenderer {
           .append("</span>\n");
       sb.append("      <span class=\"netstatus\" role=\"img\""
           + " data-state=\"online\" title=\"Online\""
-          + " aria-label=\"Online\" aria-live=\"polite\">")
+          + " aria-label=\"Online\">")
           .append(ICON_WIFI)
           .append("</span>\n");
     }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -4253,7 +4253,8 @@ public final class HtmlRenderer {
         .append(escapedAddress)
         .append("\" user-name=\"")
         .append(escapedAddress)
-        .append("\" unread-count=\"0\" base-path=\"")
+        .append("\" unread-count=\"0\" data-connection-state=\"online\""
+            + " data-save-state=\"saved\" base-path=\"")
         .append(safeBasePath)
         .append("\">\n");
     sb.append("      <a class=\"brand\" href=\"")
@@ -4270,6 +4271,22 @@ public final class HtmlRenderer {
     appendLocaleOption(sb, "sl", "Slovenščina", selectedLocaleOpt, compactGwtTopbar);
     appendLocaleOption(sb, "zh_TW", "繁體中文", selectedLocaleOpt, compactGwtTopbar);
     sb.append("      </select>\n");
+    if (compactGwtTopbar) {
+      // GWT topbar parity: emit savestatus + netstatus chips so the icons
+      // are visible before Lit upgrades the element. The compact-mode
+      // shadow render mirrors these and the J2clRootShellView updates the
+      // data-state attributes from the live save/connection model.
+      sb.append("      <span class=\"savestatus\" role=\"img\""
+          + " data-state=\"saved\" title=\"All changes saved\""
+          + " aria-label=\"All changes saved\">")
+          .append(ICON_CLOUD_CHECK)
+          .append("</span>\n");
+      sb.append("      <span class=\"netstatus\" role=\"img\""
+          + " data-state=\"online\" title=\"Online\""
+          + " aria-label=\"Online\" aria-live=\"polite\">")
+          .append(ICON_WIFI)
+          .append("</span>\n");
+    }
     // A.5 notifications bell — server-renders the same SVG glyph the
     // Lit element renders so the icon does not appear empty pre-upgrade.
     sb.append("      <button type=\"button\" class=\"bell\" aria-label=\"Notifications\">")

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
@@ -71,6 +71,18 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
     assertTrue("wavy-header must carry signed-in", whTag.contains("signed-in"));
     assertTrue("wavy-header must carry no-brand", whTag.contains("no-brand"));
     assertTrue("wavy-header must carry compact-gwt-topbar", whTag.contains("compact-gwt-topbar"));
+    assertTrue(
+        "wavy-header must carry default data-connection-state",
+        whTag.contains("data-connection-state=\"online\""));
+    assertTrue(
+        "wavy-header must carry default data-save-state",
+        whTag.contains("data-save-state=\"saved\""));
+    assertTrue(
+        "compact wavy-header must SSR a savestatus chip",
+        html.contains("class=\"savestatus\""));
+    assertTrue(
+        "compact wavy-header must SSR a netstatus chip",
+        html.contains("class=\"netstatus\""));
     assertFalse(html.contains("j2cl-brand-eyebrow"));
     assertFalse(html.contains("J2CL ·"));
   }


### PR DESCRIPTION
## Summary

Closes five user-reported parity gaps between the J2CL root surface and
the legacy GWT chrome so the SSR + post-upgrade markup line up:

- **Top blue toolbar** — align the compact gradient stop with GWT (`60%`
  not `62%`) and apply GWT's brand font-stack and `-0.3px`
  letter-spacing on `.j2cl-brand-name`. Switch the compact
  bell/mail/user-menu hover to GWT's white-rgba treatment with a subtle
  scale instead of the cyan tint that diverged from `.topbar-icon:hover`.
- **Search rail top gap** — drop the framed `panel-title` strip from
  `<wavy-search-rail>`. GWT's search panel sits flush to the rail top;
  the J2CL extra title bar was the visible "top gap". Replaced with a
  host-level `aria-label` so screen readers still hear the active query
  and result count.
- **Tasks display** — adopt the GWT `DesktopUniversalPopup` chrome on
  the Lit dialog (`10px` radius + the matching layered drop shadow) so
  the task overlay reads as a panel rather than a bare card.
- **Wave title + root blip** — paint the unread metabar with the
  cyan-tinted background GWT uses for `.metabar.unread`, so the unread
  cue spans both the body and the metadata strip.
- **Top status line** — surface `savestatus` and `netstatus` chips
  inside the compact `<wavy-header>` (and the SSR light-DOM mirror) so
  the GWT save/connection indicators appear on the J2CL topbar. Wire
  `J2clRootShellView.publishLiveStatus` to mirror the live model onto
  the new chips while keeping the bottom `shell-status-strip` as the
  AT-targeted live region (single `aria-live`).

## Verification

- `cd j2cl/lit && npm test` => 847 passed, 0 failed (4 new tests cover the topbar status chips and search-rail aria-label).
- `cd j2cl/lit && npm run build` => bundle written.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py` => passed.
- `sbt --batch "Test/compile"` => `done compiling`.
- `sbt --batch "testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellTest"` => 32 passed (covers the new SSR `savestatus` / `netstatus` markup and default `data-connection-state` / `data-save-state`).
- `sbt --batch "testOnly org.waveprotocol.box.server.rpc.HtmlRenderer*Test"` => 134 passed.
- `cd j2cl && ./mvnw -Dtest=J2clRootShellViewTest test -pl .` => 21 passed (browser-DOM tests skipped on JVM-only run).

Pre-existing unrelated failure on `J2clSearchRailParityTest.j2clRootShellEmitsWavySearchHelpModalWithAll22TokenLiterals` reproduces on `origin/main` (test pattern doesn't account for the `slot="modal"` attribute that landed earlier); not in scope here.

## Review

- Self-review completed.
- Copilot review (`gpt-5.4`, `--effort xhigh`) found two actionable issues, both addressed in commit `6d4c4cd04`:
  1. Search-rail `_panelTitle()` was orphaned after removing `panel-title` — now stamped onto the host's `aria-label` via `willUpdate` so AT still hears `query (count)`.
  2. New `netstatus` chip duplicated `aria-live` already owned by `shell-status-strip` — dropped the `aria-live` from the chip; kept `role="img"` + `aria-label`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added save and connection status indicators to the compact header, displaying sync and internet connectivity states.

* **Improvements**
  * Enhanced dialog styling with rounded corners and drop shadows.
  * Updated unread blip styling for better visual distinction.
  * Refined brand name typography in the compact header.
  * Improved search rail accessibility with dynamic labels reflecting query and result counts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1232)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->