### PR TITLE
Round 3 J2CL parity: ship sidecar.css + match wave-panel toolbar gradient

### DIFF
--- a/j2cl/lit/esbuild.config.mjs
+++ b/j2cl/lit/esbuild.config.mjs
@@ -16,7 +16,17 @@ await build({
     // F-2 slice 2 (#1046): thread collapse motion + .j2cl-read-surface
     // positioning context for the focus frame. Sibling stylesheet so the
     // server template can <link> it next to wavy-tokens.css.
-    { in: resolve(here, "src/design/wavy-thread-collapse.css"), out: "wavy-thread-collapse" }
+    { in: resolve(here, "src/design/wavy-thread-collapse.css"), out: "wavy-thread-collapse" },
+    // Round 3 (#1235): the J2CL shell template references
+    // /j2cl/assets/sidecar.css but the source lives under
+    // j2cl/src/main/webapp/assets/sidecar.css and was not copied into
+    // war/j2cl/assets/, leaving the wave-panel chrome (blue title
+    // strip, empty-state recipe, etc.) un-styled in production. Re-emit
+    // it via esbuild so it ships next to shell.css.
+    {
+      in: resolve(here, "../src/main/webapp/assets/sidecar.css"),
+      out: "sidecar"
+    }
   ],
   bundle: true,
   format: "esm",

--- a/j2cl/lit/src/elements/wavy-wave-nav-row.js
+++ b/j2cl/lit/src/elements/wavy-wave-nav-row.js
@@ -67,9 +67,12 @@ export class WavyWaveNavRow extends LitElement {
       container-name: wave-nav-row;
       min-height: 36px;
       box-sizing: border-box;
-      background: var(--wavy-toolbar-pill-bg, #f0f4f8);
-      border-bottom: 1px solid var(--wavy-border-hairline, #e2e8f0);
-      padding: 3px 4px;
+      /* Round 3 (#1235): match the search-rail's .action-row gradient so
+       * the wave-panel toolbar reads as the same band of chrome on the
+       * y-coordinate just below the blue title strip. */
+      background: linear-gradient(180deg, #eef7ff 0%, #dcecff 100%);
+      border-bottom: 1px solid rgba(120, 170, 220, 0.35);
+      padding: 4px;
     }
     nav {
       display: flex;

--- a/j2cl/lit/test/wavy-wave-nav-row.test.js
+++ b/j2cl/lit/test/wavy-wave-nav-row.test.js
@@ -240,7 +240,10 @@ describe("<wavy-wave-nav-row>", () => {
     const el = await fixture(html`<wavy-wave-nav-row></wavy-wave-nav-row>`);
     await el.updateComplete;
     const host = getComputedStyle(el);
-    expect(host.backgroundColor).to.equal("rgb(240, 244, 248)");
+    // Round 3 (#1235): match the search-rail .action-row gradient so the
+    // wave-panel toolbar reads as the same band as the search panel's.
+    expect(host.backgroundImage).to.contain("linear-gradient");
+    expect(host.backgroundImage).to.contain("238, 247, 255");
     expect(parseInt(host.minHeight, 10)).to.equal(36);
     const button = el.renderRoot.querySelector('button[data-action="recent"]');
     const buttonStyle = getComputedStyle(button);

--- a/wave/config/changelog.d/2026-05-09-j2cl-parity-round3.json
+++ b/wave/config/changelog.d/2026-05-09-j2cl-parity-round3.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-09-j2cl-parity-round3",
+  "version": "Issue #1235",
+  "date": "2026-05-09",
+  "title": "J2CL search rail and wave panel toolbars now share the same blue chrome at matching heights.",
+  "summary": "Round 3 parity work: ship sidecar.css next to shell.css so the wave-panel chrome actually loads, and align the wave-nav toolbar with the search rail's action toolbar.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Bundles sidecar.css into war/j2cl/assets so the wave-panel blue title strip, empty-state recipe, and selected-wave chrome render correctly in production (the link tag pointed at a path that was 404ing).",
+        "Repaints the wave-panel nav toolbar (`<wavy-wave-nav-row>`) with the same light-blue gradient as the search rail's action toolbar so both panels read as the same band of chrome side-by-side."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Round 3 of the J2CL/GWT parity work. Round 1 (#1232) restored chrome
on the topbar. Round 2 (#1234) put back the rail's blue title strip
and pointed the brand link at the landing page. This PR fixes two more
gaps the user flagged after seeing round 2 in production.

### sidecar.css 404 → wave-panel chrome falls back to browser defaults

The J2CL SSR template links `/j2cl/assets/sidecar.css`, but the file
lives at `j2cl/src/main/webapp/assets/sidecar.css` and was only copied
into `war/j2cl/assets/` by the j2cl-maven-plugin during
`j2clProductionBuild`. Local dev (`sbt run`) and any environment that
runs `j2clLitBuild` without `j2clProductionBuild` ends up with a 404
on that link tag, leaving the wave panel's blue title strip, empty-
state recipe, and selected-wave chrome un-styled. Promoted sidecar.css
to a fourth esbuild entry so `npm run build` writes it next to shell.css
unconditionally. (`/j2cl/assets/sidecar.css` now returns 200 with the
expected `.sidecar-selected-title` rule when running via local sbt.)

### Wave-panel toolbar surface parity

Repainted `<wavy-wave-nav-row>`'s host with the same
`linear-gradient(180deg, #eef7ff, #dcecff)` and 1 px GWT-style
border-bottom as the search rail's `.action-row`. Both panels now read
as the same band of chrome side-by-side.

## Verification

- `cd j2cl/lit && npm test` — 847/847 passed (one nav-row test updated to assert the new gradient).
- `cd j2cl/lit && npm run build` — bundle now writes `war/j2cl/assets/sidecar.css` (and its sourcemap).
- Local `sbt run` + browser probe:
  - `/j2cl/assets/sidecar.css` → 200 (was 404 on main).
  - `.sidecar-selected-title` computed `backgroundImage` = `linear-gradient(rgb(105,169,236), rgb(47,128,209))` (was `none`).
  - `<wavy-wave-nav-row>` host computed `backgroundImage` = the rail's light-blue gradient (was `#f0f4f8`).

Both panels now show matching blue title strips and matching toolbar bands.

## Review

- Self-review completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)