### PR TITLE
Round 5 follow-up: drop unconditional wave-blip padding, reset focus marker on empty, fix scroll comment

### DIFF
--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -448,8 +448,8 @@ shell-header > span[slot^="actions"] {
 }
 
 /* GWT-parity (round 5, #1237): scope wave-blip layout effects so a
- * Lit re-render of one blip does not invalidate layout / paint /
- * style for the entire stream. Pure perf hint — no visual change.
+ * Lit re-render of one blip does not invalidate layout / style for
+ * the entire stream. Pure perf hint — no visual change.
  * The pre-upgrade skeleton (wavy-thread-collapse.css `wave-blip:not
  * (:defined)`) and the post-upgrade shadow `.body` continue to own
  * the visual envelope. */

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -447,69 +447,14 @@ shell-header > span[slot^="actions"] {
   color: var(--shell-color-text-muted);
 }
 
-/* GWT-parity (round 5, #1237): pre-upgrade light-DOM styling for
- * <wave-blip>. The Java renderer (J2clReadSurfaceDomRenderer) creates
- * <wave-blip> hosts with a plain <div class="j2cl-read-blip-content
- * blip-content"> child of unstyled text and appends them to the read
- * surface BEFORE Lit upgrades the custom element. Until the upgrade
- * runs, the slotted .blip-content has no margin / padding / border, so
- * users see naked text that shifts and re-paints when the shadow root
- * attaches and the .body styling kicks in. The result is the visible
- * "blips appear as plain text, then flicker, then resize" effect users
- * report on big-wave open and on every renderWindow rebuild (e.g.
- * after marking a reply as done).
- *
- * These rules mirror the post-upgrade .body geometry from wave-blip.js
- * so the slotted content already paints inside a card before the
- * shadow root takes over. The :not(:defined) guard scopes them to the
- * pre-upgrade window only — once Lit upgrades wave-blip, the slot
- * pulls .blip-content into the shadow .body and these rules no longer
- * match (the child becomes a slot assignee, not a direct light-DOM
- * descendant rendered inline). */
+/* GWT-parity (round 5, #1237): scope wave-blip layout effects so a
+ * Lit re-render of one blip does not invalidate layout / paint /
+ * style for the entire stream. Pure perf hint — no visual change.
+ * The pre-upgrade skeleton (wavy-thread-collapse.css `wave-blip:not
+ * (:defined)`) and the post-upgrade shadow `.body` continue to own
+ * the visual envelope. */
 wave-blip {
-  display: block;
-  position: relative;
-  margin: 0;
-  padding: 3px;
   contain: layout style;
-}
-
-wave-blip:not(:defined) > .j2cl-read-blip-content,
-wave-blip:not(:defined) > .blip-content {
-  display: block;
-  margin-left: 3.35em;
-  min-height: 1.5em;
-  padding: 6px 8px;
-  border: 1px solid #e2e8f0;
-  border-radius: 4px;
-  background: #f8fafc;
-  color: #1a202c;
-  font: 13px / 1.35 Arial, Helvetica, sans-serif;
-  overflow-wrap: break-word;
-  word-break: normal;
-  white-space: pre-wrap;
-}
-
-wave-blip:not(:defined)[unread] > .j2cl-read-blip-content,
-wave-blip:not(:defined)[unread] > .blip-content {
-  border-color: rgba(0, 119, 182, 0.5);
-  background: rgba(0, 180, 216, 0.1);
-  color: #0f3f5f;
-  font-weight: 600;
-  box-shadow: inset 3px 0 0 #0077b6;
-}
-
-/* Reserve the metadata-strip space so the body does not jump up when
- * the shadow header materialises post-upgrade. Matches .header
- * min-height (32px) + margin-bottom (0.3em ≈ 4px) from wave-blip.js. */
-wave-blip:not(:defined)::before {
-  content: "";
-  display: block;
-  height: 32px;
-  margin-bottom: 0.3em;
-  margin-left: 3.35em;
-  background: #f0f4f8;
-  border-radius: 6px;
 }
 
 shell-header[compact-gwt-topbar] > span[slot^="actions"] {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -668,6 +668,7 @@ public final class J2clReadSurfaceDomRenderer {
       renderedWindowEntries = Collections.<J2clReadWindowEntry>emptyList();
       renderedSurface = null;
       focusedBlip = null;
+      initialFocusAppliedForWaveId = null;
       return false;
     }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -728,6 +728,11 @@ public final class J2clReadSurfaceDomRenderer {
       renderedConversationManifest = SidecarConversationManifest.empty();
       renderedSurface = null;
       focusedBlip = null;
+      // Round 5 (#1237): reset the initial-focus marker so that if the
+      // wave is re-populated (loading state, retry, server reload) the
+      // seek-to-latest path runs again instead of dropping the user
+      // back at the first visible blip.
+      initialFocusAppliedForWaveId = null;
       return false;
     }
     List<J2clReadWindowEntry> effectiveEntries = orderWindowEntriesForRender(entries);
@@ -3678,10 +3683,11 @@ public final class J2clReadSurfaceDomRenderer {
 
   /**
    * GWT-parity (round 5, #1237): bring a blip into the viewport on
-   * initial wave open. Uses native scrollIntoView with block: "nearest"
-   * so the chosen blip appears without forcing the surface to jump if
-   * it is already visible. Wrapped in try/catch because some test
-   * environments (mocked Element prototypes) lack scrollIntoView.
+   * initial wave open. Calls {@code scrollIntoView(false)} which
+   * aligns the blip with the BOTTOM of the visible area — matches
+   * GWT's behavior of pinning the latest blip to the viewport bottom
+   * on open. Wrapped in try/catch because some test environments
+   * (mocked Element prototypes) lack {@code scrollIntoView}.
    */
   private void scrollBlipIntoView(HTMLElement blip) {
     if (blip == null) {

--- a/wave/config/changelog.d/2026-05-10-j2cl-parity-round5b.json
+++ b/wave/config/changelog.d/2026-05-10-j2cl-parity-round5b.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-05-10-j2cl-parity-round5b",
+  "version": "Issue #1239",
+  "date": "2026-05-10",
+  "title": "J2CL parity round 5 follow-up: drop unconditional <wave-blip> padding, reset initial-focus marker on empty entries, correct scrollIntoView javadoc.",
+  "summary": "Round 5 (#1238) shipped before a self-review caught three issues. The unconditional `wave-blip { padding: 3px; margin: 0; position: relative }` declaration leaked into post-upgrade rendering for every blip; `initialFocusAppliedForWaveId` was not reset when the wave went empty, so re-population (loading state, retry) would skip the seek-to-latest path; and the `scrollBlipIntoView` Javadoc described a different scroll alignment than the code performed.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Trim the new wave-blip rule in shell-tokens.css down to `contain: layout style` only — drop padding / margin / position which were unconditionally applied post-upgrade and would have changed layout for every blip in the stream.",
+        "Reset initialFocusAppliedForWaveId in J2clReadSurfaceDomRenderer's empty-entries branch so a re-populated wave triggers the seek-to-latest path again instead of dropping the user back at the first blip.",
+        "Update scrollBlipIntoView Javadoc to describe the actual `scrollIntoView(false)` bottom-aligned behavior (matches the GWT pin-to-bottom-on-open pattern)."
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.d/2026-05-10-j2cl-parity-round5b.json
+++ b/wave/config/changelog.d/2026-05-10-j2cl-parity-round5b.json
@@ -3,7 +3,7 @@
   "version": "Issue #1239",
   "date": "2026-05-10",
   "title": "J2CL parity round 5 follow-up: drop unconditional <wave-blip> padding, reset initial-focus marker on empty entries, correct scrollIntoView javadoc.",
-  "summary": "Round 5 (#1238) shipped before a self-review caught three issues. The unconditional `wave-blip { padding: 3px; margin: 0; position: relative }` declaration leaked into post-upgrade rendering for every blip; `initialFocusAppliedForWaveId` was not reset when the wave went empty, so re-population (loading state, retry) would skip the seek-to-latest path; and the `scrollBlipIntoView` Javadoc described a different scroll alignment than the code performed.",
+  "summary": "Round 5 (#1237) shipped before a self-review caught three issues. The unconditional `wave-blip { padding: 3px; margin: 0; position: relative }` declaration leaked into post-upgrade rendering for every blip; `initialFocusAppliedForWaveId` was not reset when the wave went empty, so re-population (loading state, retry) would skip the seek-to-latest path; and the `scrollBlipIntoView` Javadoc described a different scroll alignment than the code performed.",
   "sections": [
     {
       "type": "fix",


### PR DESCRIPTION
## Summary

Round 5 (#1238) auto-merged before a self-review with Copilot/Opus 4.7 caught three issues. This PR addresses them.

1. **`wave-blip { padding: 3px; margin: 0; position: relative }` was unconditionally applied** ([shell-tokens.css](https://github.com/vega113/supawave/blob/main/j2cl/lit/src/tokens/shell-tokens.css)). It changes layout for every wave-blip post-upgrade, not just pre-upgrade. The pre-upgrade window is already covered by the `wave-blip:not(:defined)` skeleton in [`wavy-thread-collapse.css`](https://github.com/vega113/supawave/blob/main/j2cl/lit/src/design/wavy-thread-collapse.css), and the post-upgrade visual envelope is owned by the shadow `.body`. Trim the new rule down to `contain: layout style` only — that's a pure perf hint with no visual change.

2. **`initialFocusAppliedForWaveId` was not reset on empty entries.** If a wave went empty (loading state, retry, server reload) then re-populated, the seek-to-latest path would skip and the user would land on the first visible blip again. Reset the field alongside the rest of the render state in the empty branch.

3. **`scrollBlipIntoView` Javadoc described `block: "nearest"`** but the code calls `scrollIntoView(false)` (alignToTop=false, bottom-aligned). The behavior is correct (matches GWT's pin-to-bottom-on-open) — only the comment is wrong. Update it.

## Files changed

- `j2cl/lit/src/tokens/shell-tokens.css` — trim the new wave-blip rule down to `contain: layout style`
- `j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java` — reset `initialFocusAppliedForWaveId` on empty branch + correct scroll Javadoc
- `wave/config/changelog.d/2026-05-10-j2cl-parity-round5b.json` — changelog entry

## Test plan

- [x] `npx web-test-runner` in `j2cl/lit` — 851 tests pass
- [x] `sbt compile` — server compiles cleanly
- [ ] CI smoke / parity tests
- [ ] Visual verification on `?view=j2cl-root`: blip layout unchanged from pre-#1238 baseline; reload + re-open scenario lands on latest blip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed focus behavior to properly reset when wave content is empty, restoring correct navigation to unread content upon repopulation.
  * Corrected scroll alignment to position selected items at the bottom of the visible area.

* **Documentation**
  * Updated method documentation to reflect scroll behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1239)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->