### PR TITLE
Show deploy upgrade banner on J2CL root shell (GWT parity)

### DIFF
--- a/wave/config/changelog.d/2026-05-10-j2cl-version-upgrade-banner.json
+++ b/wave/config/changelog.d/2026-05-10-j2cl-version-upgrade-banner.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-10-j2cl-version-upgrade-banner",
+  "version": "J2CL parity",
+  "date": "2026-05-10",
+  "title": "J2CL root shell now shows the deploy upgrade banner just like GWT.",
+  "summary": "The J2CL root shell page now polls /version every 60 seconds and shows the same upgrade banner GWT shows when the deployed build commit or build time changes, so users on the J2CL client get notified to reload after a deploy.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Server now injects the same /version polling + upgrade-banner script into the J2CL root shell page, mirroring the GWT wave client."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3728,9 +3728,9 @@ public final class HtmlRenderer {
       sb.append("</shell-root-signed-out>\n");
       appendJ2clRootShellBootstrap(sb, resolvedReturnTarget, resolvedBasePath, false);
     }
-    // Mirror GWT parity (renderWaveClientPage line 3314): poll /version every
-    // 60s and surface the upgrade banner when the deployed build changes
-    // while the J2CL root shell page is still open.
+    // Mirrors the renderWaveClientPage version-check script injection: poll
+    // /version every 60s and surface the upgrade banner when the deployed
+    // build changes while the J2CL root shell page is still open.
     appendVersionCheckScript(sb, buildCommit, serverBuildTime, currentReleaseId);
     sb.append("</body>\n</html>\n");
     return sb.toString();

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3728,6 +3728,10 @@ public final class HtmlRenderer {
       sb.append("</shell-root-signed-out>\n");
       appendJ2clRootShellBootstrap(sb, resolvedReturnTarget, resolvedBasePath, false);
     }
+    // Mirror GWT parity (renderWaveClientPage line 3314): poll /version every
+    // 60s and surface the upgrade banner when the deployed build changes
+    // while the J2CL root shell page is still open.
+    appendVersionCheckScript(sb, buildCommit, serverBuildTime, currentReleaseId);
     sb.append("</body>\n</html>\n");
     return sb.toString();
   }

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererChangelogTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererChangelogTest.java
@@ -51,6 +51,27 @@ public final class HtmlRendererChangelogTest {
   }
 
   @Test
+  public void j2clRootShellPageUsesVersionPayloadForUpgradeBanner() {
+    String html = HtmlRenderer.renderJ2clRootShellPage(
+        new JSONObject("{\"address\":\"alice@example.com\"}"),
+        "",
+        "abc123build",
+        1700000000000L,
+        "2026-03-27-unread-only-search-filter",
+        "/?view=j2cl-root",
+        "localhost:9898");
+
+    assertTrue(html.contains("var currentBuildCommit = \"abc123build\";"));
+    assertTrue(html.contains("var currentBuildTime = 1700000000000;"));
+    assertTrue(html.contains("var currentReleaseId = \"2026-03-27-unread-only-search-filter\";"));
+    assertTrue(html.contains("fetch('/version?since=' + encodeURIComponent(currentReleaseId || '')"));
+    assertTrue(html.contains("showUpgradeBanner(data.releaseNotesStatus, data.releaseNotes || []);"));
+    assertTrue(html.contains("setInterval(checkVersion, 60000);"));
+    assertTrue(html.contains("upgrade-banner"));
+    assertTrue(html.contains("What's New \\u2192"));
+  }
+
+  @Test
   public void j2clRootShellNormalizesLegacyHashDeepLinksBeforeMount() {
     String html = HtmlRenderer.renderJ2clRootShellPage(
         new JSONObject("{\"address\":\"alice@example.com\"}"),


### PR DESCRIPTION
## Summary

- The GWT wave client polls `/version` every 60s and shows the *"SupaWave has been updated"* banner whenever the deployed `buildCommit`/`buildTime` changes while the page is still open. The J2CL root shell page already received `buildCommit`/`serverBuildTime`/`currentReleaseId` and emitted them as `<meta>` tags, but it never wired the actual polling + banner script — so J2CL users were never notified to reload after a deploy.
- This calls the existing `appendVersionCheckScript(...)` from `renderJ2clRootShellPage` just before `</body>`, mirroring the GWT call site at line 3314 in `renderWaveClientPage`. No new endpoints, no API changes, no client-side rebuild — purely server HTML rendering parity.
- Adds `j2clRootShellPageUsesVersionPayloadForUpgradeBanner` regression test paralleling the existing GWT `waveClientPageUsesVersionPayloadForUpgradeBanner` test, plus a changelog fragment.

## Test plan
- [x] `sbt 'wave/testOnly org.waveprotocol.box.server.rpc.HtmlRendererChangelogTest'` — all 10 tests pass, including the new J2CL assertion.
- [x] `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d/` — passes.
- [ ] Manual: open J2CL root shell, redeploy, confirm banner appears within 60 s with Reload + What's New buttons (matches GWT visual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * J2CL root shell now displays an upgrade banner when the deployed build changes, prompting users to reload after updates. The system automatically checks for new versions every 60 seconds and works for both signed-in and signed-out sessions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1237)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->