### PR TITLE
Round 2 J2CL/GWT parity: rail title strip, brand→landing, right-cluster

### DIFF
--- a/j2cl/lit/src/elements/wavy-search-rail.js
+++ b/j2cl/lit/src/elements/wavy-search-rail.js
@@ -97,6 +97,25 @@ export class WavySearchRail extends LitElement {
       font: var(--wavy-type-body, 13px / 1.35 Arial, sans-serif);
       min-width: 280px;
     }
+      /* GWT-parity (round 2): flat, full-width blue title strip that
+       * mirrors .sidecar-selected-title (sidecar.css) byte-for-byte so the
+       * rail and wave-panel headers sit at the same y / height / color
+       * side-by-side. The visible heading is aria-hidden so the host's
+       * aria-label remains the AT label. */
+      .panel-title {
+        box-sizing: border-box;
+        display: block;
+        min-height: 22px;
+        margin: 0;
+        padding: 3px 8px;
+        border-bottom: 1px solid #7aa7d9;
+        background: linear-gradient(180deg, #69a9ec 0%, #2f80d1 100%);
+        color: #ffffff;
+        font: 700 12px / 16px Arial, Helvetica, sans-serif;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
       .search {
       position: relative;
       display: flex;
@@ -1090,6 +1109,12 @@ export class WavySearchRail extends LitElement {
     const effectiveSort = explicitSort || defaultSort;
     const pinnedSearches = this.savedSearches.filter((item) => item.pinned);
     return html`
+      <h2
+        class="panel-title"
+        id="wavy-search-rail-title"
+        data-j2cl-rail-title
+        aria-hidden="true"
+      >${this._panelTitle()}</h2>
       <div class="search">
         <span class="waveform" aria-hidden="true">
           <svg viewBox="0 0 14 14" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6">

--- a/j2cl/lit/src/elements/wavy-search-rail.js
+++ b/j2cl/lit/src/elements/wavy-search-rail.js
@@ -97,9 +97,9 @@ export class WavySearchRail extends LitElement {
       font: var(--wavy-type-body, 13px / 1.35 Arial, sans-serif);
       min-width: 280px;
     }
-      /* GWT-parity (round 2): flat, full-width blue title strip that
-       * mirrors .sidecar-selected-title (sidecar.css) byte-for-byte so the
-       * rail and wave-panel headers sit at the same y / height / color
+      /* GWT-parity (round 2): flat, full-width blue title strip matching
+       * the geometry of .sidecar-selected-title (sidecar.css) so the rail
+       * and wave-panel headers sit at the same y / height / color
        * side-by-side. The visible heading is aria-hidden so the host's
        * aria-label remains the AT label. */
       .panel-title {

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -405,11 +405,40 @@ shell-header > [slot="actions-signed-out"] {
   box-sizing: border-box;
 }
 
+/* GWT-parity (round 2, #1233): pre-upgrade light-DOM mirror of the rail
+ * title strip and the topbar right-cluster container. Without these
+ * rules, the SSR <h2 class="panel-title"> renders as plain heading
+ * styling until shell.js upgrades the element. The shadow-DOM rule in
+ * wavy-search-rail.js carries identical values. */
+wavy-search-rail > .panel-title {
+  box-sizing: border-box;
+  display: block;
+  min-height: 22px;
+  margin: 0;
+  padding: 3px 8px;
+  border-bottom: 1px solid #7aa7d9;
+  background: linear-gradient(180deg, #69a9ec 0%, #2f80d1 100%);
+  color: #ffffff;
+  font: 700 12px / 16px Arial, Helvetica, sans-serif;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+shell-header[compact-gwt-topbar] wavy-header {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  gap: 8px;
+  margin-left: auto;
+}
+
 shell-header[compact-gwt-topbar] > [slot="actions-signed-in"],
 shell-header[compact-gwt-topbar] > [slot="actions-signed-out"] {
   min-height: 32px;
   height: 32px;
-  padding: 0 8px;
+  padding: 0 4px 0 8px;
+  margin-left: auto;
   border-radius: 6px;
   color: #fff;
 }

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -438,7 +438,6 @@ shell-header[compact-gwt-topbar] > [slot="actions-signed-out"] {
   min-height: 32px;
   height: 32px;
   padding: 0 4px 0 8px;
-  margin-left: auto;
   border-radius: 6px;
   color: #fff;
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellView.java
@@ -62,7 +62,8 @@ public final class J2clRootShellView implements J2clRootLiveSurfaceController.Sh
     }
     String returnTarget = resolveReturnTarget(routeUrl, shell);
     shell.setAttribute("data-j2cl-root-return-target", returnTarget);
-    updateHref(shell, "j2cl-root-brand-link", returnTarget);
+    // GWT parity (round 2): the brand link is a fixed hop to the marketing
+    // landing page; do not bind it to the J2CL return target.
     updateAuthHrefs(shell, "[data-j2cl-root-signin='true']", "/auth/signin", returnTarget);
     updateAuthHrefs(shell, "[data-j2cl-root-signout='true']", "/auth/signout", returnTarget);
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootShellViewTest.java
@@ -98,8 +98,8 @@ public class J2clRootShellViewTest {
     Assert.assertEquals(
         "/?view=j2cl-root&q=in%3Ainbox",
         secondRoot.getAttribute("data-j2cl-root-return-target"));
-    Assert.assertEquals(
-        "/?view=j2cl-root&q=in%3Ainbox",
+    // Round 2: brand link href is no longer driven by the return target.
+    Assert.assertNull(
         ((HTMLElement) secondRoot.querySelector("#j2cl-root-brand-link")).getAttribute("href"));
     Assert.assertEquals(
         "/auth/signin?r=/%3Fview%3Dj2cl-root%26q%3Din%253Ainbox",
@@ -136,8 +136,8 @@ public class J2clRootShellViewTest {
 
     view.syncReturnTarget("?view=j2cl-root&q=in%3Ainbox");
 
-    Assert.assertEquals(
-        "/?view=j2cl-root&q=in%3Ainbox",
+    // Round 2: brand link href is no longer driven by the return target.
+    Assert.assertNull(
         ((HTMLElement) outerRoot.querySelector("#j2cl-root-brand-link")).getAttribute("href"));
     Assert.assertEquals(
         "/auth/signin?r=/%3Fview%3Dj2cl-root%26q%3Din%253Ainbox",
@@ -329,8 +329,8 @@ public class J2clRootShellViewTest {
     Assert.assertEquals(
         "/app/?view=j2cl-root&q=in%3Ainbox",
         rootShell.getAttribute("data-j2cl-root-return-target"));
-    Assert.assertEquals(
-        "/app/?view=j2cl-root&q=in%3Ainbox",
+    // Round 2: brand link href is no longer driven by the return target.
+    Assert.assertNull(
         ((HTMLElement) rootShell.querySelector("#j2cl-root-brand-link")).getAttribute("href"));
   }
 
@@ -350,8 +350,8 @@ public class J2clRootShellViewTest {
     Assert.assertEquals(
         "/app?view=j2cl-root&q=in%3Ainbox",
         rootShell.getAttribute("data-j2cl-root-return-target"));
-    Assert.assertEquals(
-        "/app?view=j2cl-root&q=in%3Ainbox",
+    // Round 2: brand link href is no longer driven by the return target.
+    Assert.assertNull(
         ((HTMLElement) rootShell.querySelector("#j2cl-root-brand-link")).getAttribute("href"));
   }
 
@@ -371,8 +371,8 @@ public class J2clRootShellViewTest {
     Assert.assertEquals(
         "/?view=j2cl-root&q=in%3Ainbox",
         rootShell.getAttribute("data-j2cl-root-return-target"));
-    Assert.assertEquals(
-        "/?view=j2cl-root&q=in%3Ainbox",
+    // Round 2: brand link href is no longer driven by the return target.
+    Assert.assertNull(
         ((HTMLElement) rootShell.querySelector("#j2cl-root-brand-link")).getAttribute("href"));
   }
 

--- a/wave/config/changelog.d/2026-05-09-j2cl-parity-round2.json
+++ b/wave/config/changelog.d/2026-05-09-j2cl-parity-round2.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-05-09-j2cl-parity-round2",
+  "version": "Issue #1233",
+  "date": "2026-05-09",
+  "title": "J2CL search rail and wave-panel headers align with the GWT chrome side-by-side.",
+  "summary": "Round 2 parity work: restore the rail's blue title strip at GWT geometry, hop the brand link to the landing page, and tighten the topbar right cluster.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Restores a flat full-width blue title strip on the J2CL search rail that mirrors the wave-panel header so both panels' headers sit at the same y / height / color.",
+        "Sends the SupaWave brand link to the marketing landing page from the J2CL shell, matching the legacy GWT topbar.",
+        "Tightens the J2CL topbar right cluster so status and user-menu chips hug the viewport edge."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -4951,8 +4951,9 @@ public final class HtmlRenderer {
     sb.append("  var encoded=encodeLocalReturnTargetForQuery(target, fallback);\n");
     sb.append("  var shell=document.querySelector('[data-j2cl-root-shell]');\n");
     sb.append("  if(shell){shell.setAttribute('data-j2cl-root-return-target', target);}\n");
-    sb.append("  var brand=document.getElementById('j2cl-root-brand-link');\n");
-    sb.append("  if(brand){brand.href=target;}\n");
+    // Round 2: the brand link is a fixed hop to the marketing landing
+    // page (set at SSR render via J2CL_BRAND_HOME_HREF) and must not be
+    // rewritten by the return-target bootstrap.
     sb.append("  var targetText=document.getElementById('j2cl-root-return-target-text');\n");
     sb.append("  if(targetText){targetText.className='j2cl-status-live-text';targetText.textContent='Return target: ' + target;}\n");
     sb.append("  document.querySelectorAll('[data-j2cl-root-signin]').forEach(function(anchor){anchor.href='/auth/signin?r=' + encoded;});\n");

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -63,6 +63,11 @@ public final class HtmlRenderer {
   private static final String WAVE_FONT =
       "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', Arial, sans-serif";
   private static final String J2CL_ROOT_RETURN_TARGET = "/?view=j2cl-root";
+  // GWT-parity: clicking the SupaWave brand link returns to the marketing
+  // landing page, matching the legacy GWT topbar (HtmlRenderer.java:5874
+  // emits "/?view=landing" for the GWT brand). Hardcoded to a path so the
+  // J2CL shell does not bounce inside its own route.
+  private static final String J2CL_BRAND_HOME_HREF = "/?view=landing";
 
   // =========================================================================
   // User-menu CSS shared by the wave-client page and the standalone topbar
@@ -3565,9 +3570,10 @@ public final class HtmlRenderer {
           .append("</shell-skip-link>\n");
       sb.append("  <shell-header slot=\"header\" signed-in compact-gwt-topbar>\n");
       // Compact GWT parity: keep the SupaWave brand in the root shell header
-      // without exposing the J2CL route/debug eyebrow in the user chrome.
+      // without exposing the J2CL route/debug eyebrow in the user chrome. The
+      // brand href hops to the landing page (matches GWT topbar parity).
       sb.append("    <a slot=\"brand\" id=\"j2cl-root-brand-link\" href=\"")
-          .append(safeResolvedReturnTarget)
+          .append(J2CL_BRAND_HOME_HREF)
           .append("\" aria-label=\"SupaWave\">\n");
       sb.append("      <span class=\"j2cl-brand-mark\" aria-hidden=\"true\">")
           .append("<svg viewBox=\"0 0 48 48\" width=\"36\" height=\"36\" aria-hidden=\"true\">")
@@ -3697,9 +3703,9 @@ public final class HtmlRenderer {
           .append("</shell-skip-link>\n");
       sb.append("  <shell-header slot=\"header\" compact-gwt-topbar>\n");
       // Compact GWT parity: mirror the signed-in brand treatment without
-      // exposing the J2CL route/debug eyebrow.
+      // exposing the J2CL route/debug eyebrow; brand href hops to landing.
       sb.append("    <a slot=\"brand\" id=\"j2cl-root-brand-link\" href=\"")
-          .append(safeResolvedReturnTarget)
+          .append(J2CL_BRAND_HOME_HREF)
           .append("\" aria-label=\"SupaWave\">\n");
       sb.append("      <span class=\"j2cl-brand-mark\" aria-hidden=\"true\">")
           .append("<svg viewBox=\"0 0 48 48\" width=\"36\" height=\"36\" aria-hidden=\"true\">")
@@ -4387,6 +4393,15 @@ public final class HtmlRenderer {
       sb.append(" data-rail-cards-enabled=\"true\"");
     }
     sb.append(">\n");
+    // GWT-parity (round 2, #1233): blue title strip at the top of the rail.
+    // Mirrors `.sidecar-selected-title` so the rail header and the wave-panel
+    // header sit at identical y / height / color side-by-side. The visible
+    // heading is aria-hidden because the host's aria-label is the AT label
+    // (set by WavySearchRail.willUpdate).
+    sb.append("      <h2 class=\"panel-title\" id=\"wavy-search-rail-title\""
+        + " data-j2cl-rail-title aria-hidden=\"true\">")
+        .append(safeInitialQuery)
+        .append("</h2>\n");
     sb.append("      <div class=\"search\">\n");
     // F-2 slice 5 (#1055, A.4): explicit width/height on the SVG element.
     // Pre-upgrade, the Lit `:host { display:block }` rule has not attached

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -63,11 +63,6 @@ public final class HtmlRenderer {
   private static final String WAVE_FONT =
       "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', Arial, sans-serif";
   private static final String J2CL_ROOT_RETURN_TARGET = "/?view=j2cl-root";
-  // GWT-parity: clicking the SupaWave brand link returns to the marketing
-  // landing page, matching the legacy GWT topbar (HtmlRenderer.java:5874
-  // emits "/?view=landing" for the GWT brand). Hardcoded to a path so the
-  // J2CL shell does not bounce inside its own route.
-  private static final String J2CL_BRAND_HOME_HREF = "/?view=landing";
 
   // =========================================================================
   // User-menu CSS shared by the wave-client page and the standalone topbar
@@ -3573,7 +3568,7 @@ public final class HtmlRenderer {
       // without exposing the J2CL route/debug eyebrow in the user chrome. The
       // brand href hops to the landing page (matches GWT topbar parity).
       sb.append("    <a slot=\"brand\" id=\"j2cl-root-brand-link\" href=\"")
-          .append(J2CL_BRAND_HOME_HREF)
+          .append(safeResolvedBasePath).append("?view=landing")
           .append("\" aria-label=\"SupaWave\">\n");
       sb.append("      <span class=\"j2cl-brand-mark\" aria-hidden=\"true\">")
           .append("<svg viewBox=\"0 0 48 48\" width=\"36\" height=\"36\" aria-hidden=\"true\">")
@@ -3705,7 +3700,7 @@ public final class HtmlRenderer {
       // Compact GWT parity: mirror the signed-in brand treatment without
       // exposing the J2CL route/debug eyebrow; brand href hops to landing.
       sb.append("    <a slot=\"brand\" id=\"j2cl-root-brand-link\" href=\"")
-          .append(J2CL_BRAND_HOME_HREF)
+          .append(safeResolvedBasePath).append("?view=landing")
           .append("\" aria-label=\"SupaWave\">\n");
       sb.append("      <span class=\"j2cl-brand-mark\" aria-hidden=\"true\">")
           .append("<svg viewBox=\"0 0 48 48\" width=\"36\" height=\"36\" aria-hidden=\"true\">")
@@ -4392,12 +4387,12 @@ public final class HtmlRenderer {
       // single contract J2clSearchPanelView reads on construction.
       sb.append(" data-rail-cards-enabled=\"true\"");
     }
-    sb.append(">\n");
+    sb.append(" aria-label=\"Search\">\n");
     // GWT-parity (round 2, #1233): blue title strip at the top of the rail.
     // Mirrors `.sidecar-selected-title` so the rail header and the wave-panel
     // header sit at identical y / height / color side-by-side. The visible
-    // heading is aria-hidden because the host's aria-label is the AT label
-    // (set by WavySearchRail.willUpdate).
+    // heading is aria-hidden; aria-label on the host covers pre-upgrade AT
+    // access before WavySearchRail.willUpdate fires.
     sb.append("      <h2 class=\"panel-title\" id=\"wavy-search-rail-title\""
         + " data-j2cl-rail-title aria-hidden=\"true\">")
         .append(safeInitialQuery)
@@ -4952,7 +4947,7 @@ public final class HtmlRenderer {
     sb.append("  var shell=document.querySelector('[data-j2cl-root-shell]');\n");
     sb.append("  if(shell){shell.setAttribute('data-j2cl-root-return-target', target);}\n");
     // Round 2: the brand link is a fixed hop to the marketing landing
-    // page (set at SSR render via J2CL_BRAND_HOME_HREF) and must not be
+    // page (built from resolvedBasePath at SSR render) and must not be
     // rewritten by the return-target bootstrap.
     sb.append("  var targetText=document.getElementById('j2cl-root-return-target-text');\n");
     sb.append("  if(targetText){targetText.className='j2cl-status-live-text';targetText.textContent='Return target: ' + target;}\n");

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
@@ -83,6 +83,12 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
     assertTrue(
         "compact wavy-header must SSR a netstatus chip",
         html.contains("class=\"netstatus\""));
+    assertTrue(
+        "signed-in J2CL brand must hop to the GWT-style landing target",
+        html.contains("id=\"j2cl-root-brand-link\" href=\"/?view=landing\""));
+    assertTrue(
+        "signed-in J2CL search rail must SSR the blue panel-title strip",
+        html.contains("<h2 class=\"panel-title\" id=\"wavy-search-rail-title\""));
     assertFalse(html.contains("j2cl-brand-eyebrow"));
     assertFalse(html.contains("J2CL ·"));
   }
@@ -111,6 +117,9 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
     assertTrue(html.contains("<span slot=\"actions-signed-out\">Signed out</span>"));
     assertTrue(html.contains("<a slot=\"actions-signed-out\""));
     assertTrue(html.contains("Sign in"));
+    assertTrue(
+        "signed-out J2CL brand must hop to the GWT-style landing target",
+        html.contains("id=\"j2cl-root-brand-link\" href=\"/?view=landing\""));
     assertFalse(html.contains("j2cl-brand-eyebrow"));
     assertFalse(html.contains("J2CL ·"));
   }


### PR DESCRIPTION
## Summary

Round 2 of the J2CL/GWT parity work (round 1 was #1232). User reviewed
that round and reported the rail/wave-panel header alignment was still
off, the brand link didn't go to the landing page, and the topbar right
cluster didn't hug the edge the way GWT does.

- **Rail title strip restored at GWT geometry.** Round 1 removed the
  rail panel-title because the prior strip was a narrow rounded inset
  pill that didn't span the rail and floated above the search input —
  the user perceived it as a gap. This PR puts a flat full-width
  gradient strip back, mirroring `.sidecar-selected-title` byte-for-byte
  so both panels' headers sit at identical y / height / color
  side-by-side. Heading is `aria-hidden` because the host already
  carries the query+count via `aria-label` (#1232 contract).
- **Brand link hops to `/?view=landing`.** SSR signed-in and signed-out
  J2CL shells emit the landing target. `J2clRootShellView.syncReturnTarget`
  no longer mutates the brand href. The bootstrap script's
  `syncReturnTargetUi` also stops rewriting it (caught in copilot
  review). Read-surface preview keeps its existing return-target href
  intentionally.
- **Topbar right cluster hugs the edge.** Compact actions slot drops
  its right padding; `<wavy-header>` carries `margin-left: auto` so it
  pushes itself right when sharing the slot with sibling Admin / Sign
  out anchors instead of distributing free space across all three.

## Verification

- `cd j2cl/lit && npm test` — 847 passed, 0 failed
- `cd j2cl/lit && npm run build` — bundle written
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py` — passed
- `sbt --batch testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellTest` — 32 passed (covers landing-href on both branches + SSR panel-title strip)
- `sbt --batch JakartaTest/testOnly org.waveprotocol.box.server.rpc.J2clSearchRailParityTest` — 16 / 17. The 1 failure (`j2clRootShellEmitsWavySearchHelpModalWithAll22TokenLiterals`) reproduces on `origin/main` and is unrelated to this PR.

## Review

- Self-review completed.
- Copilot review (`gpt-5.4`) found 2 actionable items — both addressed in commit `cbecb8ed8`:
  1. Bootstrap `syncReturnTargetUi` was still rewriting the brand link href; removed.
  2. Doubled `margin-left:auto` on the slot + `<wavy-header>` would have distributed space across multi-sibling slots; auto margin now lives only on `<wavy-header>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a branded title panel to the search rail component.

* **Bug Fixes**
  * Fixed the brand link navigation to consistently point to the landing page instead of following dynamic return targets.
  * Updated search rail and topbar styling and spacing for improved visual consistency and layout alignment.

* **Tests / Changelog**
  * Updated tests and added a changelog entry to reflect these UI and navigation changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1234)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->