### PR TITLE
J2CL: add tooltips + localization to all action buttons

### DIFF
--- a/j2cl/lit/package.json
+++ b/j2cl/lit/package.json
@@ -5,6 +5,8 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "audit:buttons": "node scripts/audit-buttons.mjs",
+    "prebuild": "node scripts/audit-buttons.mjs",
     "build": "node esbuild.config.mjs",
     "test": "web-test-runner"
   },

--- a/j2cl/lit/scripts/audit-buttons.mjs
+++ b/j2cl/lit/scripts/audit-buttons.mjs
@@ -136,8 +136,8 @@ for (const file of listJs(elementsDir)) {
     const close = findCloseAngle(src, open);
     if (close === -1) break;
     const opener = src.slice(open, close + 1);
-    const hasAria = /\baria-label\s*=/.test(opener);
-    const hasTitle = /\btitle\s*=/.test(opener);
+    const hasAria = /(?:^|[\s<])aria-label\s*=/.test(opener);
+    const hasTitle = /(?:^|[\s<])title\s*=/.test(opener);
     if (hasAria && hasTitle) continue;
     violations.push({
       file,

--- a/j2cl/lit/scripts/audit-buttons.mjs
+++ b/j2cl/lit/scripts/audit-buttons.mjs
@@ -1,0 +1,160 @@
+// audit-buttons.mjs — fail the build if any <button> in
+// j2cl/lit/src/elements/*.js renders without both an aria-label AND a
+// title/tooltip source. This locks in the J2CL/GWT parity that issue
+// #1234+ keeps regressing on (see PR description for "objective-dewdney").
+//
+// Heuristics (intentionally simple — Lit elements ship as html`` template
+// literals, so we walk the source text rather than parsing JS):
+//
+// - Find every "<button" opener.
+// - Pair it with the first ">" that closes the opening tag (skipping any
+//   nested template-literal expressions ${...} that would otherwise look
+//   like ">" inside JS code).
+// - Within that opener, require BOTH `aria-label=` and `title=` (or
+//   confirm the button is rendered through a helper that we know provides
+//   both: <toolbar-button>, <composer-submit-affordance>, <wavy-task-affordance>).
+//
+// If a violation is found, the audit prints the file + offending line and
+// exits non-zero so `npm prebuild` (and CI) refuses to ship.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const elementsDir = resolve(here, "..", "src", "elements");
+
+function listJs(dir) {
+  return readdirSync(dir)
+    .filter((name) => name.endsWith(".js"))
+    .map((name) => join(dir, name))
+    .filter((path) => statSync(path).isFile());
+}
+
+// Replace `//` line comments and `/* … */` block comments with whitespace
+// of the same length so subsequent regex/index lookups still report the
+// correct line numbers but never match content inside comments. We do NOT
+// touch backtick template literals (Lit `html\`\`` blocks); those are the
+// real targets we want to lint.
+function stripJsComments(src) {
+  let out = "";
+  let i = 0;
+  let inString = null; // ', ", or `
+  while (i < src.length) {
+    const ch = src[i];
+    const next = src[i + 1];
+    if (inString) {
+      if (ch === "\\" && i + 1 < src.length) {
+        out += ch + next;
+        i += 2;
+        continue;
+      }
+      if (ch === inString) {
+        inString = null;
+      }
+      out += ch;
+      i += 1;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === "`") {
+      inString = ch;
+      out += ch;
+      i += 1;
+      continue;
+    }
+    if (ch === "/" && next === "/") {
+      // Skip until newline.
+      while (i < src.length && src[i] !== "\n") {
+        out += src[i] === "\n" ? "\n" : " ";
+        i += 1;
+      }
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      out += "  ";
+      i += 2;
+      while (i < src.length && !(src[i] === "*" && src[i + 1] === "/")) {
+        out += src[i] === "\n" ? "\n" : " ";
+        i += 1;
+      }
+      if (i < src.length) {
+        out += "  ";
+        i += 2;
+      }
+      continue;
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
+}
+
+// Find the matching `>` that closes a `<button` opener, skipping `${...}`
+// expression blocks (Lit interpolation may contain `>` characters that are
+// not part of HTML).
+function findCloseAngle(src, startIndex) {
+  let i = startIndex;
+  while (i < src.length) {
+    const ch = src[i];
+    if (ch === "$" && src[i + 1] === "{") {
+      // Skip balanced ${...} block.
+      let depth = 1;
+      i += 2;
+      while (i < src.length && depth > 0) {
+        const c2 = src[i];
+        if (c2 === "{") depth += 1;
+        else if (c2 === "}") depth -= 1;
+        i += 1;
+      }
+      continue;
+    }
+    if (ch === ">") return i;
+    i += 1;
+  }
+  return -1;
+}
+
+function lineNumberAt(src, index) {
+  return src.slice(0, index).split("\n").length;
+}
+
+const violations = [];
+
+for (const file of listJs(elementsDir)) {
+  const raw = readFileSync(file, "utf8");
+  const src = stripJsComments(raw);
+  let cursor = 0;
+  while (true) {
+    const open = src.indexOf("<button", cursor);
+    if (open === -1) break;
+    cursor = open + 1;
+    // Skip e.g. "<button-like" custom names (the `<` followed by "button"
+    // with a hyphen) — only real <button> matches must end with whitespace,
+    // newline, "/", or ">".
+    const next = src[open + 7];
+    if (!/[\s/>]/.test(next || "")) continue;
+    const close = findCloseAngle(src, open);
+    if (close === -1) break;
+    const opener = src.slice(open, close + 1);
+    const hasAria = /\baria-label\s*=/.test(opener);
+    const hasTitle = /\btitle\s*=/.test(opener);
+    if (hasAria && hasTitle) continue;
+    violations.push({
+      file,
+      line: lineNumberAt(src, open),
+      opener: opener.replace(/\s+/g, " ").slice(0, 160)
+    });
+  }
+}
+
+if (violations.length === 0) {
+  console.log(`audit-buttons: OK (${listJs(elementsDir).length} files scanned)`);
+  process.exit(0);
+}
+
+console.error(`audit-buttons: ${violations.length} violation(s):`);
+for (const v of violations) {
+  console.error(`  ${v.file}:${v.line}`);
+  console.error(`    ${v.opener}`);
+}
+process.exit(1);

--- a/j2cl/lit/scripts/audit-buttons.mjs
+++ b/j2cl/lit/scripts/audit-buttons.mjs
@@ -10,9 +10,14 @@
 // - Pair it with the first ">" that closes the opening tag (skipping any
 //   nested template-literal expressions ${...} that would otherwise look
 //   like ">" inside JS code).
-// - Within that opener, require BOTH `aria-label=` and `title=` (or
-//   confirm the button is rendered through a helper that we know provides
-//   both: <toolbar-button>, <composer-submit-affordance>, <wavy-task-affordance>).
+// - Within that opener, require BOTH `aria-label=…` and `title=…`,
+//   *and* require their values to be syntactically non-empty (no
+//   `aria-label=""` or `title=${nothing}` slipping through).
+//
+// We do NOT special-case wrapper custom elements like <toolbar-button>;
+// audit only inspects raw `<button>` openers found in source. Wrappers
+// that internally render <button> are caught when their own source is
+// scanned. Audit covers `src/{elements,design,input,controllers}`.
 //
 // If a violation is found, the audit prints the file + offending line and
 // exits non-zero so `npm prebuild` (and CI) refuses to ship.
@@ -22,10 +27,21 @@ import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const elementsDir = resolve(here, "..", "src", "elements");
+const SCAN_DIRS = [
+  resolve(here, "..", "src", "elements"),
+  resolve(here, "..", "src", "design"),
+  resolve(here, "..", "src", "input"),
+  resolve(here, "..", "src", "controllers")
+];
 
 function listJs(dir) {
-  return readdirSync(dir)
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch (_err) {
+    return [];
+  }
+  return entries
     .filter((name) => name.endsWith(".js"))
     .map((name) => join(dir, name))
     .filter((path) => statSync(path).isFile());
@@ -118,37 +134,63 @@ function lineNumberAt(src, index) {
   return src.slice(0, index).split("\n").length;
 }
 
-const violations = [];
+// Reject `aria-label=""` (the literal empty string), `aria-label=${nothing}`
+// (the Lit `nothing` sentinel), and `aria-label=${undefined}`. Anything else
+// — string literals, template strings, function calls, ternaries — counts
+// as "non-empty" for the audit; runtime fixtures cover the dynamic case.
+const EMPTY_VALUE_RE = /^(""|''|`\s*`|\$\{\s*(?:nothing|undefined|null)\s*\})/;
 
-for (const file of listJs(elementsDir)) {
-  const raw = readFileSync(file, "utf8");
-  const src = stripJsComments(raw);
-  let cursor = 0;
-  while (true) {
-    const open = src.indexOf("<button", cursor);
-    if (open === -1) break;
-    cursor = open + 1;
-    // Skip e.g. "<button-like" custom names (the `<` followed by "button"
-    // with a hyphen) — only real <button> matches must end with whitespace,
-    // newline, "/", or ">".
-    const next = src[open + 7];
-    if (!/[\s/>]/.test(next || "")) continue;
-    const close = findCloseAngle(src, open);
-    if (close === -1) break;
-    const opener = src.slice(open, close + 1);
-    const hasAria = /(?:^|[\s<])aria-label\s*=/.test(opener);
-    const hasTitle = /(?:^|[\s<])title\s*=/.test(opener);
-    if (hasAria && hasTitle) continue;
-    violations.push({
-      file,
-      line: lineNumberAt(src, open),
-      opener: opener.replace(/\s+/g, " ").slice(0, 160)
-    });
+// Use a stricter word-boundary regex when matching attribute names so a
+// hypothetical `data-aria-label=` or `data-title=` cannot mask a missing
+// real attr. We then fish out the attribute value and reject empty / nothing
+// sentinels so a literal `aria-label=""` or `title=${nothing}` is also a
+// violation, not a free pass.
+function attrValue(opener, attr) {
+  const re = new RegExp(`(?:^|[\\s<])${attr}\\s*=`);
+  const m = re.exec(opener);
+  if (!m) return null;
+  let i = m.index + m[0].length;
+  while (i < opener.length && /\s/.test(opener[i])) i += 1;
+  return opener.slice(i);
+}
+
+const violations = [];
+let scanned = 0;
+
+for (const dir of SCAN_DIRS) {
+  for (const file of listJs(dir)) {
+    scanned += 1;
+    const raw = readFileSync(file, "utf8");
+    const src = stripJsComments(raw);
+    let cursor = 0;
+    while (true) {
+      const open = src.indexOf("<button", cursor);
+      if (open === -1) break;
+      cursor = open + 1;
+      // Skip e.g. "<button-like" custom names (the `<` followed by "button"
+      // with a hyphen) — only real <button> matches must end with whitespace,
+      // newline, "/", or ">".
+      const next = src[open + 7];
+      if (!/[\s/>]/.test(next || "")) continue;
+      const close = findCloseAngle(src, open);
+      if (close === -1) break;
+      const opener = src.slice(open, close + 1);
+      const ariaValue = attrValue(opener, "aria-label");
+      const titleValue = attrValue(opener, "title");
+      const hasAria = ariaValue != null && !EMPTY_VALUE_RE.test(ariaValue);
+      const hasTitle = titleValue != null && !EMPTY_VALUE_RE.test(titleValue);
+      if (hasAria && hasTitle) continue;
+      violations.push({
+        file,
+        line: lineNumberAt(src, open),
+        opener: opener.replace(/\s+/g, " ").slice(0, 160)
+      });
+    }
   }
 }
 
 if (violations.length === 0) {
-  console.log(`audit-buttons: OK (${listJs(elementsDir).length} files scanned)`);
+  console.log(`audit-buttons: OK (${scanned} files scanned)`);
   process.exit(0);
 }
 

--- a/j2cl/lit/src/design/wavy-pulse-stage.js
+++ b/j2cl/lit/src/design/wavy-pulse-stage.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { t } from "../i18n/t.js";
 
 /**
  * <wavy-pulse-stage> — F-0 (#1035) demo helper that drives a single
@@ -85,7 +86,12 @@ export class WavyPulseStage extends LitElement {
 
   render() {
     return html`
-      <button type="button" @click=${this.firePulse}>Fire pulse</button>
+      <button
+        type="button"
+        aria-label=${t("pulseStage.fire", "Fire pulse")}
+        title=${t("pulseStage.fire", "Fire pulse")}
+        @click=${this.firePulse}
+      >${t("pulseStage.fire", "Fire pulse")}</button>
       <slot></slot>
     `;
   }

--- a/j2cl/lit/src/design/wavy-rail-panel.js
+++ b/j2cl/lit/src/design/wavy-rail-panel.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { t } from "../i18n/t.js";
 
 /**
  * <wavy-rail-panel> — F-0 (#1035) recipe for a right-rail panel
@@ -121,7 +122,8 @@ export class WavyRailPanel extends LitElement {
           <button
             class="toggle"
             type="button"
-            aria-label=${this.collapsed ? "Expand panel" : "Collapse panel"}
+            aria-label=${this.collapsed ? t("railPanel.expand", "Expand panel") : t("railPanel.collapse", "Collapse panel")}
+            title=${this.collapsed ? t("railPanel.expand", "Expand panel") : t("railPanel.collapse", "Collapse panel")}
             @click=${this.toggleCollapsed}
           >
             ${this.collapsed ? "+" : "–"}

--- a/j2cl/lit/src/elements/compose-attachment-card.js
+++ b/j2cl/lit/src/elements/compose-attachment-card.js
@@ -1,5 +1,6 @@
 import { LitElement, css, html } from "lit";
 import { DISPLAY_SIZES } from "./attachment-display-sizes.js";
+import { t } from "../i18n/t.js";
 
 export class ComposeAttachmentCard extends LitElement {
   static properties = {
@@ -123,8 +124,11 @@ export class ComposeAttachmentCard extends LitElement {
     const displaySize = DISPLAY_SIZES.includes(this.displaySize)
       ? this.displaySize
       : "medium";
+    const articleLabel = `${t("attachments.cardLabel", "Attachment")} ${this.filename}`;
+    const openLabel = `${t("attachments.openPrefix", "Open attachment")} ${this.filename}`;
+    const downloadLabel = `${t("attachments.downloadPrefix", "Download attachment")} ${this.filename}`;
     return html`
-      <article class=${`size-${displaySize}`} aria-label=${`Attachment ${this.filename}`}>
+      <article class=${`size-${displaySize}`} aria-label=${articleLabel}>
         <div class="preview">
           ${this.thumbnailUrl
             ? html`<img src=${this.thumbnailUrl} alt=${this.filename} />`
@@ -138,26 +142,28 @@ export class ComposeAttachmentCard extends LitElement {
           ? html`<p role="status" aria-live="polite">${this.status}</p>`
           : ""}
         ${blocked
-          ? html`<p role="alert" aria-live="assertive">${this.error || "Attachment blocked."}</p>`
+          ? html`<p role="alert" aria-live="assertive">${this.error || t("attachments.blocked", "Attachment blocked.")}</p>`
           : ""}
         <div class="actions">
           <button
             type="button"
             data-action="attachment-open"
-            aria-label=${`Open attachment ${this.filename}`}
+            aria-label=${openLabel}
+            title=${openLabel}
             ?disabled=${openDisabled}
             @click=${this.onOpen}
           >
-            Open
+            ${t("attachments.open", "Open")}
           </button>
           <button
             type="button"
             data-action="attachment-download"
-            aria-label=${`Download attachment ${this.filename}`}
+            aria-label=${downloadLabel}
+            title=${downloadLabel}
             ?disabled=${downloadDisabled}
             @click=${this.onDownload}
           >
-            Download
+            ${t("attachments.download", "Download")}
           </button>
         </div>
       </article>

--- a/j2cl/lit/src/elements/compose-attachment-picker.js
+++ b/j2cl/lit/src/elements/compose-attachment-picker.js
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from "lit";
 import "./interaction-overlay-layer.js";
 import { DISPLAY_SIZES } from "./attachment-display-sizes.js";
+import { t } from "../i18n/t.js";
 
 export class ComposeAttachmentPicker extends LitElement {
   static properties = {
@@ -118,21 +119,23 @@ export class ComposeAttachmentPicker extends LitElement {
         aria-haspopup="dialog"
         aria-expanded=${this.open ? "true" : "false"}
         aria-controls="attachment-picker-overlay"
+        aria-label=${t("attachments.attachFile", "Attach file")}
+        title=${t("attachments.attachFile", "Attach file")}
         @click=${this.openPicker}
       >
-        Attach file
+        ${t("attachments.attachFile", "Attach file")}
       </button>
       <interaction-overlay-layer
         id="attachment-picker-overlay"
         ?open=${this.open}
         modal
-        label="Attach a file"
+        label=${t("attachments.dialogLabel", "Attach a file")}
         focus-target-id="attachment-picker-trigger"
         @overlay-close=${this.onOverlayClose}
       >
         <div class="panel">
           <label>
-            File
+            ${t("attachments.fileLabel", "File")}
             <input
               type="file"
               multiple
@@ -140,16 +143,16 @@ export class ComposeAttachmentPicker extends LitElement {
             />
           </label>
           <label>
-            Caption
+            ${t("attachments.captionLabel", "Caption")}
             <textarea
               name="attachment-caption"
-              aria-label="Attachment caption"
+              aria-label=${t("attachments.captionLabel", "Caption")}
               .value=${this.caption}
               @input=${this.onCaptionInput}
             ></textarea>
           </label>
           <fieldset @keydown=${this.onSizeKeyDown}>
-            <legend>Display size</legend>
+            <legend>${t("attachments.displaySize", "Display size")}</legend>
             <div class="sizes">
               ${DISPLAY_SIZES.map(size => html`
                 <label>
@@ -167,8 +170,14 @@ export class ComposeAttachmentPicker extends LitElement {
           </fieldset>
           ${this.renderUploadState()}
           <div class="actions">
-            <button type="button" data-action="attachment-cancel" @click=${this.cancel}>
-              Cancel
+            <button
+              type="button"
+              data-action="attachment-cancel"
+              aria-label=${t("common.cancel", "Cancel")}
+              title=${t("common.cancel", "Cancel")}
+              @click=${this.cancel}
+            >
+              ${t("common.cancel", "Cancel")}
             </button>
           </div>
         </div>
@@ -183,7 +192,7 @@ export class ComposeAttachmentPicker extends LitElement {
           role="alert"
           aria-live="assertive"
           data-state="attachment-error-state"
-        >${this.uploadError || "Attachment upload failed."}</p>
+        >${this.uploadError || t("attachments.uploadFailed", "Attachment upload failed.")}</p>
       `;
     }
     if (!this.uploadState) {
@@ -196,7 +205,7 @@ export class ComposeAttachmentPicker extends LitElement {
           ? html`
               <progress
                 role="progressbar"
-                aria-label="Attachment upload progress"
+                aria-label=${t("attachments.uploadProgress", "Attachment upload progress")}
                 max="100"
                 value=${this.normalizedProgress()}
                 aria-valuemin="0"

--- a/j2cl/lit/src/elements/composer-inline-reply.js
+++ b/j2cl/lit/src/elements/composer-inline-reply.js
@@ -1,5 +1,6 @@
 import { LitElement, css, html } from "lit";
 import "./composer-submit-affordance.js";
+import { t } from "../i18n/t.js";
 
 export class ComposerInlineReply extends LitElement {
   static properties = {
@@ -95,7 +96,7 @@ export class ComposerInlineReply extends LitElement {
           ? html`<p class="target">Reply target: ${this.targetLabel || "No current wave"}</p>`
           : ""}
         <textarea
-          aria-label="Reply"
+          aria-label=${t("composer.replyLabel", "Reply")}
           .value=${this.draft}
           ?disabled=${textareaDisabled}
           @input=${this.onInput}

--- a/j2cl/lit/src/elements/composer-submit-affordance.js
+++ b/j2cl/lit/src/elements/composer-submit-affordance.js
@@ -78,6 +78,7 @@ export class ComposerSubmitAffordance extends LitElement {
       <button
         type="button"
         aria-label=${this.label}
+        title=${this.label}
         aria-busy=${this.busy ? "true" : "false"}
         ?disabled=${disabled}
         @click=${this.onClick}

--- a/j2cl/lit/src/elements/interaction-overlay-layer.js
+++ b/j2cl/lit/src/elements/interaction-overlay-layer.js
@@ -1,5 +1,6 @@
 import { LitElement, css, html } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { t } from "../i18n/t.js";
 
 export class InteractionOverlayLayer extends LitElement {
   static properties = {
@@ -58,7 +59,7 @@ export class InteractionOverlayLayer extends LitElement {
         role=${this.modal ? "dialog" : "group"}
         tabindex="-1"
         aria-modal=${ifDefined(this.modal ? "true" : undefined)}
-        aria-label=${this.label || "Interaction overlay"}
+        aria-label=${this.label || t("interactionOverlay.defaultLabel", "Interaction overlay")}
       >
         <slot></slot>
       </div>

--- a/j2cl/lit/src/elements/mention-suggestion-popover.js
+++ b/j2cl/lit/src/elements/mention-suggestion-popover.js
@@ -1,5 +1,6 @@
 import { LitElement, css, html } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { t } from "../i18n/t.js";
 
 let mentionPopoverCounter = 0;
 
@@ -117,11 +118,11 @@ export class MentionSuggestionPopover extends LitElement {
         <div
           role="listbox"
           tabindex="-1"
-          aria-label="Mention suggestions"
+          aria-label=${t("mentions.suggestions", "Mention suggestions")}
           aria-activedescendant=${ifDefined(activeId || undefined)}
         >
           ${candidates.length === 0
-            ? html`<p>No mention matches</p>`
+            ? html`<p>${t("mentions.noMatches", "No mention matches")}</p>`
             : candidates.map((candidate, index) =>
                 this.renderCandidate(candidate, index, activeIndex)
               )}

--- a/j2cl/lit/src/elements/reaction-authors-popover.js
+++ b/j2cl/lit/src/elements/reaction-authors-popover.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { t } from "../i18n/t.js";
 
 export class ReactionAuthorsPopover extends LitElement {
   static properties = {
@@ -40,16 +41,17 @@ export class ReactionAuthorsPopover extends LitElement {
       return "";
     }
     const authors = this.safeAuthors();
-    const label = this.reactionLabel || this.emoji || "this reaction";
+    const label = this.reactionLabel || this.emoji || t("reactions.thisReaction", "this reaction");
+    const heading = `${t("reactions.authorsForPrefix", "Authors for")} ${label}`;
     return html`
       <section
         class="popover"
         role="region"
         tabindex="-1"
-        aria-label=${`Authors for ${label}`}
+        aria-label=${heading}
       >
         ${authors.length === 0
-          ? html`<p>No reactions yet</p>`
+          ? html`<p>${t("reactions.noneYet", "No reactions yet")}</p>`
           : html`
               <ul>
                 ${authors.map(author => html`<li>${author}</li>`)}

--- a/j2cl/lit/src/elements/reaction-picker-popover.js
+++ b/j2cl/lit/src/elements/reaction-picker-popover.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { t } from "../i18n/t.js";
 
 let activePicker = null;
 
@@ -76,7 +77,7 @@ export class ReactionPickerPopover extends LitElement {
       <div
         class="picker"
         role="menu"
-        aria-label="Choose reaction"
+        aria-label=${t("reactions.pickerTitle", "Choose reaction")}
         aria-orientation="horizontal"
       >
         ${this.safeEmojis().map(
@@ -85,6 +86,8 @@ export class ReactionPickerPopover extends LitElement {
               type="button"
               role="menuitem"
               data-emoji=${emoji}
+              aria-label=${`${t("reactions.pick", "React with")} ${emoji}`}
+              title=${`${t("reactions.pick", "React with")} ${emoji}`}
               @click=${() => this.pick(emoji)}
             >
               ${emoji}

--- a/j2cl/lit/src/elements/reaction-row.js
+++ b/j2cl/lit/src/elements/reaction-row.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { t } from "../i18n/t.js";
 
 export class ReactionRow extends LitElement {
   static properties = {
@@ -90,13 +91,13 @@ export class ReactionRow extends LitElement {
 
   render() {
     return html`
-      <div class="row" role="group" aria-label="Reactions">
+      <div class="row" role="group" aria-label=${t("reactions.rowLabel", "Reactions")}>
         ${this.safeReactions().map(reaction => this.renderReaction(reaction))}
         <button
           type="button"
           data-reaction-add
-          aria-label="Add reaction"
-          title="Add reaction"
+          aria-label=${t("reactions.add", "Add reaction")}
+          title=${t("reactions.add", "Add reaction")}
           @click=${this.onAdd}
         >
           ☺
@@ -150,16 +151,25 @@ export class ReactionRow extends LitElement {
     const glyph = reaction.glyph || emoji;
     const name = reaction.accessibleName || reaction.label || this.humanizeName(emoji);
     const count = this.safeCount(reaction.count);
+    const groupLabel = `${name} ${t("reactions.reactionSuffix", "reaction")}`;
+    const peopleLabel = count === 1
+      ? t("reactions.person", "person")
+      : t("reactions.people", "people");
+    const toggleLabel = `${t("reactions.toggle", "Toggle")} ${name} ${t(
+      "reactions.reactionSuffix",
+      "reaction"
+    )}, ${count} ${peopleLabel}`;
+    const inspectLabel = reaction.inspectLabel
+      || `${t("reactions.inspectPrefix", "Inspect")} ${name} ${t("reactions.reactionsSuffix", "reactions")}`;
     return html`
-      <span role="group" aria-label=${`${name} reaction`}>
+      <span role="group" aria-label=${groupLabel}>
         <button
           type="button"
           data-reaction-chip
           data-emoji=${emoji}
           aria-pressed=${reaction.active ? "true" : "false"}
-          aria-label=${`Toggle ${name} reaction, ${count} ${
-            count === 1 ? "person" : "people"
-          }`}
+          aria-label=${toggleLabel}
+          title=${toggleLabel}
           @click=${() => this.emit("reaction-toggle", emoji)}
         >
           ${glyph} ${count}
@@ -168,10 +178,11 @@ export class ReactionRow extends LitElement {
           type="button"
           data-reaction-inspect
           data-emoji=${emoji}
-          aria-label=${reaction.inspectLabel || `Inspect ${name} reactions`}
+          aria-label=${inspectLabel}
+          title=${inspectLabel}
           @click=${() => this.emit("reaction-inspect", emoji)}
         >
-          authors
+          ${t("reactions.authorsShort", "authors")}
         </button>
       </span>
     `;

--- a/j2cl/lit/src/elements/shell-skip-link.js
+++ b/j2cl/lit/src/elements/shell-skip-link.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { t } from "../i18n/t.js";
 
 export class ShellSkipLink extends LitElement {
   static properties = {
@@ -34,7 +35,7 @@ export class ShellSkipLink extends LitElement {
   constructor() {
     super();
     this.target = "#j2cl-root-shell-workflow";
-    this.label = "Skip to main content";
+    this.label = t("skipLink.label", "Skip to main content");
   }
 
   connectedCallback() {

--- a/j2cl/lit/src/elements/shell-skip-link.js
+++ b/j2cl/lit/src/elements/shell-skip-link.js
@@ -35,7 +35,7 @@ export class ShellSkipLink extends LitElement {
   constructor() {
     super();
     this.target = "#j2cl-root-shell-workflow";
-    this.label = t("skipLink.label", "Skip to main content");
+    this.label = "";
   }
 
   connectedCallback() {
@@ -58,7 +58,7 @@ export class ShellSkipLink extends LitElement {
       this.appendChild(anchor);
     }
     anchor.setAttribute("href", this.target);
-    anchor.textContent = this.label;
+    anchor.textContent = this.label || t("skipLink.label", "Skip to main content");
   }
 }
 

--- a/j2cl/lit/src/elements/shell-status-strip.js
+++ b/j2cl/lit/src/elements/shell-status-strip.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { t } from "../i18n/t.js";
 
 export class ShellStatusStrip extends LitElement {
   static properties = {
@@ -97,23 +98,27 @@ export class ShellStatusStrip extends LitElement {
   }
 
   _connectionLabel() {
-    return this.connectionState === "offline" ? "Offline" : "Online";
+    return this.connectionState === "offline"
+      ? t("statusStrip.offline", "Offline")
+      : t("statusStrip.online", "Online");
   }
 
   _saveLabel() {
-    return this.saveState === "unsaved" || this.saveState === "saving" ? "Saving changes" : "Saved";
+    return this.saveState === "unsaved" || this.saveState === "saving"
+      ? t("statusStrip.saving", "Saving changes")
+      : t("statusStrip.saved", "Saved");
   }
 
   _routeLabel() {
     switch (this.routeState) {
       case "selected-wave":
-        return "Selected wave active";
+        return t("statusStrip.selectedWave", "Selected wave active");
       case "search":
-        return "Search results active";
+        return t("statusStrip.search", "Search results active");
       case "loading":
-        return "Loading workspace";
+        return t("statusStrip.loading", "Loading workspace");
       default:
-        return "Workspace ready";
+        return t("statusStrip.ready", "Workspace ready");
     }
   }
 

--- a/j2cl/lit/src/elements/task-metadata-popover.js
+++ b/j2cl/lit/src/elements/task-metadata-popover.js
@@ -1,5 +1,6 @@
 import { LitElement, css, html } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { t } from "../i18n/t.js";
 
 let taskMetadataPopoverCounter = 0;
 
@@ -149,11 +150,11 @@ export class TaskMetadataPopover extends LitElement {
         aria-labelledby=${titleId}
         @submit=${this.submit}
       >
-        <h2 id=${titleId}>Task details</h2>
+        <h2 id=${titleId}>${t("taskMetadata.title", "Task details")}</h2>
         <label>
-          Assignee
-          <select name="assignee">
-            <option value="">Unassigned</option>
+          ${t("taskMetadata.assignee", "Assignee")}
+          <select name="assignee" aria-label=${t("taskMetadata.assignee", "Assignee")}>
+            <option value="">${t("taskMetadata.unassigned", "Unassigned")}</option>
             ${assigneeOptions.map(
               participant => html`
                 <option
@@ -167,11 +168,12 @@ export class TaskMetadataPopover extends LitElement {
           </select>
         </label>
         <label>
-          Due date
+          ${t("taskMetadata.dueDate", "Due date")}
           <input
             name="dueDate"
             inputmode="numeric"
-            placeholder="YYYY-MM-DD"
+            placeholder=${t("taskMetadata.dueDatePlaceholder", "YYYY-MM-DD")}
+            aria-label=${t("taskMetadata.dueDate", "Due date")}
             aria-invalid=${this.error ? "true" : "false"}
             aria-describedby=${ifDefined(this.error ? errorId : undefined)}
             .value=${this.dueDate}
@@ -179,8 +181,17 @@ export class TaskMetadataPopover extends LitElement {
         </label>
         ${this.error ? html`<p id=${errorId} role="alert">${this.error}</p>` : ""}
         <div class="actions">
-          <button type="button" @click=${() => this.close("cancel")}>Cancel</button>
-          <button type="submit">Save</button>
+          <button
+            type="button"
+            aria-label=${t("common.cancel", "Cancel")}
+            title=${t("common.cancel", "Cancel")}
+            @click=${() => this.close("cancel")}
+          >${t("common.cancel", "Cancel")}</button>
+          <button
+            type="submit"
+            aria-label=${t("taskMetadata.save", "Save")}
+            title=${t("taskMetadata.save", "Save")}
+          >${t("taskMetadata.save", "Save")}</button>
         </div>
       </form>
     `;

--- a/j2cl/lit/src/elements/toolbar-overflow-menu.js
+++ b/j2cl/lit/src/elements/toolbar-overflow-menu.js
@@ -41,7 +41,7 @@ export class ToolbarOverflowMenu extends LitElement {
 
   constructor() {
     super();
-    this.label = t("toolbar.overflowMenu", "More actions");
+    this.label = "";
     this.open = false;
     this.addEventListener("keydown", this.onKeyDown);
     this.addEventListener("click", this.onLightDomClick);
@@ -49,17 +49,18 @@ export class ToolbarOverflowMenu extends LitElement {
   }
 
   render() {
+    const label = this.label || t("toolbar.overflowMenu", "More actions");
     return html`
       <button
         type="button"
         aria-haspopup="true"
         aria-expanded=${this.open ? "true" : "false"}
-        aria-label=${this.label}
-        title=${this.label}
+        aria-label=${label}
+        title=${label}
         @click=${this.toggle}
         @keydown=${this.onTriggerKeyDown}
       >
-        ${this.label}
+        ${label}
       </button>
       <div class="menu"><slot></slot></div>
     `;

--- a/j2cl/lit/src/elements/toolbar-overflow-menu.js
+++ b/j2cl/lit/src/elements/toolbar-overflow-menu.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { t } from "../i18n/t.js";
 
 export class ToolbarOverflowMenu extends LitElement {
   static properties = {
@@ -40,7 +41,7 @@ export class ToolbarOverflowMenu extends LitElement {
 
   constructor() {
     super();
-    this.label = "More actions";
+    this.label = t("toolbar.overflowMenu", "More actions");
     this.open = false;
     this.addEventListener("keydown", this.onKeyDown);
     this.addEventListener("click", this.onLightDomClick);
@@ -53,6 +54,8 @@ export class ToolbarOverflowMenu extends LitElement {
         type="button"
         aria-haspopup="true"
         aria-expanded=${this.open ? "true" : "false"}
+        aria-label=${this.label}
+        title=${this.label}
         @click=${this.toggle}
         @keydown=${this.onTriggerKeyDown}
       >

--- a/j2cl/lit/src/elements/wave-blip-toolbar.js
+++ b/j2cl/lit/src/elements/wave-blip-toolbar.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { t } from "../i18n/t.js";
 
 /**
  * <wave-blip-toolbar> — F-2 (#1037, R-3.1) per-blip action toolbar that
@@ -104,42 +105,46 @@ export class WaveBlipToolbar extends LitElement {
   }
 
   render() {
+    const replyAction = t("blipToolbar.replyAction", "Reply to this blip");
+    const editAction = t("blipToolbar.editAction", "Edit this blip");
+    const deleteAction = t("blipToolbar.deleteAction", "Delete this blip");
+    const linkAction = t("blipToolbar.linkAction", "Copy permalink to this blip");
     return html`
       <button
         type="button"
         data-toolbar-action="reply"
-        aria-label="Reply to this blip"
-        title="Reply to this blip"
+        aria-label=${replyAction}
+        title=${replyAction}
         @click=${() => this._emit("wave-blip-toolbar-reply")}
       >
-        <span class="glyph" aria-hidden="true">↩</span><span class="label">Reply</span>
+        <span class="glyph" aria-hidden="true">↩</span><span class="label">${t("blipToolbar.reply", "Reply")}</span>
       </button>
       <button
         type="button"
         data-toolbar-action="edit"
-        aria-label="Edit this blip"
-        title="Edit this blip"
+        aria-label=${editAction}
+        title=${editAction}
         @click=${() => this._emit("wave-blip-toolbar-edit")}
       >
-        <span class="glyph" aria-hidden="true">✎</span><span class="label">Edit</span>
+        <span class="glyph" aria-hidden="true">✎</span><span class="label">${t("blipToolbar.edit", "Edit")}</span>
       </button>
       <button
         type="button"
         data-toolbar-action="delete"
-        aria-label="Delete this blip"
-        title="Delete this blip"
+        aria-label=${deleteAction}
+        title=${deleteAction}
         @click=${() => this._emit("wave-blip-toolbar-delete")}
       >
-        <span class="glyph" aria-hidden="true">⌫</span><span class="label">Delete</span>
+        <span class="glyph" aria-hidden="true">⌫</span><span class="label">${t("blipToolbar.deleteShort", "Delete")}</span>
       </button>
       <button
         type="button"
         data-toolbar-action="link"
-        aria-label="Copy permalink to this blip"
-        title="Copy permalink to this blip"
+        aria-label=${linkAction}
+        title=${linkAction}
         @click=${() => this._emit("wave-blip-toolbar-link")}
       >
-        <span class="glyph" aria-hidden="true">↗</span><span class="label">Link</span>
+        <span class="glyph" aria-hidden="true">↗</span><span class="label">${t("blipToolbar.linkShort", "Link")}</span>
       </button>
     `;
   }

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -689,8 +689,8 @@ export class WaveBlip extends LitElement {
             class="avatar"
             data-blip-avatar="true"
             data-palette=${String(palette)}
-            aria-label=${`${t("blip.openProfilePrefix", "Open")} ${authorLabel} ${t("blip.profileSuffix", "profile")}`}
-            title=${`${t("blip.openProfilePrefix", "Open")} ${authorLabel} ${t("blip.profileSuffix", "profile")}`}
+            aria-label=${t("blip.openAuthorProfile", "Open {name} profile").replace("{name}", authorLabel)}
+            title=${t("blip.openAuthorProfile", "Open {name} profile").replace("{name}", authorLabel)}
             @click=${this._onAvatarClick}
           >
             ${avatarUrl

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 import "./wavy-task-affordance.js";
+import { t } from "../i18n/t.js";
 
 /**
  * <wave-blip> — F-2 (#1037, R-3.1) read-surface wrapper around the F-0
@@ -647,17 +648,25 @@ export class WaveBlip extends LitElement {
     const palette = this._palette();
     const hasReplies = this.replyCount > 0;
     const visuallyFocused = this._visuallyFocused();
-    const replyNoun = this.replyCount === 1 ? "reply" : "replies";
-    const threadToggleVerb = this.threadCollapsed ? "Expand" : "Collapse";
+    const replyNoun = this.replyCount === 1
+      ? t("blip.reply", "reply")
+      : t("blip.replies", "replies");
+    const threadToggleVerb = this.threadCollapsed
+      ? t("blip.expand", "Expand")
+      : t("blip.collapse", "Collapse");
     const authorLabel = this._authorLabel();
     const avatarUrl = this._avatarUrl();
+    const threadLabel = `${threadToggleVerb} ${this.replyCount} ${replyNoun} ${t(
+      "blip.underThisBlipSuffix",
+      "under this blip"
+    )}`;
     const chevron = hasReplies
       ? html`<button
           type="button"
           class="thread-chevron"
           data-thread-chevron="true"
-          aria-label=${`${threadToggleVerb} ${this.replyCount} ${replyNoun} under this blip`}
-          title=${`${threadToggleVerb} ${this.replyCount} ${replyNoun} under this blip`}
+          aria-label=${threadLabel}
+          title=${threadLabel}
           @click=${this._onThreadChevronClick}
         >${this._chevronGlyph()}</button>`
       : html`<span class="thread-chevron" hidden></span>`;
@@ -680,7 +689,8 @@ export class WaveBlip extends LitElement {
             class="avatar"
             data-blip-avatar="true"
             data-palette=${String(palette)}
-            aria-label=${`Open ${authorLabel} profile`}
+            aria-label=${`${t("blip.openProfilePrefix", "Open")} ${authorLabel} ${t("blip.profileSuffix", "profile")}`}
+            title=${`${t("blip.openProfilePrefix", "Open")} ${authorLabel} ${t("blip.profileSuffix", "profile")}`}
             @click=${this._onAvatarClick}
           >
             ${avatarUrl

--- a/j2cl/lit/src/elements/wavy-back-to-inbox.js
+++ b/j2cl/lit/src/elements/wavy-back-to-inbox.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { t } from "../i18n/t.js";
 
 /**
  * <wavy-back-to-inbox> — F-2.S4 (#1048, J.5) "Back to inbox" header
@@ -76,14 +77,16 @@ export class WavyBackToInbox extends LitElement {
   }
 
   render() {
+    const label = t("backToInbox.label", "Back to inbox");
     return html`
       <a
         href=${this.href || "#inbox"}
-        aria-label="Back to inbox"
+        aria-label=${label}
+        title=${label}
         @click=${this._onClick}
       >
         <span aria-hidden="true">←</span>
-        <span>Inbox</span>
+        <span>${t("header.inbox", "Inbox")}</span>
       </a>
     `;
   }

--- a/j2cl/lit/src/elements/wavy-colorpicker-popover.js
+++ b/j2cl/lit/src/elements/wavy-colorpicker-popover.js
@@ -1,5 +1,6 @@
 import { LitElement, css, html, nothing } from "lit";
 import { WAVY_COLOR_PALETTE } from "../format/color-options.js";
+import { t } from "../i18n/t.js";
 
 const COLS = 10;
 const VIEWPORT_MARGIN_PX = 8;
@@ -130,7 +131,9 @@ export class WavyColorpickerPopover extends LitElement {
 
   render() {
     if (!this.open) return nothing;
-    const label = this.mode === "highlight" ? "Highlight color palette" : "Text color palette";
+    const label = this.mode === "highlight"
+      ? t("colorPicker.highlightPalette", "Highlight color palette")
+      : t("colorPicker.textPalette", "Text color palette");
     return html`<div
       class="panel"
       role="grid"
@@ -143,6 +146,7 @@ export class WavyColorpickerPopover extends LitElement {
         role="gridcell"
         data-color=${color}
         aria-label=${color}
+        title=${color}
         aria-selected=${String(index === this.activeIndex)}
         style=${`background: ${color}`}
         @click=${() => this._select(index)}

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 import "../design/wavy-compose-card.js";
+import { t } from "../i18n/t.js";
 import "./composer-submit-affordance.js";
 import "./mention-suggestion-popover.js";
 import "./wavy-link-modal.js";
@@ -1781,10 +1782,12 @@ export class WavyComposer extends LitElement {
   }
 
   _composeBodyAriaLabel() {
-    if (this.mode === "edit") return "Edit blip";
-    if (this.mode === "wave-root") return "Reply to wave";
-    if (this.mode === "create") return "New wave";
-    return this.targetLabel ? `Reply to ${this.targetLabel}` : "Reply";
+    if (this.mode === "edit") return t("composer.editBlip", "Edit blip");
+    if (this.mode === "wave-root") return t("composer.replyToWave", "Reply to wave");
+    if (this.mode === "create") return t("composer.newWave", "New wave");
+    return this.targetLabel
+      ? `${t("composer.replyToPrefix", "Reply to")} ${this.targetLabel}`
+      : t("composer.replyLabel", "Reply");
   }
 
   _serializeBodyText() {
@@ -2883,7 +2886,8 @@ export class WavyComposer extends LitElement {
           type="button"
           class="reply-chip-close"
           data-reply-chip-close="true"
-          aria-label="Cancel"
+          aria-label=${t("common.cancel", "Cancel")}
+          title=${t("common.cancel", "Cancel")}
           @click=${this._onCloseClick}
         >×</button>
       </span>

--- a/j2cl/lit/src/elements/wavy-confirm-dialog.js
+++ b/j2cl/lit/src/elements/wavy-confirm-dialog.js
@@ -244,12 +244,16 @@ export class WavyConfirmDialog extends LitElement {
               type="button"
               data-confirm-action="cancel"
               data-confirm-tone="default"
+              aria-label=${this.cancelLabel}
+              title=${this.cancelLabel}
               @click=${() => this._resolve(false)}
             >${this.cancelLabel}</button>
             <button
               type="button"
               data-confirm-action="confirm"
               data-confirm-tone=${this.tone}
+              aria-label=${this.confirmLabel}
+              title=${this.confirmLabel}
               @click=${() => this._resolve(true)}
             >${this.confirmLabel}</button>
           </div>

--- a/j2cl/lit/src/elements/wavy-depth-nav-bar.js
+++ b/j2cl/lit/src/elements/wavy-depth-nav-bar.js
@@ -176,12 +176,17 @@ export class WavyDepthNavBar extends LitElement {
   }
 
   _upOneLevelLabel() {
-    return this.parentAuthorName
-      ? `${t("depthNav.upOneLevelTo", "Up one level to")} ${this.parentAuthorName}${t(
-          "depthNav.upOneLevelThreadSuffix",
-          "'s thread"
-        )}`
-      : t("depthNav.upOneLevel", "Up one level");
+    if (!this.parentAuthorName) {
+      return t("depthNav.upOneLevel", "Up one level");
+    }
+    // Single-key template with a `{name}` placeholder so locales that need
+    // a different word order (e.g. German genitive "Alices Thread" vs.
+    // English possessive "Alice's thread") can express the whole sentence.
+    const template = t(
+      "depthNav.upOneLevelToNameThread",
+      "Up one level to {name}'s thread"
+    );
+    return template.replace("{name}", this.parentAuthorName);
   }
 
   render() {

--- a/j2cl/lit/src/elements/wavy-depth-nav-bar.js
+++ b/j2cl/lit/src/elements/wavy-depth-nav-bar.js
@@ -1,5 +1,6 @@
 import { LitElement, css, html } from "lit";
 import "../design/wavy-depth-nav.js";
+import { t } from "../i18n/t.js";
 
 /**
  * <wavy-depth-nav-bar> — F-2 (#1037, R-3.7-chrome; slice 2 #1046)
@@ -176,23 +177,27 @@ export class WavyDepthNavBar extends LitElement {
 
   _upOneLevelLabel() {
     return this.parentAuthorName
-      ? `Up one level to ${this.parentAuthorName}'s thread`
-      : "Up one level";
+      ? `${t("depthNav.upOneLevelTo", "Up one level to")} ${this.parentAuthorName}${t(
+          "depthNav.upOneLevelThreadSuffix",
+          "'s thread"
+        )}`
+      : t("depthNav.upOneLevel", "Up one level");
   }
 
   render() {
     const items = Array.isArray(this.crumbs) ? this.crumbs : [];
     return html`
-      <div class="bar" role="toolbar" aria-label="Depth navigation">
+      <div class="bar" role="toolbar" aria-label=${t("depthNav.label", "Thread navigation")}>
         <div class="left">
           <button
             type="button"
             data-action="up-one-level"
             aria-label=${this._upOneLevelLabel()}
+            title=${this._upOneLevelLabel()}
             @click=${this._onUpOneLevel}
           >
             <span class="glyph" aria-hidden="true">▲</span>
-            ${this.parentAuthorName || "Up"}
+            ${this.parentAuthorName || t("depthNav.up", "Up")}
           </button>
         </div>
         <div class="center">
@@ -206,11 +211,12 @@ export class WavyDepthNavBar extends LitElement {
           <button
             type="button"
             data-action="up-to-wave"
-            aria-label="Back to top of wave"
+            aria-label=${t("depthNav.backToTop", "Back to top of wave")}
+            title=${t("depthNav.backToTop", "Back to top of wave")}
             @click=${this._onUpToWave}
           >
             <span class="glyph" aria-hidden="true">⌃</span>
-            Up to wave
+            ${t("depthNav.upToWave", "Up to wave")}
           </button>
         </div>
       </div>

--- a/j2cl/lit/src/elements/wavy-floating-scroll-to-new.js
+++ b/j2cl/lit/src/elements/wavy-floating-scroll-to-new.js
@@ -126,6 +126,7 @@ export class WavyFloatingScrollToNew extends LitElement {
   render() {
     const c = this.count || 0;
     const label = t("scrollToNew.label", "Scroll to new messages");
+    const newSuffix = t("scrollToNew.newSuffix", "new");
     return html`
       <button
         type="button"
@@ -133,7 +134,7 @@ export class WavyFloatingScrollToNew extends LitElement {
         title=${label}
         @click=${this._onClick}
       >
-        <span aria-hidden="true">↓ ${c} new</span>
+        <span aria-hidden="true">↓ ${c} ${newSuffix}</span>
       </button>
     `;
   }

--- a/j2cl/lit/src/elements/wavy-floating-scroll-to-new.js
+++ b/j2cl/lit/src/elements/wavy-floating-scroll-to-new.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { t } from "../i18n/t.js";
 
 /**
  * <wavy-floating-scroll-to-new> — F-2.S4 (#1048, J.2) floating "scroll to
@@ -124,10 +125,12 @@ export class WavyFloatingScrollToNew extends LitElement {
 
   render() {
     const c = this.count || 0;
+    const label = t("scrollToNew.label", "Scroll to new messages");
     return html`
       <button
         type="button"
-        aria-label="Scroll to new messages"
+        aria-label=${label}
+        title=${label}
         @click=${this._onClick}
       >
         <span aria-hidden="true">↓ ${c} new</span>

--- a/j2cl/lit/src/elements/wavy-format-toolbar.js
+++ b/j2cl/lit/src/elements/wavy-format-toolbar.js
@@ -4,6 +4,7 @@ import { FONT_FAMILY_OPTIONS, FONT_SIZE_OPTIONS } from "../format/font-options.j
 import "./toolbar-button.js";
 import "./toolbar-group.js";
 import "./wavy-colorpicker-popover.js";
+import { t } from "../i18n/t.js";
 
 /**
  * <wavy-format-toolbar> — F-3.S1 (#1038, R-5.2) selection-driven floating
@@ -74,16 +75,20 @@ const ACTIVE_ANNOTATION_MAP = {
  * controller, etc.) see the same `actionId` payload. This is purely a
  * visual structural change.
  */
+// English labels are kept inline as fallbacks; the visible label is resolved
+// at render time via t(`formatToolbar.${id}`, fallback) so locale changes
+// re-render cleanly.
 const DAILY_RICH_EDIT_ACTIONS = [
-  { id: "bold", label: "Bold", group: "text", toggle: true },
-  { id: "italic", label: "Italic", group: "text", toggle: true },
-  { id: "underline", label: "Underline", group: "text", toggle: true },
-  { id: "strikethrough", label: "Strikethrough", group: "text", toggle: true },
-  { id: "superscript", label: "Superscript", group: "text", toggle: true },
-  { id: "subscript", label: "Subscript", group: "text", toggle: true },
+  { id: "bold", labelKey: "formatToolbar.bold", labelDefault: "Bold", group: "text", toggle: true },
+  { id: "italic", labelKey: "formatToolbar.italic", labelDefault: "Italic", group: "text", toggle: true },
+  { id: "underline", labelKey: "formatToolbar.underline", labelDefault: "Underline", group: "text", toggle: true },
+  { id: "strikethrough", labelKey: "formatToolbar.strikethrough", labelDefault: "Strikethrough", group: "text", toggle: true },
+  { id: "superscript", labelKey: "formatToolbar.superscript", labelDefault: "Superscript", group: "text", toggle: true },
+  { id: "subscript", labelKey: "formatToolbar.subscript", labelDefault: "Subscript", group: "text", toggle: true },
   {
     id: "font-family",
-    label: "Font",
+    labelKey: "formatToolbar.fontFamily",
+    labelDefault: "Font",
     group: "text",
     toggle: false,
     kind: "select",
@@ -91,39 +96,37 @@ const DAILY_RICH_EDIT_ACTIONS = [
   },
   {
     id: "font-size",
-    label: "Size",
+    labelKey: "formatToolbar.fontSize",
+    labelDefault: "Size",
     group: "text",
     toggle: false,
     kind: "select",
     options: FONT_SIZE_OPTIONS
   },
-  { id: "text-color", label: "Text color", group: "text", toggle: false },
-  { id: "highlight-color", label: "Highlight color", group: "text", toggle: false },
-  { id: "heading", label: "Heading", group: "block", toggle: false },
-  { id: "unordered-list", label: "Bulleted list", group: "block", toggle: true },
-  { id: "ordered-list", label: "Numbered list", group: "block", toggle: true },
-  { id: "indent", label: "Indent", group: "block", toggle: false },
-  { id: "outdent", label: "Outdent", group: "block", toggle: false },
-  { id: "align-left", label: "Align left", group: "align", toggle: false },
-  { id: "align-center", label: "Align center", group: "align", toggle: false },
-  { id: "align-right", label: "Align right", group: "align", toggle: false },
-  { id: "rtl", label: "Right-to-left", group: "align", toggle: false },
-  { id: "link", label: "Insert link", group: "link", toggle: false },
-  { id: "unlink", label: "Remove link", group: "link", toggle: false },
-  { id: "clear-formatting", label: "Clear formatting", group: "clear", toggle: false },
-  // F-3.S2 (#1038, R-5.4 step 6 + H.20): inline task list insert.
-  // Display-only inside the body (the `<input type="checkbox">` is
-  // disabled — the per-blip task affordance owns model state).
-  { id: "insert-task", label: "Insert task", group: "insert", toggle: false },
-  // F-3.S4 (#1038, R-5.6 H.19): attachment paperclip. Clicking emits
-  // wavy-format-toolbar-action with actionId "attachment-insert"; the
-  // controller maps that to view.openAttachmentPicker() via the
-  // existing handleAttachmentToolbarAction path.
-  { id: "attachment-insert", label: "Attach file", group: "insert", toggle: false }
+  { id: "text-color", labelKey: "formatToolbar.textColor", labelDefault: "Text color", group: "text", toggle: false },
+  { id: "highlight-color", labelKey: "formatToolbar.highlightColor", labelDefault: "Highlight color", group: "text", toggle: false },
+  { id: "heading", labelKey: "formatToolbar.heading", labelDefault: "Heading", group: "block", toggle: false },
+  { id: "unordered-list", labelKey: "formatToolbar.bulletList", labelDefault: "Bulleted list", group: "block", toggle: true },
+  { id: "ordered-list", labelKey: "formatToolbar.numberedList", labelDefault: "Numbered list", group: "block", toggle: true },
+  { id: "indent", labelKey: "formatToolbar.indent", labelDefault: "Indent", group: "block", toggle: false },
+  { id: "outdent", labelKey: "formatToolbar.outdent", labelDefault: "Outdent", group: "block", toggle: false },
+  { id: "align-left", labelKey: "formatToolbar.alignLeft", labelDefault: "Align left", group: "align", toggle: false },
+  { id: "align-center", labelKey: "formatToolbar.alignCenter", labelDefault: "Align center", group: "align", toggle: false },
+  { id: "align-right", labelKey: "formatToolbar.alignRight", labelDefault: "Align right", group: "align", toggle: false },
+  { id: "rtl", labelKey: "formatToolbar.rtl", labelDefault: "Right-to-left", group: "align", toggle: false },
+  { id: "link", labelKey: "formatToolbar.link", labelDefault: "Insert link", group: "link", toggle: false },
+  { id: "unlink", labelKey: "formatToolbar.unlink", labelDefault: "Remove link", group: "link", toggle: false },
+  { id: "clear-formatting", labelKey: "formatToolbar.clearFormatting", labelDefault: "Clear formatting", group: "clear", toggle: false },
+  { id: "insert-task", labelKey: "formatToolbar.insertTask", labelDefault: "Insert task", group: "insert", toggle: false },
+  { id: "attachment-insert", labelKey: "formatToolbar.attachFile", labelDefault: "Attach file", group: "insert", toggle: false }
 ];
 
+function actionLabel(action) {
+  return t(action.labelKey, action.labelDefault);
+}
+
 const GROUP_ORDER = ["text", "block", "align", "link", "clear", "insert"];
-const GROUP_LABELS = {
+const GROUP_LABEL_DEFAULTS = {
   text: "Text formatting",
   block: "Block formatting",
   align: "Alignment",
@@ -131,6 +134,11 @@ const GROUP_LABELS = {
   clear: "Clear formatting",
   insert: "Insert"
 };
+
+function groupLabel(groupId) {
+  const fallback = GROUP_LABEL_DEFAULTS[groupId] || groupId;
+  return t(`formatToolbar.group.${groupId}`, fallback);
+}
 
 export class WavyFormatToolbar extends LitElement {
   static properties = {
@@ -362,14 +370,16 @@ export class WavyFormatToolbar extends LitElement {
   }
 
   _renderAction(action) {
+    const label = actionLabel(action);
     if (action.kind === "select") {
       return html`<select
         class="toolbar-select"
         data-toolbar-action=${action.id}
-        aria-label=${action.label}
+        aria-label=${label}
+        title=${label}
         @change=${(event) => this._onSelectAction(action, event)}
       >
-        <option value="">${action.label}</option>
+        <option value="">${label}</option>
         ${action.options.map((option) => html`<option value=${option}>${option}</option>`)}
       </select>`;
     }
@@ -377,7 +387,7 @@ export class WavyFormatToolbar extends LitElement {
       data-toolbar-action=${action.id}
       action=${action.id}
       icon=${action.id}
-      label=${action.label}
+      label=${label}
       ?toggle=${action.toggle}
       ?pressed=${this._isActionActive(action)}
     ></toolbar-button>`;
@@ -386,7 +396,7 @@ export class WavyFormatToolbar extends LitElement {
   _renderGroup(groupId) {
     const actions = DAILY_RICH_EDIT_ACTIONS.filter((a) => a.group === groupId);
     if (actions.length === 0) return null;
-    return html`<toolbar-group label=${GROUP_LABELS[groupId] || groupId}>
+    return html`<toolbar-group label=${groupLabel(groupId)}>
       ${actions.map((action) => this._renderAction(action))}
     </toolbar-group>`;
   }

--- a/j2cl/lit/src/elements/wavy-header.js
+++ b/j2cl/lit/src/elements/wavy-header.js
@@ -55,15 +55,19 @@ export class WavyHeader extends LitElement {
   };
 
   // Locale set re-derived from the GWT locale build set; matches the
-  // SearchWidgetMessages_*.properties files in the resources tree.
+  // SearchWidgetMessages_*.properties files in the resources tree. Each
+  // entry carries `shipped: true` if a JS catalog is registered (see
+  // `SHIPPED_LOCALES` in ../i18n/locale.js); unshipped entries render as
+  // disabled options in the picker so we don't advertise locales whose
+  // catalogs have not yet landed.
   static LOCALES = [
-    { code: "en", label: "English" },
-    { code: "de", label: "Deutsch" },
-    { code: "es", label: "Español" },
-    { code: "fr", label: "Français" },
-    { code: "ru", label: "Русский" },
-    { code: "sl", label: "Slovenščina" },
-    { code: "zh_TW", label: "繁體中文" }
+    { code: "en", label: "English", shipped: true },
+    { code: "de", label: "Deutsch", shipped: true },
+    { code: "es", label: "Español", shipped: false },
+    { code: "fr", label: "Français", shipped: false },
+    { code: "ru", label: "Русский", shipped: false },
+    { code: "sl", label: "Slovenščina", shipped: false },
+    { code: "zh_TW", label: "繁體中文", shipped: false }
   ];
 
   static styles = css`
@@ -403,7 +407,11 @@ export class WavyHeader extends LitElement {
       >
         ${WavyHeader.LOCALES.map(
           (loc) =>
-            html`<option value=${loc.code} ?selected=${loc.code === this.locale}>
+            html`<option
+              value=${loc.code}
+              ?selected=${loc.code === this.locale}
+              ?disabled=${loc.shipped === false}
+            >
               ${this.compactGwtTopbar ? loc.code.replace("_", "-").toUpperCase() : loc.label}
             </option>`
         )}

--- a/j2cl/lit/src/elements/wavy-header.js
+++ b/j2cl/lit/src/elements/wavy-header.js
@@ -1,4 +1,6 @@
 import { LitElement, css, html } from "lit";
+import { getLocale, setLocale, subscribe } from "../i18n/locale.js";
+import { t } from "../i18n/t.js";
 
 /**
  * <wavy-header> — F-2 (#1037, #1047 slice 3) header end-region chrome.
@@ -289,7 +291,7 @@ export class WavyHeader extends LitElement {
   constructor() {
     super();
     this.signedIn = false;
-    this.locale = "en";
+    this.locale = getLocale();
     this.address = "";
     this.userName = "";
     this.unreadCount = 0;
@@ -298,6 +300,25 @@ export class WavyHeader extends LitElement {
     this.noBrand = false;
     this.connectionState = "online";
     this.saveState = "saved";
+    this._unsubscribeLocale = null;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._unsubscribeLocale = subscribe((next) => {
+      if (this.locale !== next) {
+        this.locale = next;
+      }
+      this.requestUpdate();
+    });
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._unsubscribeLocale) {
+      this._unsubscribeLocale();
+      this._unsubscribeLocale = null;
+    }
   }
 
   _normalizedBasePath() {
@@ -326,6 +347,7 @@ export class WavyHeader extends LitElement {
   _onLocaleChange(evt) {
     const next = evt.target.value;
     this.locale = next;
+    setLocale(next);
     this.dispatchEvent(
       new CustomEvent("wavy-locale-changed", {
         bubbles: true,
@@ -346,15 +368,15 @@ export class WavyHeader extends LitElement {
   }
 
   _saveLabel() {
-    if (this.saveState === "saving") return "Saving changes";
-    if (this.saveState === "unsaved") return "Unsaved changes";
-    return "All changes saved";
+    if (this.saveState === "saving") return t("header.saveSaving", "Saving changes");
+    if (this.saveState === "unsaved") return t("header.saveUnsaved", "Unsaved changes");
+    return t("header.saveSaved", "All changes saved");
   }
 
   _netLabel() {
-    if (this.connectionState === "offline") return "Offline";
-    if (this.connectionState === "connecting") return "Connecting";
-    return "Online";
+    if (this.connectionState === "offline") return t("header.netOffline", "Offline");
+    if (this.connectionState === "connecting") return t("header.netConnecting", "Connecting");
+    return t("header.netOnline", "Online");
   }
 
   render() {
@@ -366,7 +388,7 @@ export class WavyHeader extends LitElement {
       ${this.noBrand
         ? null
         : html`
-            <a class="brand" href=${base} aria-label="SupaWave home">
+            <a class="brand" href=${base} aria-label=${t("header.brand", "SupaWave home")} title=${t("header.brand", "SupaWave home")}>
               <span class="brand-dot" aria-hidden="true"></span>
               <span class="brand-text">SupaWave</span>
             </a>
@@ -374,7 +396,8 @@ export class WavyHeader extends LitElement {
 
       <select
         class="locale"
-        aria-label="Language"
+        aria-label=${t("header.localePicker", "Language")}
+        title=${t("header.localePicker", "Language")}
         .value=${this.locale}
         @change=${this._onLocaleChange}
       >
@@ -432,7 +455,8 @@ export class WavyHeader extends LitElement {
             <button
               type="button"
               class="bell"
-              aria-label="Notifications"
+              aria-label=${t("header.notifications", "Notifications")}
+              title=${t("header.notifications", "Notifications")}
             >
               <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true">
                 <path d="M3 12h10l-1.4-1.4A2 2 0 0 1 11 9.2V7a3 3 0 0 0-6 0v2.2a2 2 0 0 1-.6 1.4L3 12z" stroke-linecap="round" stroke-linejoin="round"/>
@@ -441,7 +465,7 @@ export class WavyHeader extends LitElement {
               <span class="dot violet" ?hidden=${!hasUnread} aria-hidden="true"></span>
             </button>
 
-            <a class="mail" href=${`${base}?view=j2cl-root&q=in:inbox`} aria-label="Inbox">
+            <a class="mail" href=${`${base}?view=j2cl-root&q=in:inbox`} aria-label=${t("header.inbox", "Inbox")} title=${t("header.inbox", "Inbox")}>
               <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true">
                 <rect x="2" y="3.5" width="12" height="9" rx="1.4"/>
                 <path d="M2.5 4.5l5.5 4 5.5-4" stroke-linecap="round" stroke-linejoin="round"/>
@@ -452,7 +476,8 @@ export class WavyHeader extends LitElement {
               type="button"
               class="user-menu"
               aria-haspopup="menu"
-              aria-label="Open user menu"
+              aria-label=${t("header.userMenu", "Open user menu")}
+              title=${t("header.userMenu", "Open user menu")}
               @click=${this._onUserMenuClick}
             >
               <span class="avatar" aria-hidden="true">${initials}</span>

--- a/j2cl/lit/src/elements/wavy-link-modal.js
+++ b/j2cl/lit/src/elements/wavy-link-modal.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { t } from "../i18n/t.js";
 
 /**
  * <wavy-link-modal> — F-3.S1 (#1038, R-5.2 step 5) modal dialog used by
@@ -179,13 +180,14 @@ export class WavyLinkModal extends LitElement {
         aria-labelledby="wavy-link-modal-title"
         @click=${(e) => e.stopPropagation()}
       >
-        <h2 id="wavy-link-modal-title">Insert link</h2>
+        <h2 id="wavy-link-modal-title">${t("linkModal.title", "Insert link")}</h2>
         <form @submit=${this._onSubmit}>
           <label>
-            URL
+            ${t("linkModal.urlLabel", "URL")}
             <input
               name="url"
               type="url"
+              aria-label=${t("linkModal.urlLabel", "URL")}
               .value=${this.urlValue}
               autocomplete="off"
               autofocus
@@ -194,10 +196,11 @@ export class WavyLinkModal extends LitElement {
             />
           </label>
           <label>
-            Display text
+            ${t("linkModal.textLabel", "Display text")}
             <input
               name="display"
               type="text"
+              aria-label=${t("linkModal.textLabel", "Display text")}
               .value=${this.displayValue}
               autocomplete="off"
               data-link-modal-display
@@ -207,10 +210,21 @@ export class WavyLinkModal extends LitElement {
             ? html`<p class="error" role="alert" data-link-modal-error>${this._error}</p>`
             : ""}
           <div class="actions">
-            <button type="button" data-link-modal-cancel @click=${this._cancel.bind(this)}>
-              Cancel
+            <button
+              type="button"
+              data-link-modal-cancel
+              aria-label=${t("linkModal.cancel", "Cancel")}
+              title=${t("linkModal.cancel", "Cancel")}
+              @click=${this._cancel.bind(this)}
+            >
+              ${t("linkModal.cancel", "Cancel")}
             </button>
-            <button type="submit" data-link-modal-submit>Insert</button>
+            <button
+              type="submit"
+              data-link-modal-submit
+              aria-label=${t("linkModal.insert", "Insert")}
+              title=${t("linkModal.insert", "Insert")}
+            >${t("linkModal.insert", "Insert")}</button>
           </div>
         </form>
       </div>

--- a/j2cl/lit/src/elements/wavy-nav-drawer-toggle.js
+++ b/j2cl/lit/src/elements/wavy-nav-drawer-toggle.js
@@ -1,5 +1,6 @@
 import { LitElement, css, html } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { t } from "../i18n/t.js";
 
 /**
  * <wavy-nav-drawer-toggle> — F-2.S4 (#1048, J.4) hamburger / close
@@ -91,12 +92,15 @@ export class WavyNavDrawerToggle extends LitElement {
     // element. The host carries no role/tabindex (no nested-button).
     const ariaControls = this.getAttribute("aria-controls") || undefined;
     const glyph = this.open ? "✕" : "☰";
-    const label = this.open ? "Close navigation drawer" : "Open navigation drawer";
+    const label = this.open
+      ? t("navDrawer.close", "Close navigation drawer")
+      : t("navDrawer.open", "Open navigation drawer");
     return html`
       <button
         type="button"
         aria-expanded=${this.open ? "true" : "false"}
         aria-label=${label}
+        title=${label}
         aria-controls=${ifDefined(ariaControls)}
         @click=${this._onClick}
       >

--- a/j2cl/lit/src/elements/wavy-profile-overlay.js
+++ b/j2cl/lit/src/elements/wavy-profile-overlay.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { t } from "../i18n/t.js";
 
 /**
  * <wavy-profile-overlay> — F-2.S4 (#1048, L.1 + L.5) modal that opens
@@ -577,8 +578,8 @@ export class WavyProfileOverlay extends LitElement {
     }
     const ageMs = Date.now() - lastSeen;
     return ageMs >= 0 && ageMs <= 5 * 60 * 1000
-      ? "Online"
-      : "Last seen " + new Date(lastSeen).toLocaleString();
+      ? t("profileOverlay.online", "Online")
+      : `${t("profileOverlay.lastSeenPrefix", "Last seen")} ${new Date(lastSeen).toLocaleString()}`;
   }
 
   _coerceTime(value) {
@@ -640,7 +641,8 @@ export class WavyProfileOverlay extends LitElement {
         <button
           class="exit"
           type="button"
-          aria-label="Close profile"
+          aria-label=${t("profileOverlay.close", "Close profile")}
+          title=${t("profileOverlay.close", "Close profile")}
           @click=${this._onClose}
         >
           <span aria-hidden="true">×</span>
@@ -648,7 +650,8 @@ export class WavyProfileOverlay extends LitElement {
         <button
           class="nav prev"
           type="button"
-          aria-label="Previous participant"
+          aria-label=${t("profileOverlay.previous", "Previous participant")}
+          title=${t("profileOverlay.previous", "Previous participant")}
           ?disabled=${prevDisabled}
           @click=${this._prev}
         >
@@ -657,7 +660,8 @@ export class WavyProfileOverlay extends LitElement {
         <button
           class="nav next"
           type="button"
-          aria-label="Next participant"
+          aria-label=${t("profileOverlay.next", "Next participant")}
+          title=${t("profileOverlay.next", "Next participant")}
           ?disabled=${nextDisabled}
           @click=${this._next}
         >
@@ -675,7 +679,7 @@ export class WavyProfileOverlay extends LitElement {
           ? html`<p
               class="status"
               data-profile-status
-              data-online=${statusLabel === "Online" ? "true" : "false"}
+              data-online=${statusLabel === t("profileOverlay.online", "Online") ? "true" : "false"}
             >${statusLabel}</p>`
           : null}
         ${memberSince
@@ -688,26 +692,32 @@ export class WavyProfileOverlay extends LitElement {
               href=${profileUrl}
               target="_blank"
               rel="noopener noreferrer"
-            >${current && current.isBot ? "Bot profile" : "Profile"}</a>`
+            >${current && current.isBot
+              ? t("profileOverlay.botProfile", "Bot profile")
+              : t("profileOverlay.profile", "Profile")}</a>`
           : null}
         <div class="actions-slot">
           <button
             class="profile-action profile-action-primary"
             type="button"
             data-profile-send-message
+            aria-label=${t("profileOverlay.sendMessage", "Send Message")}
+            title=${t("profileOverlay.sendMessage", "Send Message")}
             ?hidden=${!canSendMessage}
             @click=${() => this._onSendMessage(current)}
           >
-            Send Message
+            ${t("profileOverlay.sendMessage", "Send Message")}
           </button>
           <button
             class="profile-action"
             type="button"
             data-profile-edit
+            aria-label=${t("profileOverlay.editProfile", "Edit Profile")}
+            title=${t("profileOverlay.editProfile", "Edit Profile")}
             ?hidden=${!isSelf}
             @click=${() => this._onEditProfile(current)}
           >
-            Edit Profile
+            ${t("profileOverlay.editProfile", "Edit Profile")}
           </button>
           <slot name="actions"></slot>
         </div>

--- a/j2cl/lit/src/elements/wavy-search-help.js
+++ b/j2cl/lit/src/elements/wavy-search-help.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { t } from "../i18n/t.js";
 
 /**
  * <wavy-search-help> — F-2 (#1037, #1047 slice 3) modal that documents
@@ -336,7 +337,8 @@ export class WavySearchHelp extends LitElement {
             type="button"
             class="dismiss"
             @click=${this._dismiss}
-            aria-label="Close search help"
+            aria-label=${t("searchHelp.close", "Close search help")}
+            title=${t("searchHelp.close", "Close search help")}
           >
             Got it
           </button>

--- a/j2cl/lit/src/elements/wavy-search-help.js
+++ b/j2cl/lit/src/elements/wavy-search-help.js
@@ -337,10 +337,10 @@ export class WavySearchHelp extends LitElement {
             type="button"
             class="dismiss"
             @click=${this._dismiss}
-            aria-label=${t("searchHelp.close", "Close search help")}
+            aria-label=${t("searchHelp.gotIt", "Got it")}
             title=${t("searchHelp.close", "Close search help")}
           >
-            Got it
+            ${t("searchHelp.gotIt", "Got it")}
           </button>
         </header>
         <div class="columns">

--- a/j2cl/lit/src/elements/wavy-search-rail-card.js
+++ b/j2cl/lit/src/elements/wavy-search-rail-card.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html, nothing } from "lit";
+import { t } from "../i18n/t.js";
 
 /**
  * <wavy-search-rail-card> — G-PORT-2 (#1111) per-digest card. Cloned
@@ -327,7 +328,7 @@ export class WavySearchRailCard extends LitElement {
         aria-current=${this.selected ? "true" : nothing}
       >
         <div class="inner">
-          <div class="avatars" data-digest-avatars aria-label="Authors">
+          <div class="avatars" data-digest-avatars aria-label=${t("searchRail.cardAuthors", "Authors")}>
             ${visible.map(
               (name) =>
                 html`<span class="avatar" data-initials=${this._initials(name)} title=${name}
@@ -335,12 +336,12 @@ export class WavySearchRailCard extends LitElement {
                 >`
             )}
             ${overflow > 0
-              ? html`<span class="avatar more" title="and ${overflow} more">+${overflow}</span>`
+              ? html`<span class="avatar more" title="${t("searchRail.cardAndMorePrefix", "and")} ${overflow} ${t("searchRail.cardMoreSuffix", "more")}">+${overflow}</span>`
               : null}
           </div>
           <div class="info">
             ${this.pinned
-              ? html`<span class="pin" aria-label="Pinned" title="Pinned">📌</span>`
+              ? html`<span class="pin" aria-label=${t("searchRail.cardPinned", "Pinned")} title=${t("searchRail.cardPinned", "Pinned")}>📌</span>`
               : null}
             ${this.postedAtIso
               ? html`<time
@@ -351,14 +352,14 @@ export class WavySearchRailCard extends LitElement {
                   >${this.postedAt || ""}</time
                 >`
               : html`<time class="ts" data-digest-time>${this.postedAt || ""}</time>`}
-            <span class="msgs" data-digest-msg-count aria-label="Message count">
+            <span class="msgs" data-digest-msg-count aria-label=${t("searchRail.cardMessageCount", "Message count")}>
               <span class="msg-total">${this.msgCount}</span>
               ${unread > 0
-                ? html`<span class="badge unread" aria-label="${unread} unread">${unread}</span>`
+                ? html`<span class="badge unread" aria-label="${unread} ${t("searchRail.cardUnread", "unread")}">${unread}</span>`
                 : null}
             </span>
           </div>
-          <h3 class="title" data-digest-title>${this.title || "(no title)"}</h3>
+          <h3 class="title" data-digest-title>${this.title || t("searchRail.cardNoTitle", "(no title)")}</h3>
           <p class="snippet" data-digest-snippet>${this.snippet || ""}</p>
         </div>
       </article>

--- a/j2cl/lit/src/elements/wavy-search-rail.js
+++ b/j2cl/lit/src/elements/wavy-search-rail.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { t } from "../i18n/t.js";
 import {
   SEARCH_RAIL_ICON_REFRESH,
   SEARCH_RAIL_ICON_SORT,
@@ -1125,7 +1126,8 @@ export class WavySearchRail extends LitElement {
           type="search"
           class="query"
           name="q"
-          aria-label="Search waves"
+          aria-label=${t("searchRail.searchWaves", "Search waves")}
+          placeholder=${t("searchRail.placeholder", "Search waves")}
           .value=${this.query}
           @keydown=${this._onQueryKey}
           @input=${this._onQueryInput}
@@ -1133,7 +1135,8 @@ export class WavySearchRail extends LitElement {
         <button
           type="button"
           class="help-trigger"
-          aria-label="Search help"
+          aria-label=${t("searchRail.help", "Search help")}
+          title=${t("searchRail.help", "Search help")}
           aria-haspopup="dialog"
           aria-controls="wavy-search-help"
           @click=${() => this._emit("wavy-search-help-toggle")}
@@ -1142,12 +1145,12 @@ export class WavySearchRail extends LitElement {
         </button>
       </div>
 
-      <div class="action-row" role="group" aria-label="Search actions" data-digest-action-row>
+      <div class="action-row" role="group" aria-label=${t("searchRail.actions", "Search actions")} data-digest-action-row>
         <button
           type="button"
           data-digest-action="refresh"
-          aria-label="Refresh search results"
-          title="Refresh search results"
+          aria-label=${t("searchRail.refresh", "Refresh search results")}
+          title=${t("searchRail.refresh", "Refresh search results")}
           @click=${() => this._emit("wavy-search-refresh-requested")}
         >
           ${SEARCH_RAIL_ICON_REFRESH}
@@ -1156,8 +1159,8 @@ export class WavySearchRail extends LitElement {
           <button
             type="button"
             data-digest-action="sort"
-            aria-label="Sort waves"
-            title="Sort waves"
+            aria-label=${t("searchRail.sort", "Sort waves")}
+            title=${t("searchRail.sort", "Sort waves")}
             aria-haspopup="menu"
             aria-controls="wavy-search-sort-menu"
             aria-expanded=${this.sortOpen ? "true" : "false"}
@@ -1170,7 +1173,7 @@ export class WavySearchRail extends LitElement {
                 class="sort-menu"
                 id="wavy-search-sort-menu"
                 role="menu"
-                aria-label="Sort waves"
+                aria-label=${t("searchRail.sort", "Sort waves")}
                 @keydown=${this._onSortMenuKeydown}
                 @focusout=${this._onSortMenuFocusout}
               >
@@ -1181,6 +1184,8 @@ export class WavySearchRail extends LitElement {
                     role="menuitemradio"
                     aria-checked=${effectiveSort === sort.token.toLowerCase() ? "true" : "false"}
                     data-sort-token=${sort.token}
+                    aria-label=${sort.label}
+                    title=${sort.label}
                     @click=${() => this._applySort(sort)}
                   >
                     <span>${sort.label}</span>
@@ -1193,8 +1198,8 @@ export class WavySearchRail extends LitElement {
         <button
           type="button"
           data-digest-action="filter"
-          aria-label="Filter waves"
-          title="Filter waves"
+          aria-label=${t("searchRail.filter", "Filter waves")}
+          title=${t("searchRail.filter", "Filter waves")}
           aria-pressed=${this.filtersOpen ? "true" : "false"}
           aria-expanded=${this.filtersOpen ? "true" : "false"}
           aria-controls="wavy-search-filter-strip"
@@ -1210,22 +1215,26 @@ export class WavySearchRail extends LitElement {
           class="new-wave"
           data-shortcut="Shift+Cmd+O"
           aria-keyshortcuts="Shift+Meta+O Shift+Control+O"
+          aria-label=${t("searchRail.newWave", "New Wave")}
+          title=${t("searchRail.newWave", "New Wave")}
           @click=${() => this._emit("wavy-new-wave-requested", { source: "button" })}
         >
-          New Wave
+          ${t("searchRail.newWave", "New Wave")}
         </button>
         <button
           type="button"
           class="manage-saved"
           aria-haspopup="dialog"
+          aria-label=${t("searchRail.manageSaved", "Manage saved searches")}
+          title=${t("searchRail.manageSaved", "Manage saved searches")}
           @click=${this._openSavedSearches}
         >
-          Manage saved searches
+          ${t("searchRail.manageSaved", "Manage saved searches")}
         </button>
       </div>
 
       <div class="folders-header">
-        <h2 id="folders-title">Saved searches</h2>
+        <h2 id="folders-title">${t("searchRail.savedSearches", "Saved searches")}</h2>
       </div>
       <ul class="folders" aria-labelledby="folders-title">
         ${WavySearchRail.FOLDERS.map((folder) => {
@@ -1238,20 +1247,22 @@ export class WavySearchRail extends LitElement {
                 data-folder-id=${folder.id}
                 data-query=${folder.query}
                 aria-current=${selected ? "page" : "false"}
+                aria-label=${folder.label}
+                title=${folder.label}
                 @click=${() => this._onFolderClick(folder)}
               >
                 <span class="label">${folder.label}</span>
                 ${folder.id === "mentions"
                   ? html`<span
                       class="dot mentions-dot"
-                      aria-label="${this.mentionsUnread || 0} unread mentions"
+                      aria-label="${this.mentionsUnread || 0} ${t("searchRail.unreadMentions", "unread mentions")}"
                       ?hidden=${!this.mentionsUnread || this.mentionsUnread <= 0}
                     ></span>`
                   : null}
                 ${folder.id === "tasks"
                   ? html`<span
                       class="chip tasks-chip"
-                      aria-label="${this.tasksPending || 0} pending tasks"
+                      aria-label="${this.tasksPending || 0} ${t("searchRail.pendingTasks", "pending tasks")}"
                       ?hidden=${!this.tasksPending || this.tasksPending <= 0}
                       >${this.tasksPending || 0}</span
                     >`
@@ -1263,22 +1274,26 @@ export class WavySearchRail extends LitElement {
       </ul>
       ${pinnedSearches.length > 0
         ? html`
-            <ul class="custom-searches" aria-label="Pinned saved searches">
-              ${pinnedSearches.map((item) => html`
+            <ul class="custom-searches" aria-label=${t("searchRail.pinnedSaved", "Pinned saved searches")}>
+              ${pinnedSearches.map((item) => {
+                const applyLabel = `${t("searchRail.applySavedPrefix", "Apply saved search")} ${item.name} (${item.query})`;
+                return html`
                 <li>
                   <button
                     type="button"
                     class="custom-search"
                     data-saved-search-name=${item.name}
                     data-query=${item.query}
-                    aria-label=${`Apply saved search ${item.name} (${item.query})`}
+                    aria-label=${applyLabel}
+                    title=${applyLabel}
                     @click=${() => this._applySavedSearch(item)}
                   >
                     <span class="custom-name">${item.name}</span>
                     <span class="custom-query">${item.query}</span>
                   </button>
                 </li>
-              `)}
+              `;
+              })}
             </ul>
           `
         : null}
@@ -1293,8 +1308,8 @@ export class WavySearchRail extends LitElement {
           this.filtersOpen = e.target.open;
         }}
       >
-        <summary>Filters</summary>
-        <div class="filter-chips" role="group" aria-label="Search filters">
+        <summary>${t("searchRail.filters", "Filters")}</summary>
+        <div class="filter-chips" role="group" aria-label=${t("searchRail.filtersGroup", "Search filters")}>
           ${WavySearchRail.FILTERS.map((filter) => {
             const active = this._isTokenActive(filter.token);
             return html`
@@ -1304,6 +1319,8 @@ export class WavySearchRail extends LitElement {
                 data-filter-id=${filter.id}
                 data-filter-token=${filter.token}
                 aria-pressed=${active ? "true" : "false"}
+                aria-label=${filter.label}
+                title=${filter.label}
                 @click=${() => this._toggleFilter(filter)}
               >
                 ${filter.label}
@@ -1332,29 +1349,38 @@ export class WavySearchRail extends LitElement {
           @keydown=${this._onSavedDialogKeydown}
         >
           <div class="saved-header">
-            <h3 class="saved-title" id="saved-searches-title">Manage saved searches</h3>
-            <button type="button" class="saved-button" aria-label="Close saved searches" @click=${this._closeSavedSearches}>×</button>
+            <h3 class="saved-title" id="saved-searches-title">${t("searchRail.manageSaved", "Manage saved searches")}</h3>
+            <button
+              type="button"
+              class="saved-button"
+              aria-label=${t("searchRail.closeSaved", "Close saved searches")}
+              title=${t("searchRail.closeSaved", "Close saved searches")}
+              @click=${this._closeSavedSearches}
+            >×</button>
           </div>
           <div class="saved-body">
             ${this.savedSearchesError ? html`<p class="saved-error" role="alert">${this.savedSearchesError}</p>` : null}
             ${this.savedSearchesDirty
-              ? html`<p class="saved-hint" role="status" aria-live="polite">Apply closes this dialog and discards unsaved edits. Use Save to persist them.</p>`
+              ? html`<p class="saved-hint" role="status" aria-live="polite">${t("searchRail.applyDiscardsHint", "Apply closes this dialog and discards unsaved edits. Use Save to persist them.")}</p>`
               : null}
-            ${this.savedSearchesLoading ? html`<p class="saved-empty">Loading saved searches…</p>` : null}
+            ${this.savedSearchesLoading ? html`<p class="saved-empty">${t("searchRail.savedLoading", "Loading saved searches…")}</p>` : null}
             ${!this.savedSearchesLoading && !this.savedSearchesError && this.savedSearchDrafts.length === 0
-              ? html`<p class="saved-empty">No saved searches yet. Add the current query to create one.</p>`
+              ? html`<p class="saved-empty">${t("searchRail.savedEmpty", "No saved searches yet. Add the current query to create one.")}</p>`
               : null}
-            ${this.savedSearchDrafts.map((item, index) => html`
+            ${this.savedSearchDrafts.map((item, index) => {
+              const applyLabel = `${t("searchRail.applyPrefix", "Apply")} ${item.name || item.query || t("searchRail.savedFallback", "saved search")}`;
+              const removeLabel = `${t("searchRail.removePrefix", "Remove")} ${item.name || item.query || t("searchRail.savedFallback", "saved search")}`;
+              return html`
               <div class="saved-row" data-saved-search-row>
                 <input
                   type="text"
-                  aria-label="Saved search name"
+                  aria-label=${t("searchRail.savedName", "Saved search name")}
                   .value=${item.name}
                   @input=${(evt) => this._updateSavedSearch(index, "name", evt.target.value)}
                 />
                 <input
                   type="text"
-                  aria-label="Saved search query"
+                  aria-label=${t("searchRail.savedQuery", "Saved search query")}
                   .value=${item.query}
                   @input=${(evt) => this._updateSavedSearch(index, "query", evt.target.value)}
                 />
@@ -1364,44 +1390,57 @@ export class WavySearchRail extends LitElement {
                     .checked=${item.pinned}
                     @change=${(evt) => this._updateSavedSearch(index, "pinned", evt.target.checked)}
                   />
-                  Pin
+                  ${t("searchRail.pinShort", "Pin")}
                 </label>
                 <button
                   type="button"
                   class="saved-button"
-                  aria-label=${`Apply ${item.name || item.query || "saved search"}`}
+                  aria-label=${applyLabel}
+                  title=${applyLabel}
                   @click=${() => this._applySavedSearch(item)}
                 >
-                  Apply
+                  ${t("searchRail.applyShort", "Apply")}
                 </button>
                 <button
                   type="button"
                   class="saved-button"
-                  aria-label=${`Remove ${item.name || item.query || "saved search"}`}
+                  aria-label=${removeLabel}
+                  title=${removeLabel}
                   @click=${() => this._removeSavedSearch(index)}
                 >
-                  Remove
+                  ${t("common.remove", "Remove")}
                 </button>
               </div>
-            `)}
+              `;
+            })}
           </div>
           <div class="saved-footer">
             <button
               type="button"
               class="saved-button"
+              aria-label=${t("searchRail.addCurrent", "Add current search")}
+              title=${t("searchRail.addCurrent", "Add current search")}
               ?disabled=${this.savedSearchesLoading}
               @click=${this._addCurrentSearch}
             >
-              Add current search
+              ${t("searchRail.addCurrent", "Add current search")}
             </button>
-            <button type="button" class="saved-button" @click=${this._closeSavedSearches}>Cancel</button>
+            <button
+              type="button"
+              class="saved-button"
+              aria-label=${t("common.cancel", "Cancel")}
+              title=${t("common.cancel", "Cancel")}
+              @click=${this._closeSavedSearches}
+            >${t("common.cancel", "Cancel")}</button>
             <button
               type="button"
               class="saved-button primary"
+              aria-label=${t("common.save", "Save")}
+              title=${t("common.save", "Save")}
               ?disabled=${this.savedSearchesLoading}
               @click=${this._saveAndClose}
             >
-              Save
+              ${t("common.save", "Save")}
             </button>
           </div>
         </section>

--- a/j2cl/lit/src/elements/wavy-tags-row.js
+++ b/j2cl/lit/src/elements/wavy-tags-row.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { t } from "../i18n/t.js";
 
 /**
  * <wavy-tags-row> — F-3.S1 (#1038, R-5.1 tags) wave-tag editing affordances.
@@ -153,18 +154,22 @@ export class WavyTagsRow extends LitElement {
   render() {
     const tags = Array.isArray(this.tags) ? this.tags : [];
     return html`
-      <span class="label">Tags:</span>
+      <span class="label">${t("tagsRow.tagsLabel", "Tags:")}</span>
       ${tags.map(
-        (tag) => html`<span class="chip" data-tag-chip=${tag}>
-          ${tag}
-          <button
-            type="button"
-            class="chip-remove"
-            data-tag-remove=${tag}
-            aria-label=${`Remove tag ${tag}`}
-            @click=${this._onRemoveClick(tag)}
-          >×</button>
-        </span>`
+        (tag) => {
+          const removeLabel = `${t("tagsRow.removePrefix", "Remove tag")} ${tag}`;
+          return html`<span class="chip" data-tag-chip=${tag}>
+            ${tag}
+            <button
+              type="button"
+              class="chip-remove"
+              data-tag-remove=${tag}
+              aria-label=${removeLabel}
+              title=${removeLabel}
+              @click=${this._onRemoveClick(tag)}
+            >×</button>
+          </span>`;
+        }
       )}
       ${this.editing
         ? html`
@@ -172,15 +177,16 @@ export class WavyTagsRow extends LitElement {
               type="text"
               class="input"
               data-tags-input
-              placeholder="Add tag"
-              aria-label="Add tag"
+              placeholder=${t("tagsRow.placeholder", "Add tag")}
+              aria-label=${t("tagsRow.add", "Add tag")}
               @keydown=${this._onInputKeydown}
             />
             <button
               type="button"
               class="cancel-button"
               data-tags-cancel
-              aria-label="Cancel tag entry"
+              aria-label=${t("tagsRow.cancel", "Cancel tag entry")}
+              title=${t("tagsRow.cancel", "Cancel tag entry")}
               @click=${this._onCancelClick}
             >×</button>
           `
@@ -189,9 +195,10 @@ export class WavyTagsRow extends LitElement {
               type="button"
               class="add-button"
               data-tags-add
-              aria-label="Add tag"
+              aria-label=${t("tagsRow.add", "Add tag")}
+              title=${t("tagsRow.add", "Add tag")}
               @click=${this._onAddClick}
-            >+ Add tag</button>
+            >+ ${t("tagsRow.add", "Add tag")}</button>
           `}
     `;
   }

--- a/j2cl/lit/src/elements/wavy-task-affordance.js
+++ b/j2cl/lit/src/elements/wavy-task-affordance.js
@@ -1,5 +1,6 @@
 import { LitElement, css, html } from "lit";
 import "./task-metadata-popover.js";
+import { t } from "../i18n/t.js";
 
 /**
  * <wavy-task-affordance> — F-3.S2 (#1038, R-5.4) per-blip task toggle
@@ -140,9 +141,9 @@ export class WavyTaskAffordance extends LitElement {
     this._popoverOpen = false;
     this.labelToggleOpen = "☐";
     this.labelToggleDone = "☑";
-    this.labelAriaCheck = "Mark task complete";
-    this.labelAriaUncheck = "Mark task open";
-    this.labelDetails = "Edit task details";
+    this.labelAriaCheck = t("taskAffordance.markComplete", "Mark task complete");
+    this.labelAriaUncheck = t("taskAffordance.markIncomplete", "Mark task open");
+    this.labelDetails = t("taskAffordance.editDetails", "Edit task details");
     this.labelAnnounceDone = "Task completed";
     this.labelAnnounceOpen = "Task reopened";
   }

--- a/j2cl/lit/src/elements/wavy-task-affordance.js
+++ b/j2cl/lit/src/elements/wavy-task-affordance.js
@@ -141,9 +141,9 @@ export class WavyTaskAffordance extends LitElement {
     this._popoverOpen = false;
     this.labelToggleOpen = "☐";
     this.labelToggleDone = "☑";
-    this.labelAriaCheck = t("taskAffordance.markComplete", "Mark task complete");
-    this.labelAriaUncheck = t("taskAffordance.markIncomplete", "Mark task open");
-    this.labelDetails = t("taskAffordance.editDetails", "Edit task details");
+    this.labelAriaCheck = "";
+    this.labelAriaUncheck = "";
+    this.labelDetails = "";
     this.labelAnnounceDone = "Task completed";
     this.labelAnnounceOpen = "Task reopened";
   }
@@ -232,14 +232,17 @@ export class WavyTaskAffordance extends LitElement {
   };
 
   render() {
+    const labelAriaCheck = this.labelAriaCheck || t("taskAffordance.markComplete", "Mark task complete");
+    const labelAriaUncheck = this.labelAriaUncheck || t("taskAffordance.markIncomplete", "Mark task open");
+    const labelDetails = this.labelDetails || t("taskAffordance.editDetails", "Edit task details");
     return html`
       <button
         type="button"
         data-task-toggle-trigger="true"
         role="checkbox"
         aria-checked=${this.completed ? "true" : "false"}
-        aria-label=${this.completed ? this.labelAriaUncheck : this.labelAriaCheck}
-        title=${this.completed ? this.labelAriaUncheck : this.labelAriaCheck}
+        aria-label=${this.completed ? labelAriaUncheck : labelAriaCheck}
+        title=${this.completed ? labelAriaUncheck : labelAriaCheck}
         @click=${this._toggle}
       >
         ${this.completed ? this.labelToggleDone : this.labelToggleOpen}
@@ -247,8 +250,8 @@ export class WavyTaskAffordance extends LitElement {
       <button
         type="button"
         data-task-details-trigger="true"
-        aria-label=${this.labelDetails}
-        title=${this.labelDetails}
+        aria-label=${labelDetails}
+        title=${labelDetails}
         aria-haspopup="dialog"
         aria-expanded=${this._popoverOpen ? "true" : "false"}
         @click=${this._openDetails}

--- a/j2cl/lit/src/elements/wavy-version-history.js
+++ b/j2cl/lit/src/elements/wavy-version-history.js
@@ -616,8 +616,8 @@ export class WavyVersionHistory extends LitElement {
     const version = snapshot.version == null ? "selected" : snapshot.version;
     return html`
       <section class="snapshot-preview" aria-label=${t("versionHistory.preview", "Read-only version preview")}>
-        <h3>Version ${version}</h3>
-        <p>${participants} participants · ${docs.length} documents</p>
+        <h3>${t("versionHistory.version", "Version")} ${version}</h3>
+        <p>${participants} ${t("versionHistory.participants", "participants")} · ${docs.length} ${t("versionHistory.documents", "documents")}</p>
         <ul class="snapshot-documents">
           ${docs.slice(0, 5).map((doc) => html`
             <li>

--- a/j2cl/lit/src/elements/wavy-version-history.js
+++ b/j2cl/lit/src/elements/wavy-version-history.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { t } from "../i18n/t.js";
 
 /**
  * <wavy-version-history> — F-2.S4 (#1048, K.1–K.6) full-bleed version
@@ -304,7 +305,7 @@ export class WavyVersionHistory extends LitElement {
       this.removeAttribute("hidden");
       this.setAttribute("role", "dialog");
       this.setAttribute("aria-modal", "true");
-      this.setAttribute("aria-label", "Version history");
+      this.setAttribute("aria-label", t("versionHistory.title", "Version history"));
       this.removeAttribute("aria-hidden");
       // Make the host focusable so Escape delivered via real keyboard
       // (not synthetic dispatch) reaches the host's keydown handler.
@@ -499,8 +500,15 @@ export class WavyVersionHistory extends LitElement {
     const max = versions.length > 0 ? versions.length - 1 : 0;
     const idx = Math.min(Math.max(this.value || 0, 0), max);
     const current = versions[idx] || null;
-    const restoreLabel = current ? `Restore version ${current.label}` : "Restore version";
-    const statusText = this.error || (this.loading ? "Loading…" : "");
+    const restoreLabel = current
+      ? `${t("versionHistory.restorePrefix", "Restore version")} ${current.label}`
+      : t("versionHistory.restore", "Restore version");
+    const statusText = this.error || (this.loading ? t("versionHistory.loading", "Loading…") : "");
+    const exitLabel = t("versionHistory.exit", "Exit version history");
+    const showChangesLabel = t("versionHistory.showChanges", "Show changes");
+    const textOnlyLabel = t("versionHistory.textOnly", "Text only");
+    const restoreShort = t("versionHistory.restoreShort", "Restore");
+    const cancelLabel = t("common.cancel", "Cancel");
 
     return html`
       <div class="backdrop" @click=${this._onExitClick}></div>
@@ -508,12 +516,13 @@ export class WavyVersionHistory extends LitElement {
         <button
           class="exit"
           type="button"
-          aria-label="Exit version history"
+          aria-label=${exitLabel}
+          title=${exitLabel}
           @click=${this._onExitClick}
         >
           <span aria-hidden="true">×</span>
         </button>
-        <h2>Version history</h2>
+        <h2>${t("versionHistory.title", "Version history")}</h2>
         ${statusText
           ? html`<p
               class="history-status"
@@ -521,7 +530,9 @@ export class WavyVersionHistory extends LitElement {
             >${statusText}</p>`
           : null}
         <p class="current-version-label">
-          ${current ? `Current preview: ${current.label}` : "No versions loaded yet"}
+          ${current
+            ? `${t("versionHistory.currentPreviewPrefix", "Current preview:")} ${current.label}`
+            : t("versionHistory.empty", "No versions loaded yet")}
         </p>
         <div class="slider-row">
           <input
@@ -529,7 +540,7 @@ export class WavyVersionHistory extends LitElement {
             min="0"
             max=${String(max)}
             .value=${String(idx)}
-            aria-label="Version history time slider"
+            aria-label=${t("versionHistory.slider", "Version history time slider")}
             aria-valuemin="0"
             aria-valuemax=${String(max)}
             aria-valuenow=${String(idx)}
@@ -540,13 +551,17 @@ export class WavyVersionHistory extends LitElement {
           <button
             type="button"
             aria-pressed=${this.showChanges ? "true" : "false"}
+            aria-label=${showChangesLabel}
+            title=${showChangesLabel}
             @click=${this._onShowChangesClick}
-          >Show changes</button>
+          >${showChangesLabel}</button>
           <button
             type="button"
             aria-pressed=${this.textOnly ? "true" : "false"}
+            aria-label=${textOnlyLabel}
+            title=${textOnlyLabel}
             @click=${this._onTextOnlyClick}
-          >Text only</button>
+          >${textOnlyLabel}</button>
         </div>
         ${this._renderSnapshotPreview()}
         <div class="actions">
@@ -555,20 +570,36 @@ export class WavyVersionHistory extends LitElement {
             type="button"
             ?disabled=${!this.restoreEnabled}
             aria-disabled=${this.restoreEnabled ? "false" : "true"}
+            aria-label=${restoreShort}
+            title=${restoreShort}
             @click=${this._onRestoreClick}
-          >Restore</button>
+          >${restoreShort}</button>
           ${this.restoreEnabled
             ? null
-            : html`<span class="restore-hint">Preview only — restore not available</span>`}
+            : html`<span class="restore-hint">${t(
+                "versionHistory.previewOnly",
+                "Preview only — restore not available"
+              )}</span>`}
           ${this.restoreStatus
             ? html`<span class="restore-status" role="status">${this.restoreStatus}</span>`
             : null}
         </div>
         <dialog class="confirm">
-          <p>${restoreLabel}? This rewrites the wave to this point.</p>
+          <p>${restoreLabel}? ${t("versionHistory.confirmExplanation", "This rewrites the wave to this point.")}</p>
           <div class="confirm-actions">
-            <button type="button" @click=${this._onCancelRestore}>Cancel</button>
-            <button class="confirm-restore" type="button" @click=${this._onConfirmRestore}>Restore</button>
+            <button
+              type="button"
+              aria-label=${cancelLabel}
+              title=${cancelLabel}
+              @click=${this._onCancelRestore}
+            >${cancelLabel}</button>
+            <button
+              class="confirm-restore"
+              type="button"
+              aria-label=${restoreShort}
+              title=${restoreShort}
+              @click=${this._onConfirmRestore}
+            >${restoreShort}</button>
           </div>
         </dialog>
       </div>
@@ -584,7 +615,7 @@ export class WavyVersionHistory extends LitElement {
       : 0;
     const version = snapshot.version == null ? "selected" : snapshot.version;
     return html`
-      <section class="snapshot-preview" aria-label="Read-only version preview">
+      <section class="snapshot-preview" aria-label=${t("versionHistory.preview", "Read-only version preview")}>
         <h3>Version ${version}</h3>
         <p>${participants} participants · ${docs.length} documents</p>
         <ul class="snapshot-documents">

--- a/j2cl/lit/src/elements/wavy-wave-controls-toggle.js
+++ b/j2cl/lit/src/elements/wavy-wave-controls-toggle.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { t } from "../i18n/t.js";
 
 /**
  * <wavy-wave-controls-toggle> — F-2.S4 (#1048, J.3) toggle button that
@@ -104,12 +105,15 @@ export class WavyWaveControlsToggle extends LitElement {
     // (Enter / Space). The host carries no role/tabindex so AT does
     // not announce a nested-button antipattern; the toggle's
     // pressed/label state lives on the inner button.
-    const label = this.pressed ? "Show wave controls" : "Hide wave controls";
+    const label = this.pressed
+      ? t("waveControls.open", "Show wave controls")
+      : t("waveControls.close", "Hide wave controls");
     return html`
       <button
         type="button"
         aria-pressed=${this.pressed ? "true" : "false"}
         aria-label=${label}
+        title=${label}
         @click=${this._onClick}
       >
         ${this.pressed ? this._showIcon() : this._hideIcon()}

--- a/j2cl/lit/src/elements/wavy-wave-header-actions.js
+++ b/j2cl/lit/src/elements/wavy-wave-header-actions.js
@@ -1,5 +1,7 @@
 import { LitElement, css, html, svg } from "lit";
 import { ensureWavyConfirmDialogMounted } from "./wavy-confirm-dialog.js";
+import { subscribe } from "../i18n/locale.js";
+import { t } from "../i18n/t.js";
 
 const LOCK_CYCLE = {
   unlocked: "root",
@@ -299,16 +301,22 @@ export class WavyWaveHeaderActions extends LitElement {
     this._contactsLoading = false;
     this._pendingConfirm = null;
     this._onConfirmResolved = this._onConfirmResolved.bind(this);
+    this._unsubscribeLocale = null;
   }
 
   connectedCallback() {
     super.connectedCallback();
     document.body.addEventListener("wavy-confirm-resolved", this._onConfirmResolved);
+    this._unsubscribeLocale = subscribe(() => this.requestUpdate());
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     document.body.removeEventListener("wavy-confirm-resolved", this._onConfirmResolved);
+    if (this._unsubscribeLocale) {
+      this._unsubscribeLocale();
+      this._unsubscribeLocale = null;
+    }
   }
 
   willUpdate(changedProperties) {
@@ -325,49 +333,64 @@ export class WavyWaveHeaderActions extends LitElement {
   render() {
     const unavailable = this._unavailable();
     const lockState = normalizeLockState(this.lockState);
+    const addLabel = t("waveActions.addParticipant", "Add participant");
+    const newLabel = t("waveActions.newWithParticipants", "New wave with current participants");
+    const newShort = t("waveActions.newWithParticipantsShort", "New with participants");
+    const publicityLabel = this.public
+      ? t("waveActions.makePrivate", "Make wave private")
+      : t("waveActions.makePublic", "Make wave public");
+    const publicityState = this.public
+      ? t("waveActions.public", "Public")
+      : t("waveActions.private", "Private");
+    const lockLabel = this._lockLabel(lockState);
+    const lockText = this._lockText(lockState);
     return html`
-      <div class="row" role="toolbar" aria-label="Wave header actions">
+      <div class="row" role="toolbar" aria-label=${t("waveActions.toolbarLabel", "Wave header actions")}>
         <button
           type="button"
           data-action="add-participant"
-          aria-label="Add participant"
+          aria-label=${addLabel}
+          title=${addLabel}
           ?disabled=${unavailable}
           @click=${this._openAddParticipant}
         >
           ${actionIcon("addParticipant")}
-          <span class="action-label">Add participant</span>
+          <span class="action-label">${addLabel}</span>
         </button>
         <button
           type="button"
           data-action="new-with-participants"
-          aria-label="New wave with current participants"
+          aria-label=${newLabel}
+          title=${newLabel}
           ?disabled=${unavailable}
           @click=${this._newWithParticipants}
         >
           ${actionIcon("newWave")}
-          <span class="action-label">New with participants</span>
+          <span class="action-label">${newShort}</span>
         </button>
         <button
           type="button"
           data-action="publicity-toggle"
-          aria-label=${this.public ? "Make wave private" : "Make wave public"}
+          aria-label=${publicityLabel}
+          title=${publicityLabel}
           aria-pressed=${this.public ? "true" : "false"}
           ?disabled=${unavailable}
           @click=${this._confirmPublicityToggle}
         >
           ${actionIcon("public")}
-          <span class="action-label">${this.public ? "Public" : "Private"}</span>
+          <span class="action-label">${publicityState}</span>
         </button>
         <button
           type="button"
           data-action="lock-toggle"
           data-lock-state=${lockState}
-          aria-label=${this._lockLabel(lockState)}
+          aria-label=${lockLabel}
+          title=${lockLabel}
           ?disabled=${unavailable}
           @click=${this._confirmLockToggle}
         >
           ${actionIcon("lock")}
-          <span class="action-label">${this._lockText(lockState)}</span>
+          <span class="action-label">${lockText}</span>
         </button>
       </div>
       ${this._addDialogOpen ? this._renderAddParticipantDialog() : ""}
@@ -375,14 +398,19 @@ export class WavyWaveHeaderActions extends LitElement {
   }
 
   _renderAddParticipantDialog() {
+    const cancelLabel = t("waveActions.cancel", "Cancel");
+    const addLabel = t("waveActions.add", "Add");
     return html`
       <form class="add-popover" @submit=${this._submitAddParticipant}>
         <label>
-          Participant addresses
+          ${t("waveActions.participantAddresses", "Participant addresses")}
           <input
             name="participant-addresses"
             autocomplete="off"
-            placeholder="alice@example.com, bob@example.com"
+            placeholder=${t(
+              "waveActions.participantPlaceholder",
+              "alice@example.com, bob@example.com"
+            )}
             .value=${this._participantDraft}
             @input=${this._onParticipantDraftInput}
           />
@@ -392,16 +420,20 @@ export class WavyWaveHeaderActions extends LitElement {
           <button
             type="button"
             data-action="add-participant-cancel"
+            aria-label=${cancelLabel}
+            title=${cancelLabel}
             @click=${this._closeAddParticipant}
           >
-            Cancel
+            ${cancelLabel}
           </button>
           <button
             type="submit"
             data-action="add-participant-submit"
+            aria-label=${addLabel}
+            title=${addLabel}
             ?disabled=${this._addParticipantAddresses().length === 0}
           >
-            Add
+            ${addLabel}
           </button>
         </div>
       </form>
@@ -430,20 +462,26 @@ export class WavyWaveHeaderActions extends LitElement {
   _renderContactSuggestions() {
     const suggestions = this._availableContactSuggestions();
     if (this._contactsLoading) {
-      return html`<div class="suggestions" aria-live="polite">Loading frequent contacts...</div>`;
+      return html`<div class="suggestions" aria-live="polite">${t(
+        "waveActions.loadingFrequentContacts",
+        "Loading frequent contacts..."
+      )}</div>`;
     }
     if (suggestions.length === 0) {
       return "";
     }
+    const frequent = t("waveActions.frequentContacts", "Frequent contacts");
     return html`
-      <div class="suggestions" aria-label="Frequent contacts">
-        <span class="suggestions-label">Frequent contacts</span>
+      <div class="suggestions" aria-label=${frequent}>
+        <span class="suggestions-label">${frequent}</span>
         ${suggestions.map(
           (address) => html`
             <button
               type="button"
               class="suggestion"
               data-contact-suggestion=${address}
+              aria-label=${`${t("waveActions.addContactPrefix", "Add")} ${address}`}
+              title=${`${t("waveActions.addContactPrefix", "Add")} ${address}`}
               @click=${() => this._appendSuggestedParticipant(address)}
             >
               ${address}
@@ -545,8 +583,12 @@ export class WavyWaveHeaderActions extends LitElement {
     const nextPublic = !currentlyPublic;
     this._requestConfirmation(
       "publicity",
-      currentlyPublic ? "Make this wave private?" : "Make this wave public?",
-      currentlyPublic ? "Make private" : "Make public",
+      currentlyPublic
+        ? t("waveActions.confirmPrivate", "Make this wave private?")
+        : t("waveActions.confirmPublic", "Make this wave public?"),
+      currentlyPublic
+        ? t("waveActions.confirmLabelMakePrivate", "Make private")
+        : t("waveActions.confirmLabelMakePublic", "Make public"),
       "wave-publicity-toggle-requested",
       { currentlyPublic, nextPublic }
     );
@@ -584,7 +626,7 @@ export class WavyWaveHeaderActions extends LitElement {
           requestId,
           message,
           confirmLabel,
-          cancelLabel: "Cancel",
+          cancelLabel: t("waveActions.cancel", "Cancel"),
           tone: kind === "lock" || detail.nextPublic === false ? "destructive" : "default"
         }
       })
@@ -613,27 +655,27 @@ export class WavyWaveHeaderActions extends LitElement {
   }
 
   _lockLabel(lockState) {
-    if (lockState === "root") return "Lock full wave";
-    if (lockState === "all") return "Unlock wave";
-    return "Lock root blip";
+    if (lockState === "root") return t("waveActions.lockFull", "Lock full wave");
+    if (lockState === "all") return t("waveActions.unlock", "Unlock wave");
+    return t("waveActions.lockRoot", "Lock root blip");
   }
 
   _lockText(lockState) {
-    if (lockState === "root") return "Root locked";
-    if (lockState === "all") return "Wave locked";
-    return "Unlocked";
+    if (lockState === "root") return t("waveActions.lockedRoot", "Root locked");
+    if (lockState === "all") return t("waveActions.lockedAll", "Wave locked");
+    return t("waveActions.unlocked", "Unlocked");
   }
 
   _lockConfirmLabel(nextLockState) {
-    if (nextLockState === "root") return "Lock root";
-    if (nextLockState === "all") return "Lock all";
-    return "Unlock";
+    if (nextLockState === "root") return t("waveActions.confirmLabelLockRoot", "Lock root");
+    if (nextLockState === "all") return t("waveActions.confirmLabelLockAll", "Lock all");
+    return t("waveActions.confirmLabelUnlock", "Unlock");
   }
 
   _lockConfirmMessage(currentLockState, nextLockState) {
-    if (nextLockState === "root") return "Lock the root blip?";
-    if (nextLockState === "all") return "Lock the full wave?";
-    return `Unlock this wave from ${currentLockState} lock?`;
+    if (nextLockState === "root") return t("waveActions.confirmLockRoot", "Lock the root blip?");
+    if (nextLockState === "all") return t("waveActions.confirmLockAll", "Lock the full wave?");
+    return t("waveActions.confirmUnlock", "Unlock this wave?");
   }
 }
 

--- a/j2cl/lit/src/elements/wavy-wave-nav-row.js
+++ b/j2cl/lit/src/elements/wavy-wave-nav-row.js
@@ -384,7 +384,7 @@ export class WavyWaveNavRow extends LitElement {
           data-action="version-history"
           aria-label=${t("waveNav.versionHistoryShortcut", "Open version history (h)")}
           aria-keyshortcuts="h H"
-          title=${t("waveNav.versionHistory", "Open version history")}
+          title=${t("waveNav.versionHistoryShortcut", "Open version history (h)")}
           @click=${this._onClick("version-history")}
         >
           ${getWaveActionIcon("version-history")}
@@ -397,7 +397,7 @@ export class WavyWaveNavRow extends LitElement {
           aria-haspopup="menu"
           aria-expanded=${this._overflowOpen ? "true" : "false"}
           aria-label=${t("waveNav.overflow", "More wave navigation actions")}
-          title=${t("toolbar.overflowMenu", "More actions")}
+          title=${t("waveNav.overflow", "More wave navigation actions")}
           @click=${this._onOverflowToggle}
         >
           <span aria-hidden="true">⋯</span>

--- a/j2cl/lit/src/elements/wavy-wave-nav-row.js
+++ b/j2cl/lit/src/elements/wavy-wave-nav-row.js
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from "lit";
 import { getWaveActionIcon } from "../icons/wave-action-bar-icons.js";
 import { isEditableTarget } from "../shortcuts/keybindings.js";
+import { t } from "../i18n/t.js";
 
 /**
  * <wavy-wave-nav-row> — F-2 (#1037, R-3.4; slice 2 #1046) wave-level nav
@@ -265,11 +266,13 @@ export class WavyWaveNavRow extends LitElement {
   }
 
   _pinAriaLabel() {
-    return this.pinned ? "Unpin wave" : "Pin wave";
+    return this.pinned ? t("waveNav.unpin", "Unpin wave") : t("waveNav.pin", "Pin wave");
   }
 
   _archiveAriaLabel() {
-    return this.archived ? "Restore from archive" : "Move wave to archive";
+    return this.archived
+      ? t("waveNav.unarchive", "Restore from archive")
+      : t("waveNav.archive", "Move wave to archive");
   }
 
   _nextUnreadEmphasis() {
@@ -288,12 +291,12 @@ export class WavyWaveNavRow extends LitElement {
     const archiveLabel = this._archiveAriaLabel();
     const pinLabel = this._pinAriaLabel();
     return html`
-      <nav aria-label="Wave navigation">
+      <nav aria-label=${t("waveNav.label", "Wave navigation")}>
         <button
           type="button"
           data-action="recent"
-          aria-label="Jump to recent activity"
-          title="Jump to recent activity"
+          aria-label=${t("waveNav.recent", "Jump to recent activity")}
+          title=${t("waveNav.recent", "Jump to recent activity")}
           @click=${this._onClick("recent")}
         >
           ${getWaveActionIcon("recent")}
@@ -302,8 +305,8 @@ export class WavyWaveNavRow extends LitElement {
           type="button"
           data-action="next-unread"
           data-emphasis=${this._nextUnreadEmphasis()}
-          aria-label="Jump to next unread blip"
-          title="Jump to next unread blip"
+          aria-label=${t("waveNav.nextUnread", "Jump to next unread blip")}
+          title=${t("waveNav.nextUnread", "Jump to next unread blip")}
           @click=${this._onClick("next-unread")}
         >
           ${getWaveActionIcon("next-unread")}
@@ -311,8 +314,8 @@ export class WavyWaveNavRow extends LitElement {
         <button
           type="button"
           data-action="previous"
-          aria-label="Jump to previous blip"
-          title="Jump to previous blip"
+          aria-label=${t("waveNav.previous", "Jump to previous blip")}
+          title=${t("waveNav.previous", "Jump to previous blip")}
           @click=${this._onClick("previous")}
         >
           ${getWaveActionIcon("previous")}
@@ -320,8 +323,8 @@ export class WavyWaveNavRow extends LitElement {
         <button
           type="button"
           data-action="next"
-          aria-label="Jump to next blip"
-          title="Jump to next blip"
+          aria-label=${t("waveNav.next", "Jump to next blip")}
+          title=${t("waveNav.next", "Jump to next blip")}
           @click=${this._onClick("next")}
         >
           ${getWaveActionIcon("next")}
@@ -329,8 +332,8 @@ export class WavyWaveNavRow extends LitElement {
         <button
           type="button"
           data-action="end"
-          aria-label="Jump to last blip"
-          title="Jump to last blip"
+          aria-label=${t("waveNav.end", "Jump to last blip")}
+          title=${t("waveNav.end", "Jump to last blip")}
           @click=${this._onClick("end")}
         >
           ${getWaveActionIcon("end")}
@@ -339,8 +342,8 @@ export class WavyWaveNavRow extends LitElement {
           type="button"
           data-action="prev-mention"
           data-emphasis=${this._mentionEmphasis()}
-          aria-label="Jump to previous mention"
-          title="Jump to previous mention"
+          aria-label=${t("waveNav.prevMention", "Jump to previous mention")}
+          title=${t("waveNav.prevMention", "Jump to previous mention")}
           @click=${this._onClick("prev-mention")}
         >
           ${getWaveActionIcon("prev-mention")}
@@ -349,8 +352,8 @@ export class WavyWaveNavRow extends LitElement {
           type="button"
           data-action="next-mention"
           data-emphasis=${this._mentionEmphasis()}
-          aria-label="Jump to next mention"
-          title="Jump to next mention"
+          aria-label=${t("waveNav.nextMention", "Jump to next mention")}
+          title=${t("waveNav.nextMention", "Jump to next mention")}
           @click=${this._onClick("next-mention")}
         >
           ${getWaveActionIcon("next-mention")}
@@ -379,9 +382,9 @@ export class WavyWaveNavRow extends LitElement {
         <button
           type="button"
           data-action="version-history"
-          aria-label="Open version history (h)"
+          aria-label=${t("waveNav.versionHistoryShortcut", "Open version history (h)")}
           aria-keyshortcuts="h H"
-          title="Open version history"
+          title=${t("waveNav.versionHistory", "Open version history")}
           @click=${this._onClick("version-history")}
         >
           ${getWaveActionIcon("version-history")}
@@ -393,8 +396,8 @@ export class WavyWaveNavRow extends LitElement {
           data-action="overflow"
           aria-haspopup="menu"
           aria-expanded=${this._overflowOpen ? "true" : "false"}
-          aria-label="More wave navigation actions"
-          title="More actions"
+          aria-label=${t("waveNav.overflow", "More wave navigation actions")}
+          title=${t("toolbar.overflowMenu", "More actions")}
           @click=${this._onOverflowToggle}
         >
           <span aria-hidden="true">⋯</span>
@@ -410,8 +413,8 @@ export class WavyWaveNavRow extends LitElement {
               role="menuitem"
               data-action="prev-mention"
               data-overflow="true"
-              aria-label="Jump to previous mention"
-              title="Jump to previous mention"
+              aria-label=${t("waveNav.prevMention", "Jump to previous mention")}
+              title=${t("waveNav.prevMention", "Jump to previous mention")}
               @click=${this._onClick("prev-mention")}
             >
               ${getWaveActionIcon("prev-mention")}
@@ -423,8 +426,8 @@ export class WavyWaveNavRow extends LitElement {
               role="menuitem"
               data-action="next-mention"
               data-overflow="true"
-              aria-label="Jump to next mention"
-              title="Jump to next mention"
+              aria-label=${t("waveNav.nextMention", "Jump to next mention")}
+              title=${t("waveNav.nextMention", "Jump to next mention")}
               @click=${this._onClick("next-mention")}
             >
               ${getWaveActionIcon("next-mention")}
@@ -436,8 +439,8 @@ export class WavyWaveNavRow extends LitElement {
               role="menuitem"
               data-action="version-history"
               data-overflow="true"
-              aria-label="Open version history (h)"
-              title="Open version history"
+              aria-label=${t("waveNav.versionHistoryShortcut", "Open version history (h)")}
+              title=${t("waveNav.versionHistory", "Open version history")}
               @click=${this._onClick("version-history")}
             >
               ${getWaveActionIcon("version-history")}

--- a/j2cl/lit/src/elements/wavy-wave-root-reply-trigger.js
+++ b/j2cl/lit/src/elements/wavy-wave-root-reply-trigger.js
@@ -1,4 +1,5 @@
 import { LitElement, css, html } from "lit";
+import { t } from "../i18n/t.js";
 
 /**
  * <wavy-wave-root-reply-trigger> — F-3.S1 (#1038, R-5.1 step 5) compact
@@ -75,8 +76,8 @@ export class WavyWaveRootReplyTrigger extends LitElement {
       <button
         type="button"
         data-wave-root-reply-trigger
-        aria-label="Reply to the wave"
-        title="Reply to the wave"
+        aria-label=${t("rootReply.aria", "Reply to the wave")}
+        title=${t("rootReply.aria", "Reply to the wave")}
         @click=${this._onClick}
       >
         +

--- a/j2cl/lit/src/i18n/README.md
+++ b/j2cl/lit/src/i18n/README.md
@@ -38,7 +38,7 @@ Add those when a real translator workflow lands.
 
 Per-source-file namespaces, lowerCamel keys:
 
-```
+```text
 waveActions.addParticipant        // wavy-wave-header-actions.js
 formatToolbar.bold                // wavy-format-toolbar.js
 searchRail.refresh                // wavy-search-rail.js
@@ -66,8 +66,8 @@ keep accidental `undefined` strings out of the UI.
 `getLocale()` resolves once, in this order:
 
 1. `window.__bootstrap.session.locale` — the canonical server-supplied
-   value, set by `J2clBootstrapServlet#getSessionJson` from the user's
-   `HumanAccountData#getLocale()`.
+   value, written by `WaveClientServlet.buildSessionJson(...)` from the
+   user's `HumanAccountData#getLocale()`.
 2. `<html lang>` — keeps SSR-only previews sensible.
 3. `"en"`.
 

--- a/j2cl/lit/src/i18n/README.md
+++ b/j2cl/lit/src/i18n/README.md
@@ -1,0 +1,115 @@
+# J2CL Lit shell — i18n
+
+Lightweight i18n for the SupaWave J2CL Lit shell. Built for the
+"objective-dewdney" PR (issue under tracking) to:
+
+- Restore tooltip parity with the GWT side (every `<button>` carries
+  both `aria-label` and `title`, audited at build time).
+- Surface the user's preferred locale through a single primitive so
+  wave-panel chrome localizes without ad-hoc per-component plumbing.
+
+This is intentionally pre-MVP — no plurals, no ICU, no Intl.MessageFormat.
+Add those when a real translator workflow lands.
+
+## Files
+
+| File                       | Role                                                                        |
+| -------------------------- | --------------------------------------------------------------------------- |
+| `locale.js`                | Reads `window.__bootstrap.session.locale`, normalizes, broadcasts changes.  |
+| `t.js`                     | `t(key, fallback)` — looks up active → `en` → caller-supplied fallback.     |
+| `catalog.js`               | Imports the per-locale catalog modules and exposes `lookup`/`hasLocale`.    |
+| `button.js`                | `localizedButton({key, fallback})` — same-string `aria-label` + `title`.    |
+| `catalogs/<code>.js`       | Per-locale string table. Plain ES module exporting `{ <code>: {...} }`.    |
+
+## Adding a locale
+
+1. Drop `catalogs/xx.js` next to the existing catalogs, exporting
+   `export const xx = { ... }` with the same keys.
+2. `import { xx } from "./catalogs/xx.js";` in `catalog.js` and add
+   it to `CATALOGS`.
+3. Add the locale to `WavyHeader.LOCALES` in
+   `../elements/wavy-header.js` (label + ISO code, including any
+   `_REGION` qualifier).
+4. Add the same code to `SUPPORTED_LOCALES` in `locale.js`.
+5. Run `npm --prefix j2cl/lit run audit:buttons` and `... test` to
+   ensure no regressions.
+
+## Key naming
+
+Per-source-file namespaces, lowerCamel keys:
+
+```
+waveActions.addParticipant        // wavy-wave-header-actions.js
+formatToolbar.bold                // wavy-format-toolbar.js
+searchRail.refresh                // wavy-search-rail.js
+common.cancel                     // shared
+```
+
+The `common.*` namespace covers strings used by ≥ 2 elements (Cancel,
+Save, etc.).
+
+## Lookup chain
+
+`t(key, fallback)` returns:
+
+1. `catalogs[<active>][key]` if present.
+2. `catalogs.en[key]` if present (so a German catalog with a missing
+   key still renders English instead of `undefined`).
+3. The `fallback` argument (so a key absent from every catalog still
+   renders the source-of-truth English the developer wrote inline).
+
+The fallback is a required argument — `t()` throws when omitted to
+keep accidental `undefined` strings out of the UI.
+
+## Active locale
+
+`getLocale()` resolves once, in this order:
+
+1. `window.__bootstrap.session.locale` — the canonical server-supplied
+   value, set by `J2clBootstrapServlet#getSessionJson` from the user's
+   `HumanAccountData#getLocale()`.
+2. `<html lang>` — keeps SSR-only previews sensible.
+3. `"en"`.
+
+`SUPPORTED_LOCALES` (en/de/es/fr/ru/sl/zh_TW) mirrors the GWT locale
+set. Anything unknown silently falls through to step 2 / 3, never to
+an unrecognized code.
+
+`setLocale(code)` is called by `<wavy-header>`'s locale picker. It
+notifies subscribers (components that called `subscribe()` from their
+`connectedCallback`) so they can re-render. Components currently
+re-rendering on locale change: `wavy-header`, `wavy-wave-header-actions`.
+Add `subscribe(() => this.requestUpdate())` from any component that
+uses `t()` and needs live re-render.
+
+## Catalog seed strategy
+
+The `de` catalog reuses GWT-side translations verbatim where a
+semantically equivalent string already exists under
+`wave/src/main/resources/.../*Messages_de.properties`. Lines that
+reuse a GWT string are tagged with the source `.properties` filename
+in a comment.
+
+Net-new keys (the four wave-panel action buttons, the saved-search
+dialog strings, etc.) are translated inline. Any string we are not
+confident in is intentionally left in English with a `// TODO de:`
+annotation rather than ship a wrong word — `t()`'s fallback chain
+serves the English string in those slots.
+
+## Long-term plan
+
+The GWT side already ships full `*_de`, `*_es`, `*_fr`, `*_ru`,
+`*_sl`, `*_zh_TW` `.properties` files. The intended end state is a
+Maven `generate-resources` step that walks
+`wave/src/main/resources/**/*Messages_*.properties` and emits the
+corresponding `j2cl/lit/src/i18n/catalogs/*.js` so both UIs stay in
+lockstep without manual translation drift. Until that exists, this
+module is the J2CL-side source of truth.
+
+## Build-time audit
+
+`scripts/audit-buttons.mjs` is wired as `prebuild` so any `<button>`
+that lacks both `aria-label` and `title` fails the build before
+shipping. The audit walks `j2cl/lit/src/elements/*.js` and skips both
+line and block comments to avoid false positives on JSDoc that
+mentions `<button>` literally.

--- a/j2cl/lit/src/i18n/button.js
+++ b/j2cl/lit/src/i18n/button.js
@@ -1,0 +1,13 @@
+import { t } from "./t.js";
+
+// Helper for icon-only buttons that need both `aria-label` (for screen
+// readers) and `title` (for hover tooltips). Routing both through a single
+// helper guarantees they cannot drift, and forces every visible-regression
+// affordance through the i18n primitive.
+//
+// Returns `{ label, ariaLabel, title }` where `label === ariaLabel === title`.
+// Components spread the relevant subset onto the rendered <button>.
+export function localizedButton({ key, fallback }) {
+  const label = t(key, fallback);
+  return { label, ariaLabel: label, title: label };
+}

--- a/j2cl/lit/src/i18n/catalog.js
+++ b/j2cl/lit/src/i18n/catalog.js
@@ -1,0 +1,21 @@
+// Catalog registry for the J2CL Lit shell.
+//
+// esbuild inlines JSON imports at build time, so each locale ships as part
+// of the shell.js bundle. New locales are added by dropping `xx.json` next
+// to the existing catalogs and importing it here. See ./README.md.
+
+import { en } from "./catalogs/en.js";
+import { de } from "./catalogs/de.js";
+
+const CATALOGS = Object.freeze({ en, de });
+
+export function lookup(locale, key) {
+  const catalog = CATALOGS[locale];
+  if (!catalog || typeof key !== "string") return undefined;
+  const value = catalog[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+export function hasLocale(locale) {
+  return Object.prototype.hasOwnProperty.call(CATALOGS, locale);
+}

--- a/j2cl/lit/src/i18n/catalog.js
+++ b/j2cl/lit/src/i18n/catalog.js
@@ -1,8 +1,9 @@
 // Catalog registry for the J2CL Lit shell.
 //
-// esbuild inlines JSON imports at build time, so each locale ships as part
-// of the shell.js bundle. New locales are added by dropping `xx.json` next
-// to the existing catalogs and importing it here. See ./README.md.
+// Each locale catalog is a plain ES module exporting a named object.
+// esbuild bundles them into shell.js at build time. New locales are added
+// by dropping `xx.js` next to the existing catalogs and importing it here.
+// See ./README.md.
 
 import { en } from "./catalogs/en.js";
 import { de } from "./catalogs/de.js";

--- a/j2cl/lit/src/i18n/catalogs/de.js
+++ b/j2cl/lit/src/i18n/catalogs/de.js
@@ -94,6 +94,7 @@ export const de = {
 
   "searchHelp.title": "Suchhilfe",
   "searchHelp.close": "Suchhilfe schließen",
+  "searchHelp.gotIt": "Verstanden",
 
   "profileOverlay.title": "Profil",
   "profileOverlay.close": "Profil schließen",
@@ -352,6 +353,9 @@ export const de = {
   "versionHistory.previewOnly": "Nur Vorschau — Wiederherstellen nicht verfügbar",
   "versionHistory.confirmExplanation": "Dies setzt die Wave auf diesen Stand zurück.",
   "versionHistory.preview": "Schreibgeschützte Versionsvorschau",
+  "versionHistory.version": "Version",
+  "versionHistory.participants": "Teilnehmer",
+  "versionHistory.documents": "Dokumente",
 
   "waveActions.addContactPrefix": "Hinzufügen:",
 

--- a/j2cl/lit/src/i18n/catalogs/de.js
+++ b/j2cl/lit/src/i18n/catalogs/de.js
@@ -1,0 +1,367 @@
+// German catalog for the J2CL Lit shell.
+//
+// Where a key is semantically equivalent to a string already shipped by the
+// GWT side under `wave/src/main/resources/.../*Messages_de.properties`, this
+// file reuses the existing translation verbatim so the J2CL UI cannot drift
+// from the legacy UI for shared terms (online/offline, signout, archive,
+// pin/unpin, etc.). Net-new keys are translated conservatively; anything
+// uncertain stays in English with a `// TODO de:` annotation rather than
+// shipping a wrong word — see ../README.md.
+
+export const de = {
+  // wavy-wave-header-actions.js
+  "waveActions.toolbarLabel": "Wave-Aktionen",
+  "waveActions.addParticipant": "Teilnehmer hinzufügen",
+  "waveActions.newWithParticipants": "Neue Wave mit aktuellen Teilnehmern",
+  "waveActions.newWithParticipantsShort": "Neu mit Teilnehmern",
+  // Reused from GWT ParticipantMessages_de.properties (waveIsPrivateClickToMakePublic)
+  "waveActions.makePublic": "Wave öffentlich machen",
+  "waveActions.makePrivate": "Wave privat machen",
+  "waveActions.public": "Öffentlich",
+  "waveActions.private": "Privat",
+  "waveActions.lockRoot": "Wurzel-Blip sperren",
+  "waveActions.lockFull": "Gesamte Wave sperren",
+  "waveActions.unlock": "Wave entsperren",
+  "waveActions.lockedRoot": "Wurzel gesperrt",
+  "waveActions.lockedAll": "Wave gesperrt",
+  "waveActions.unlocked": "Entsperrt",
+  "waveActions.confirmPublic": "Diese Wave öffentlich machen?",
+  "waveActions.confirmPrivate": "Diese Wave privat machen?",
+  "waveActions.confirmLockRoot": "Wurzel-Blip sperren?",
+  "waveActions.confirmLockAll": "Gesamte Wave sperren?",
+  "waveActions.confirmUnlock": "Diese Wave entsperren?",
+  "waveActions.confirmLabelMakePublic": "Öffentlich machen",
+  "waveActions.confirmLabelMakePrivate": "Privat machen",
+  "waveActions.confirmLabelLockRoot": "Wurzel sperren",
+  "waveActions.confirmLabelLockAll": "Alles sperren",
+  "waveActions.confirmLabelUnlock": "Entsperren",
+  "waveActions.participantAddresses": "Teilnehmer-Adressen",
+  "waveActions.participantPlaceholder": "alice@example.com, bob@example.com",
+  "waveActions.frequentContacts": "Häufige Kontakte",
+  "waveActions.loadingFrequentContacts": "Häufige Kontakte werden geladen...",
+  "waveActions.cancel": "Abbrechen",
+  "waveActions.add": "Hinzufügen",
+
+  // wavy-header.js — reused from SavedStateMessages_de + WebClientMessages_de
+  "header.brand": "SupaWave Startseite",
+  "header.localePicker": "Sprache",
+  "header.notifications": "Benachrichtigungen",
+  "header.inbox": "Postfach", // GWT SearchWidgetMessages_de.properties: inbox
+  "header.userMenu": "Benutzermenü öffnen",
+  "header.saveSaving": "Änderungen werden gespeichert",
+  // GWT SavedStateMessages_de.properties: unsaved
+  "header.saveUnsaved": "Noch nicht gespeichert",
+  // GWT SavedStateMessages_de.properties: saved
+  "header.saveSaved": "Gespeichert",
+  // GWT WebClientMessages_de.properties: offline / online / connecting
+  "header.netOffline": "Offline",
+  "header.netConnecting": "Verbinde...",
+  "header.netOnline": "Online",
+
+  // common
+  "common.cancel": "Abbrechen",
+  "common.confirm": "Bestätigen",
+  "common.close": "Schließen",
+  "common.delete": "Löschen",
+  "common.save": "Speichern",
+  "common.add": "Hinzufügen",
+  // GWT ParticipantMessages_de.properties: remove
+  "common.remove": "Entfernen",
+  "common.dismiss": "Schließen",
+
+  "backToInbox.label": "Zurück zum Postfach",
+
+  "scrollToNew.label": "Zu neuen Nachrichten springen",
+
+  "navDrawer.open": "Navigation öffnen",
+  "navDrawer.close": "Navigation schließen",
+
+  "waveControls.open": "Wave-Steuerung anzeigen",
+  "waveControls.close": "Wave-Steuerung ausblenden",
+
+  "searchRail.title": "Suche",
+  "searchRail.help": "Suchhilfe",
+  "searchRail.refresh": "Suchergebnisse aktualisieren",
+  "searchRail.placeholder": "Waves durchsuchen",
+  "searchRail.searchButton": "Suchen",
+  "searchRail.clear": "Suche zurücksetzen",
+  "searchRail.openWave": "Wave öffnen",
+  "searchRail.markRead": "Als gelesen markieren",
+  "searchRail.markUnread": "Als ungelesen markieren",
+  // GWT ToolbarMessages_de.properties: toArchive
+  "searchRail.archive": "Zum Archiv",
+  "searchRail.unarchive": "Aus dem Archiv wiederherstellen",
+
+  "searchHelp.title": "Suchhilfe",
+  "searchHelp.close": "Suchhilfe schließen",
+
+  "profileOverlay.title": "Profil",
+  "profileOverlay.close": "Profil schließen",
+  // GWT WebClientMessages_de.properties: signout
+  "profileOverlay.signOut": "Abmelden",
+
+  "versionHistory.title": "Versionsverlauf",
+  "versionHistory.close": "Versionsverlauf schließen",
+  // GWT ToolbarMessages_de.properties: previous / next
+  "versionHistory.previous": "Vorherig",
+  "versionHistory.next": "Nächster",
+
+  "confirmDialog.cancel": "Abbrechen",
+  "confirmDialog.confirm": "Bestätigen",
+
+  "linkModal.title": "Link einfügen",
+  "linkModal.urlLabel": "URL",
+  "linkModal.textLabel": "Anzeigetext",
+  "linkModal.cancel": "Abbrechen",
+  "linkModal.insert": "Einfügen",
+  "linkModal.remove": "Link entfernen",
+
+  "tagsRow.add": "Tag hinzufügen",
+  "tagsRow.placeholder": "Tag hinzufügen",
+  "tagsRow.remove": "Tag entfernen",
+
+  "taskAffordance.toggle": "Aufgabe umschalten",
+  "taskAffordance.markComplete": "Aufgabe als erledigt markieren",
+  "taskAffordance.markIncomplete": "Aufgabe als unerledigt markieren",
+
+  "taskMetadata.title": "Aufgaben-Details",
+  "taskMetadata.owner": "Verantwortlich",
+  "taskMetadata.dueDate": "Fälligkeitsdatum",
+  "taskMetadata.clearDueDate": "Fälligkeitsdatum entfernen",
+  "taskMetadata.close": "Aufgaben-Details schließen",
+  "taskMetadata.save": "Speichern",
+
+  "composer.placeholder": "Antwort schreiben...",
+  "composer.send": "Senden",
+  "composer.cancel": "Abbrechen",
+  "composer.discard": "Entwurf verwerfen",
+
+  "formatToolbar.label": "Formatierung",
+  "formatToolbar.bold": "Fett",
+  "formatToolbar.italic": "Kursiv",
+  "formatToolbar.underline": "Unterstrichen",
+  "formatToolbar.strikethrough": "Durchgestrichen",
+  "formatToolbar.headingMenu": "Überschrift",
+  "formatToolbar.heading1": "Überschrift 1",
+  "formatToolbar.heading2": "Überschrift 2",
+  "formatToolbar.heading3": "Überschrift 3",
+  "formatToolbar.paragraph": "Absatz",
+  "formatToolbar.link": "Link einfügen",
+  "formatToolbar.bulletList": "Aufzählung",
+  "formatToolbar.numberedList": "Nummerierte Liste",
+  "formatToolbar.indent": "Einzug vergrößern",
+  "formatToolbar.outdent": "Einzug verkleinern",
+  "formatToolbar.alignLeft": "Linksbündig",
+  "formatToolbar.alignCenter": "Zentriert",
+  "formatToolbar.alignRight": "Rechtsbündig",
+  "formatToolbar.color": "Textfarbe",
+  "formatToolbar.clearFormatting": "Formatierung entfernen",
+
+  "colorPicker.title": "Farbe wählen",
+  "colorPicker.close": "Farbauswahl schließen",
+  "colorPicker.reset": "Farbe zurücksetzen",
+
+  "composerSubmit.label": "Senden",
+  "composerSubmit.shortcutHint": "Senden (Strg+Enter)",
+
+  "attachments.add": "Anhang hinzufügen",
+  "attachments.remove": "Anhang entfernen",
+  "attachments.replace": "Anhang ersetzen",
+  "attachments.cardLabel": "Anhang",
+
+  "reactions.add": "Reaktion hinzufügen",
+  "reactions.pickerTitle": "Reaktion wählen",
+  "reactions.viewAuthors": "Personen anzeigen, die reagiert haben",
+  "reactions.close": "Reaktionen schließen",
+  "reactions.removeYours": "Eigene Reaktion entfernen",
+
+  "mentions.title": "Erwähnung",
+
+  "toolbar.overflowMenu": "Weitere Aktionen",
+
+  "navRail.label": "Hauptnavigation",
+  "navRail.toggle": "Navigation umschalten",
+
+  "statusStrip.label": "Status",
+
+  "blipToolbar.label": "Blip-Aktionen",
+  "blipToolbar.reply": "Antworten",
+  "blipToolbar.edit": "Bearbeiten",
+  "blipToolbar.delete": "Blip löschen",
+  "blipToolbar.more": "Weitere Blip-Aktionen",
+  "blip.openThread": "Thread öffnen",
+
+  "depthNav.label": "Thread-Navigation",
+  "depthNav.up": "Nach oben",
+  "depthNav.down": "Nach unten",
+
+  "waveNav.label": "Wave-Navigation",
+  // GWT ToolbarMessages_de.properties: toArchive
+  "waveNav.archive": "Zum Archiv",
+  "waveNav.unarchive": "Aus dem Archiv wiederherstellen",
+  // GWT ToolbarMessages_de.properties: pin / unpin
+  "waveNav.pin": "Anheften",
+  "waveNav.unpin": "Lösen",
+  "waveNav.versionHistory": "Versionsverlauf anzeigen",
+
+  "rootReply.label": "Oben antworten",
+  "rootReply.aria": "Auf die Wave antworten",
+
+  "skipLink.label": "Zum Hauptinhalt springen",
+
+  // Phase 2 additions — translated where confident; uncertain entries
+  // are intentionally left in English so the t() fallback chain serves
+  // a clean string instead of mojibake. See README.md.
+
+  "attachments.attachFile": "Datei anhängen",
+  "attachments.dialogLabel": "Datei anhängen",
+  "attachments.fileLabel": "Datei",
+  "attachments.captionLabel": "Beschriftung",
+  "attachments.displaySize": "Anzeigegröße",
+  "attachments.uploadProgress": "Anhang-Upload-Fortschritt",
+  "attachments.uploadFailed": "Anhang-Upload fehlgeschlagen.",
+  "attachments.blocked": "Anhang blockiert.",
+  "attachments.open": "Öffnen",
+  "attachments.openPrefix": "Anhang öffnen",
+  "attachments.download": "Herunterladen",
+  "attachments.downloadPrefix": "Anhang herunterladen",
+
+  "blip.expand": "Aufklappen",
+  "blip.collapse": "Einklappen",
+  "blip.reply": "Antwort",
+  "blip.replies": "Antworten",
+  "blip.underThisBlipSuffix": "unter diesem Blip",
+  "blip.openProfilePrefix": "Profil öffnen:",
+  "blip.profileSuffix": "",
+
+  "blipToolbar.replyAction": "Auf diesen Blip antworten",
+  "blipToolbar.editAction": "Diesen Blip bearbeiten",
+  "blipToolbar.deleteAction": "Diesen Blip löschen",
+  "blipToolbar.deleteShort": "Löschen",
+  "blipToolbar.linkAction": "Permalink zu diesem Blip kopieren",
+  "blipToolbar.linkShort": "Link",
+
+  "colorPicker.highlightPalette": "Hervorhebungs-Farbpalette",
+  "colorPicker.textPalette": "Text-Farbpalette",
+
+  "composer.editBlip": "Blip bearbeiten",
+  "composer.replyToWave": "Auf Wave antworten",
+  "composer.newWave": "Neue Wave",
+  "composer.replyToPrefix": "Antwort an",
+  "composer.replyLabel": "Antworten",
+
+  "depthNav.upOneLevel": "Eine Ebene nach oben",
+  "depthNav.upOneLevelTo": "Eine Ebene nach oben zu",
+  "depthNav.upOneLevelThreadSuffix": "s Thread",
+  "depthNav.backToTop": "Zurück zum Anfang der Wave",
+  "depthNav.upToWave": "Zur Wave",
+
+  "interactionOverlay.defaultLabel": "Interaktions-Overlay",
+
+  "mentions.suggestions": "Erwähnungs-Vorschläge",
+  "mentions.noMatches": "Keine Treffer für Erwähnungen",
+
+  "profileOverlay.previous": "Vorheriger Teilnehmer",
+  "profileOverlay.next": "Nächster Teilnehmer",
+  "profileOverlay.online": "Online",
+  "profileOverlay.lastSeenPrefix": "Zuletzt gesehen",
+  "profileOverlay.botProfile": "Bot-Profil",
+  "profileOverlay.profile": "Profil",
+  "profileOverlay.sendMessage": "Nachricht senden",
+  "profileOverlay.editProfile": "Profil bearbeiten",
+
+  "reactions.rowLabel": "Reaktionen",
+  "reactions.pick": "Reagieren mit",
+  "reactions.toggle": "Umschalten",
+  "reactions.reactionSuffix": "Reaktion",
+  "reactions.reactionsSuffix": "Reaktionen",
+  "reactions.person": "Person",
+  "reactions.people": "Personen",
+  "reactions.inspectPrefix": "Ansehen",
+  "reactions.authorsShort": "Autoren",
+  "reactions.authorsForPrefix": "Reaktionen von",
+  "reactions.thisReaction": "diese Reaktion",
+  "reactions.noneYet": "Noch keine Reaktionen",
+
+  "searchRail.searchWaves": "Waves durchsuchen",
+  "searchRail.actions": "Suchaktionen",
+  "searchRail.sort": "Waves sortieren",
+  "searchRail.filter": "Waves filtern",
+  "searchRail.filters": "Filter",
+  "searchRail.filtersGroup": "Suchfilter",
+  // GWT SearchPresenterMessages_de.properties: newWave
+  "searchRail.newWave": "Neue Wave",
+  "searchRail.manageSaved": "Gespeicherte Suchen verwalten",
+  // GWT SearchPresenterMessages_de.properties: savedSearches
+  "searchRail.savedSearches": "Gespeicherte Suchen",
+  "searchRail.unreadMentions": "ungelesene Erwähnungen",
+  "searchRail.pendingTasks": "offene Aufgaben",
+  "searchRail.pinnedSaved": "Angeheftete gespeicherte Suchen",
+  "searchRail.applySavedPrefix": "Gespeicherte Suche anwenden",
+  "searchRail.closeSaved": "Gespeicherte Suchen schließen",
+  "searchRail.applyDiscardsHint": "Anwenden schließt diesen Dialog und verwirft nicht gespeicherte Änderungen. Mit Speichern dauerhaft sichern.",
+  "searchRail.savedLoading": "Gespeicherte Suchen werden geladen…",
+  "searchRail.savedEmpty": "Noch keine gespeicherten Suchen. Aktuelle Suche hinzufügen, um eine zu erstellen.",
+  "searchRail.savedName": "Name der gespeicherten Suche",
+  "searchRail.savedQuery": "Anfrage der gespeicherten Suche",
+  "searchRail.savedFallback": "gespeicherte Suche",
+  "searchRail.applyPrefix": "Anwenden",
+  "searchRail.applyShort": "Anwenden",
+  "searchRail.removePrefix": "Entfernen",
+  "searchRail.pinShort": "Anheften",
+  "searchRail.addCurrent": "Aktuelle Suche hinzufügen",
+  "searchRail.cardAuthors": "Autoren",
+  "searchRail.cardAndMorePrefix": "und",
+  "searchRail.cardMoreSuffix": "weitere",
+  "searchRail.cardPinned": "Angeheftet",
+  "searchRail.cardMessageCount": "Nachrichtenzahl",
+  "searchRail.cardUnread": "ungelesen",
+  "searchRail.cardNoTitle": "(kein Titel)",
+
+  // GWT WebClientMessages_de.properties: online / offline / connecting
+  "statusStrip.online": "Online",
+  "statusStrip.offline": "Offline",
+  // GWT SavedStateMessages_de.properties: unsaved (re-purposed for in-progress save)
+  "statusStrip.saving": "Wird gespeichert",
+  "statusStrip.saved": "Gespeichert",
+  "statusStrip.selectedWave": "Ausgewählte Wave aktiv",
+  "statusStrip.search": "Suchergebnisse aktiv",
+  "statusStrip.loading": "Arbeitsbereich wird geladen",
+  "statusStrip.ready": "Arbeitsbereich bereit",
+
+  "tagsRow.tagsLabel": "Tags:",
+  "tagsRow.removePrefix": "Tag entfernen",
+  "tagsRow.cancel": "Tag-Eingabe abbrechen",
+
+  "taskAffordance.editDetails": "Aufgaben-Details bearbeiten",
+
+  "taskMetadata.assignee": "Verantwortlich",
+  "taskMetadata.unassigned": "Nicht zugewiesen",
+  "taskMetadata.dueDatePlaceholder": "JJJJ-MM-TT",
+
+  "versionHistory.exit": "Versionsverlauf beenden",
+  "versionHistory.loading": "Wird geladen…",
+  "versionHistory.empty": "Noch keine Versionen geladen",
+  "versionHistory.currentPreviewPrefix": "Aktuelle Vorschau:",
+  "versionHistory.slider": "Versions-Zeitschieberegler",
+  "versionHistory.showChanges": "Änderungen anzeigen",
+  "versionHistory.textOnly": "Nur Text",
+  "versionHistory.restore": "Version wiederherstellen",
+  "versionHistory.restorePrefix": "Version wiederherstellen:",
+  "versionHistory.restoreShort": "Wiederherstellen",
+  "versionHistory.previewOnly": "Nur Vorschau — Wiederherstellen nicht verfügbar",
+  "versionHistory.confirmExplanation": "Dies setzt die Wave auf diesen Stand zurück.",
+  "versionHistory.preview": "Schreibgeschützte Versionsvorschau",
+
+  "waveActions.addContactPrefix": "Hinzufügen:",
+
+  "waveNav.recent": "Zur letzten Aktivität springen",
+  "waveNav.nextUnread": "Zum nächsten ungelesenen Blip springen",
+  "waveNav.previous": "Zum vorherigen Blip springen",
+  "waveNav.next": "Zum nächsten Blip springen",
+  "waveNav.end": "Zum letzten Blip springen",
+  "waveNav.prevMention": "Zur vorherigen Erwähnung springen",
+  "waveNav.nextMention": "Zur nächsten Erwähnung springen",
+  "waveNav.versionHistoryShortcut": "Versionsverlauf öffnen (h)",
+  "waveNav.overflow": "Weitere Wave-Navigations-Aktionen"
+};

--- a/j2cl/lit/src/i18n/catalogs/de.js
+++ b/j2cl/lit/src/i18n/catalogs/de.js
@@ -104,8 +104,8 @@ export const de = {
   "versionHistory.title": "Versionsverlauf",
   "versionHistory.close": "Versionsverlauf schließen",
   // GWT ToolbarMessages_de.properties: previous / next
-  "versionHistory.previous": "Vorherig",
-  "versionHistory.next": "Nächster",
+  "versionHistory.previous": "Vorherige Version",
+  "versionHistory.next": "Nächste Version",
 
   "confirmDialog.cancel": "Abbrechen",
   "confirmDialog.confirm": "Bestätigen",
@@ -232,8 +232,7 @@ export const de = {
   "blip.reply": "Antwort",
   "blip.replies": "Antworten",
   "blip.underThisBlipSuffix": "unter diesem Blip",
-  "blip.openProfilePrefix": "Profil öffnen:",
-  "blip.profileSuffix": "",
+  "blip.openAuthorProfile": "Profil von {name} öffnen",
 
   "blipToolbar.replyAction": "Auf diesen Blip antworten",
   "blipToolbar.editAction": "Diesen Blip bearbeiten",
@@ -252,8 +251,7 @@ export const de = {
   "composer.replyLabel": "Antworten",
 
   "depthNav.upOneLevel": "Eine Ebene nach oben",
-  "depthNav.upOneLevelTo": "Eine Ebene nach oben zu",
-  "depthNav.upOneLevelThreadSuffix": "s Thread",
+  "depthNav.upOneLevelToNameThread": "Eine Ebene nach oben zu {name}s Thread",
   "depthNav.backToTop": "Zurück zum Anfang der Wave",
   "depthNav.upToWave": "Zur Wave",
 

--- a/j2cl/lit/src/i18n/catalogs/en.js
+++ b/j2cl/lit/src/i18n/catalogs/en.js
@@ -68,6 +68,7 @@ export const en = {
 
   // wavy-floating-scroll-to-new.js
   "scrollToNew.label": "Scroll to new messages",
+  "scrollToNew.newSuffix": "new",
 
   // wavy-nav-drawer-toggle.js
   "navDrawer.open": "Open navigation drawer",
@@ -93,6 +94,7 @@ export const en = {
   // wavy-search-help.js
   "searchHelp.title": "Search help",
   "searchHelp.close": "Close search help",
+  "searchHelp.gotIt": "Got it",
 
   // wavy-profile-overlay.js
   "profileOverlay.title": "Profile",
@@ -383,6 +385,9 @@ export const en = {
   "versionHistory.previewOnly": "Preview only — restore not available",
   "versionHistory.confirmExplanation": "This rewrites the wave to this point.",
   "versionHistory.preview": "Read-only version preview",
+  "versionHistory.version": "Version",
+  "versionHistory.participants": "participants",
+  "versionHistory.documents": "documents",
 
   // wave-actions popover extras
   "waveActions.addContactPrefix": "Add",

--- a/j2cl/lit/src/i18n/catalogs/en.js
+++ b/j2cl/lit/src/i18n/catalogs/en.js
@@ -254,8 +254,7 @@ export const en = {
   "blip.reply": "reply",
   "blip.replies": "replies",
   "blip.underThisBlipSuffix": "under this blip",
-  "blip.openProfilePrefix": "Open",
-  "blip.profileSuffix": "profile",
+  "blip.openAuthorProfile": "Open {name} profile",
 
   // wave-blip-toolbar
   "blipToolbar.replyAction": "Reply to this blip",
@@ -278,8 +277,7 @@ export const en = {
 
   // depth-nav
   "depthNav.upOneLevel": "Up one level",
-  "depthNav.upOneLevelTo": "Up one level to",
-  "depthNav.upOneLevelThreadSuffix": "'s thread",
+  "depthNav.upOneLevelToNameThread": "Up one level to {name}'s thread",
   "depthNav.backToTop": "Back to top of wave",
   "depthNav.upToWave": "Up to wave",
 

--- a/j2cl/lit/src/i18n/catalogs/en.js
+++ b/j2cl/lit/src/i18n/catalogs/en.js
@@ -1,0 +1,400 @@
+// English catalog for the J2CL Lit shell. The catalog file is plain JS so
+// it works under both the esbuild bundler and the web-test-runner native
+// ESM loader without import-attribute differences.
+//
+// Keys are namespaced by source file (e.g. waveActions.*, composer.*,
+// formatToolbar.*) so a future migration to per-component catalogs is a
+// mechanical rename. See ../README.md for naming convention and how to add
+// a new locale.
+
+export const en = {
+  // wavy-wave-header-actions.js
+  "waveActions.toolbarLabel": "Wave header actions",
+  "waveActions.addParticipant": "Add participant",
+  "waveActions.newWithParticipants": "New wave with current participants",
+  "waveActions.newWithParticipantsShort": "New with participants",
+  "waveActions.makePublic": "Make wave public",
+  "waveActions.makePrivate": "Make wave private",
+  "waveActions.public": "Public",
+  "waveActions.private": "Private",
+  "waveActions.lockRoot": "Lock root blip",
+  "waveActions.lockFull": "Lock full wave",
+  "waveActions.unlock": "Unlock wave",
+  "waveActions.lockedRoot": "Root locked",
+  "waveActions.lockedAll": "Wave locked",
+  "waveActions.unlocked": "Unlocked",
+  "waveActions.confirmPublic": "Make this wave public?",
+  "waveActions.confirmPrivate": "Make this wave private?",
+  "waveActions.confirmLockRoot": "Lock the root blip?",
+  "waveActions.confirmLockAll": "Lock the full wave?",
+  "waveActions.confirmUnlock": "Unlock this wave?",
+  "waveActions.confirmLabelMakePublic": "Make public",
+  "waveActions.confirmLabelMakePrivate": "Make private",
+  "waveActions.confirmLabelLockRoot": "Lock root",
+  "waveActions.confirmLabelLockAll": "Lock all",
+  "waveActions.confirmLabelUnlock": "Unlock",
+  "waveActions.participantAddresses": "Participant addresses",
+  "waveActions.participantPlaceholder": "alice@example.com, bob@example.com",
+  "waveActions.frequentContacts": "Frequent contacts",
+  "waveActions.loadingFrequentContacts": "Loading frequent contacts...",
+  "waveActions.cancel": "Cancel",
+  "waveActions.add": "Add",
+
+  // wavy-header.js
+  "header.brand": "SupaWave home",
+  "header.localePicker": "Language",
+  "header.notifications": "Notifications",
+  "header.inbox": "Inbox",
+  "header.userMenu": "Open user menu",
+  "header.saveSaving": "Saving changes",
+  "header.saveUnsaved": "Unsaved changes",
+  "header.saveSaved": "All changes saved",
+  "header.netOffline": "Offline",
+  "header.netConnecting": "Connecting",
+  "header.netOnline": "Online",
+
+  // common
+  "common.cancel": "Cancel",
+  "common.confirm": "Confirm",
+  "common.close": "Close",
+  "common.delete": "Delete",
+  "common.save": "Save",
+  "common.add": "Add",
+  "common.remove": "Remove",
+  "common.dismiss": "Dismiss",
+
+  // wavy-back-to-inbox.js
+  "backToInbox.label": "Back to inbox",
+
+  // wavy-floating-scroll-to-new.js
+  "scrollToNew.label": "Scroll to new messages",
+
+  // wavy-nav-drawer-toggle.js
+  "navDrawer.open": "Open navigation drawer",
+  "navDrawer.close": "Close navigation drawer",
+
+  // wavy-wave-controls-toggle.js
+  "waveControls.open": "Show wave controls",
+  "waveControls.close": "Hide wave controls",
+
+  // wavy-search-rail.js / wavy-search-rail-card.js
+  "searchRail.title": "Search",
+  "searchRail.help": "Search help",
+  "searchRail.refresh": "Refresh search results",
+  "searchRail.placeholder": "Search waves",
+  "searchRail.searchButton": "Search",
+  "searchRail.clear": "Clear search",
+  "searchRail.openWave": "Open wave",
+  "searchRail.markRead": "Mark as read",
+  "searchRail.markUnread": "Mark as unread",
+  "searchRail.archive": "Archive",
+  "searchRail.unarchive": "Restore from archive",
+
+  // wavy-search-help.js
+  "searchHelp.title": "Search help",
+  "searchHelp.close": "Close search help",
+
+  // wavy-profile-overlay.js
+  "profileOverlay.title": "Profile",
+  "profileOverlay.close": "Close profile",
+  "profileOverlay.signOut": "Sign out",
+
+  // wavy-version-history.js
+  "versionHistory.title": "Version history",
+  "versionHistory.close": "Close version history",
+  "versionHistory.previous": "Previous version",
+  "versionHistory.next": "Next version",
+
+  // wavy-confirm-dialog.js
+  "confirmDialog.cancel": "Cancel",
+  "confirmDialog.confirm": "Confirm",
+
+  // wavy-link-modal.js
+  "linkModal.title": "Insert link",
+  "linkModal.urlLabel": "URL",
+  "linkModal.textLabel": "Display text",
+  "linkModal.cancel": "Cancel",
+  "linkModal.insert": "Insert",
+  "linkModal.remove": "Remove link",
+
+  // wavy-tags-row.js
+  "tagsRow.add": "Add tag",
+  "tagsRow.placeholder": "Add a tag",
+  "tagsRow.remove": "Remove tag",
+
+  // wavy-task-affordance.js
+  "taskAffordance.toggle": "Toggle task",
+  "taskAffordance.markComplete": "Mark task complete",
+  "taskAffordance.markIncomplete": "Mark task incomplete",
+
+  // task-metadata-popover.js
+  "taskMetadata.title": "Task details",
+  "taskMetadata.owner": "Owner",
+  "taskMetadata.dueDate": "Due date",
+  "taskMetadata.clearDueDate": "Clear due date",
+  "taskMetadata.close": "Close task details",
+  "taskMetadata.save": "Save",
+
+  // wavy-composer.js
+  "composer.placeholder": "Write a reply...",
+  "composer.send": "Send",
+  "composer.cancel": "Cancel",
+  "composer.discard": "Discard draft",
+
+  // wavy-format-toolbar.js
+  "formatToolbar.label": "Formatting",
+  "formatToolbar.bold": "Bold",
+  "formatToolbar.italic": "Italic",
+  "formatToolbar.underline": "Underline",
+  "formatToolbar.strikethrough": "Strikethrough",
+  "formatToolbar.headingMenu": "Heading style",
+  "formatToolbar.heading1": "Heading 1",
+  "formatToolbar.heading2": "Heading 2",
+  "formatToolbar.heading3": "Heading 3",
+  "formatToolbar.paragraph": "Paragraph",
+  "formatToolbar.link": "Insert link",
+  "formatToolbar.bulletList": "Bullet list",
+  "formatToolbar.numberedList": "Numbered list",
+  "formatToolbar.indent": "Increase indent",
+  "formatToolbar.outdent": "Decrease indent",
+  "formatToolbar.alignLeft": "Align left",
+  "formatToolbar.alignCenter": "Align center",
+  "formatToolbar.alignRight": "Align right",
+  "formatToolbar.color": "Text color",
+  "formatToolbar.clearFormatting": "Clear formatting",
+
+  // wavy-colorpicker-popover.js
+  "colorPicker.title": "Choose color",
+  "colorPicker.close": "Close color picker",
+  "colorPicker.reset": "Reset color",
+
+  // composer-submit-affordance.js
+  "composerSubmit.label": "Send",
+  "composerSubmit.shortcutHint": "Send (Ctrl+Enter)",
+
+  // compose-attachment-picker.js / compose-attachment-card.js
+  "attachments.add": "Add attachment",
+  "attachments.remove": "Remove attachment",
+  "attachments.replace": "Replace attachment",
+  "attachments.cardLabel": "Attachment",
+
+  // reaction-picker-popover.js / reaction-row.js
+  "reactions.add": "Add reaction",
+  "reactions.pickerTitle": "Pick a reaction",
+  "reactions.viewAuthors": "View people who reacted",
+  "reactions.close": "Close reactions",
+  "reactions.removeYours": "Remove your reaction",
+
+  // mention-suggestion-popover.js
+  "mentions.title": "Mention",
+
+  // toolbar-button.js / toolbar-overflow-menu.js
+  "toolbar.overflowMenu": "More actions",
+
+  // shell-nav-rail.js
+  "navRail.label": "Primary navigation",
+  "navRail.toggle": "Toggle navigation",
+
+  // shell-status-strip.js
+  "statusStrip.label": "Status",
+
+  // wave-blip-toolbar.js / wave-blip.js
+  "blipToolbar.label": "Blip actions",
+  "blipToolbar.reply": "Reply",
+  "blipToolbar.edit": "Edit",
+  "blipToolbar.delete": "Delete blip",
+  "blipToolbar.more": "More blip actions",
+  "blip.openThread": "Open thread",
+
+  // wavy-depth-nav-bar.js
+  "depthNav.label": "Thread navigation",
+  "depthNav.up": "Go up",
+  "depthNav.down": "Go down",
+
+  // wavy-wave-nav-row.js
+  "waveNav.label": "Wave navigation",
+  "waveNav.archive": "Move wave to archive",
+  "waveNav.unarchive": "Restore from archive",
+  "waveNav.pin": "Pin wave",
+  "waveNav.unpin": "Unpin wave",
+  "waveNav.versionHistory": "Show version history",
+
+  // wavy-wave-root-reply-trigger.js
+  "rootReply.label": "Reply at top",
+  "rootReply.aria": "Reply to the wave",
+
+  // shell-skip-link.js
+  "skipLink.label": "Skip to main content",
+
+  // ---- additional keys exercised by the Phase 2 sweep (kept here so
+  // the catalog is the source of truth and a future translator only has
+  // to scan one file). All values are ASCII / English; non-English
+  // catalogs only need to override the user-visible strings they care
+  // to translate. ----
+
+  // attachments
+  "attachments.attachFile": "Attach file",
+  "attachments.dialogLabel": "Attach a file",
+  "attachments.fileLabel": "File",
+  "attachments.captionLabel": "Caption",
+  "attachments.displaySize": "Display size",
+  "attachments.uploadProgress": "Attachment upload progress",
+  "attachments.uploadFailed": "Attachment upload failed.",
+  "attachments.blocked": "Attachment blocked.",
+  "attachments.open": "Open",
+  "attachments.openPrefix": "Open attachment",
+  "attachments.download": "Download",
+  "attachments.downloadPrefix": "Download attachment",
+
+  // wave-blip
+  "blip.expand": "Expand",
+  "blip.collapse": "Collapse",
+  "blip.reply": "reply",
+  "blip.replies": "replies",
+  "blip.underThisBlipSuffix": "under this blip",
+  "blip.openProfilePrefix": "Open",
+  "blip.profileSuffix": "profile",
+
+  // wave-blip-toolbar
+  "blipToolbar.replyAction": "Reply to this blip",
+  "blipToolbar.editAction": "Edit this blip",
+  "blipToolbar.deleteAction": "Delete this blip",
+  "blipToolbar.deleteShort": "Delete",
+  "blipToolbar.linkAction": "Copy permalink to this blip",
+  "blipToolbar.linkShort": "Link",
+
+  // wavy-colorpicker-popover
+  "colorPicker.highlightPalette": "Highlight color palette",
+  "colorPicker.textPalette": "Text color palette",
+
+  // wavy-composer
+  "composer.editBlip": "Edit blip",
+  "composer.replyToWave": "Reply to wave",
+  "composer.newWave": "New wave",
+  "composer.replyToPrefix": "Reply to",
+  "composer.replyLabel": "Reply",
+
+  // depth-nav
+  "depthNav.upOneLevel": "Up one level",
+  "depthNav.upOneLevelTo": "Up one level to",
+  "depthNav.upOneLevelThreadSuffix": "'s thread",
+  "depthNav.backToTop": "Back to top of wave",
+  "depthNav.upToWave": "Up to wave",
+
+  // interaction-overlay-layer
+  "interactionOverlay.defaultLabel": "Interaction overlay",
+
+  // mentions
+  "mentions.suggestions": "Mention suggestions",
+  "mentions.noMatches": "No mention matches",
+
+  // profile-overlay
+  "profileOverlay.previous": "Previous participant",
+  "profileOverlay.next": "Next participant",
+  "profileOverlay.online": "Online",
+  "profileOverlay.lastSeenPrefix": "Last seen",
+  "profileOverlay.botProfile": "Bot profile",
+  "profileOverlay.profile": "Profile",
+  "profileOverlay.sendMessage": "Send Message",
+  "profileOverlay.editProfile": "Edit Profile",
+
+  // reactions
+  "reactions.rowLabel": "Reactions",
+  "reactions.pick": "React with",
+  "reactions.toggle": "Toggle",
+  "reactions.reactionSuffix": "reaction",
+  "reactions.reactionsSuffix": "reactions",
+  "reactions.person": "person",
+  "reactions.people": "people",
+  "reactions.inspectPrefix": "Inspect",
+  "reactions.authorsShort": "authors",
+  "reactions.authorsForPrefix": "Authors for",
+  "reactions.thisReaction": "this reaction",
+  "reactions.noneYet": "No reactions yet",
+
+  // search rail
+  "searchRail.searchWaves": "Search waves",
+  "searchRail.actions": "Search actions",
+  "searchRail.sort": "Sort waves",
+  "searchRail.filter": "Filter waves",
+  "searchRail.filters": "Filters",
+  "searchRail.filtersGroup": "Search filters",
+  "searchRail.newWave": "New Wave",
+  "searchRail.manageSaved": "Manage saved searches",
+  "searchRail.savedSearches": "Saved searches",
+  "searchRail.unreadMentions": "unread mentions",
+  "searchRail.pendingTasks": "pending tasks",
+  "searchRail.pinnedSaved": "Pinned saved searches",
+  "searchRail.applySavedPrefix": "Apply saved search",
+  "searchRail.closeSaved": "Close saved searches",
+  "searchRail.applyDiscardsHint": "Apply closes this dialog and discards unsaved edits. Use Save to persist them.",
+  "searchRail.savedLoading": "Loading saved searches…",
+  "searchRail.savedEmpty": "No saved searches yet. Add the current query to create one.",
+  "searchRail.savedName": "Saved search name",
+  "searchRail.savedQuery": "Saved search query",
+  "searchRail.savedFallback": "saved search",
+  "searchRail.applyPrefix": "Apply",
+  "searchRail.applyShort": "Apply",
+  "searchRail.removePrefix": "Remove",
+  "searchRail.pinShort": "Pin",
+  "searchRail.addCurrent": "Add current search",
+  "searchRail.cardAuthors": "Authors",
+  "searchRail.cardAndMorePrefix": "and",
+  "searchRail.cardMoreSuffix": "more",
+  "searchRail.cardPinned": "Pinned",
+  "searchRail.cardMessageCount": "Message count",
+  "searchRail.cardUnread": "unread",
+  "searchRail.cardNoTitle": "(no title)",
+
+  // status strip
+  "statusStrip.online": "Online",
+  "statusStrip.offline": "Offline",
+  "statusStrip.saving": "Saving changes",
+  "statusStrip.saved": "Saved",
+  "statusStrip.selectedWave": "Selected wave active",
+  "statusStrip.search": "Search results active",
+  "statusStrip.loading": "Loading workspace",
+  "statusStrip.ready": "Workspace ready",
+
+  // tags row
+  "tagsRow.tagsLabel": "Tags:",
+  "tagsRow.removePrefix": "Remove tag",
+  "tagsRow.cancel": "Cancel tag entry",
+
+  // task affordance
+  "taskAffordance.editDetails": "Edit task details",
+
+  // task metadata
+  "taskMetadata.assignee": "Assignee",
+  "taskMetadata.unassigned": "Unassigned",
+  "taskMetadata.dueDatePlaceholder": "YYYY-MM-DD",
+
+  // version history
+  "versionHistory.exit": "Exit version history",
+  "versionHistory.loading": "Loading…",
+  "versionHistory.empty": "No versions loaded yet",
+  "versionHistory.currentPreviewPrefix": "Current preview:",
+  "versionHistory.slider": "Version history time slider",
+  "versionHistory.showChanges": "Show changes",
+  "versionHistory.textOnly": "Text only",
+  "versionHistory.restore": "Restore version",
+  "versionHistory.restorePrefix": "Restore version",
+  "versionHistory.restoreShort": "Restore",
+  "versionHistory.previewOnly": "Preview only — restore not available",
+  "versionHistory.confirmExplanation": "This rewrites the wave to this point.",
+  "versionHistory.preview": "Read-only version preview",
+
+  // wave-actions popover extras
+  "waveActions.addContactPrefix": "Add",
+
+  // wave-nav extras (granular per-button keys for Phase 2 sweep)
+  "waveNav.recent": "Jump to recent activity",
+  "waveNav.nextUnread": "Jump to next unread blip",
+  "waveNav.previous": "Jump to previous blip",
+  "waveNav.next": "Jump to next blip",
+  "waveNav.end": "Jump to last blip",
+  "waveNav.prevMention": "Jump to previous mention",
+  "waveNav.nextMention": "Jump to next mention",
+  "waveNav.versionHistoryShortcut": "Open version history (h)",
+  "waveNav.overflow": "More wave navigation actions"
+};

--- a/j2cl/lit/src/i18n/locale.js
+++ b/j2cl/lit/src/i18n/locale.js
@@ -6,10 +6,16 @@
 // `t()` should `subscribe()` from `connectedCallback` so they re-render
 // when the user changes the locale via <wavy-header>.
 
+// SUPPORTED_LOCALES is the GWT locale set — what the picker may *advertise*.
+// SHIPPED_LOCALES is the subset we actually have a JS catalog for. setLocale
+// only accepts shipped locales so a bogus picker value can never strand the UI
+// in a state where every t() call falls through to the English fallback.
 export const SUPPORTED_LOCALES = ["en", "de", "es", "fr", "ru", "sl", "zh_TW"];
+export const SHIPPED_LOCALES = ["en", "de"];
 const DEFAULT_LOCALE = "en";
 
 let currentLocale = null;
+let manualOverride = false;
 const listeners = new Set();
 
 export function normalizeLocale(raw) {
@@ -43,23 +49,48 @@ function readDocumentLocale() {
 }
 
 export function getLocale() {
-  if (currentLocale) return currentLocale;
-  currentLocale = readBootstrapLocale() || readDocumentLocale() || DEFAULT_LOCALE;
+  // While the user has not explicitly picked a locale via setLocale(), keep
+  // re-reading the bootstrap surface on every call. This means a deferred
+  // <script> that populates window.__bootstrap *after* the first <wavy-...>
+  // upgrade is still picked up by subsequent t() calls. Once a manual
+  // override has happened, we honor it without re-checking the bootstrap.
+  if (manualOverride && currentLocale) return currentLocale;
+  const bootstrap = readBootstrapLocale();
+  if (bootstrap) {
+    currentLocale = bootstrap;
+    return currentLocale;
+  }
+  if (!currentLocale) {
+    currentLocale = readDocumentLocale() || DEFAULT_LOCALE;
+  }
   return currentLocale;
 }
 
 export function setLocale(code) {
-  const next = normalizeLocale(code) || DEFAULT_LOCALE;
-  if (next === currentLocale) return next;
-  currentLocale = next;
+  const normalized = normalizeLocale(code);
+  if (!normalized) return currentLocale || DEFAULT_LOCALE;
+  // Only commit to a locale we actually have a catalog for; otherwise every
+  // t() call would silently fall through to the English fallback. Returning
+  // the current (or default) locale keeps the picker rerender deterministic.
+  if (!SHIPPED_LOCALES.includes(normalized)) {
+    return currentLocale || DEFAULT_LOCALE;
+  }
+  manualOverride = true;
+  if (normalized === currentLocale) return normalized;
+  currentLocale = normalized;
+  if (typeof document !== "undefined" && document.documentElement) {
+    // Keep <html lang> in sync so CSS :lang() and assistive tech see the
+    // same locale the i18n module is using.
+    document.documentElement.lang = normalized.replace("_", "-");
+  }
   for (const listener of listeners) {
     try {
-      listener(next);
-    } catch (_err) {
-      // Listeners are best-effort; one component throwing must not stop others.
+      listener(normalized);
+    } catch (err) {
+      console.warn("i18n locale listener threw:", err);
     }
   }
-  return next;
+  return normalized;
 }
 
 export function subscribe(listener) {
@@ -71,7 +102,16 @@ export function subscribe(listener) {
 }
 
 // Test-only: drop cached state so each unit test starts from a clean slate.
+// Also clears the side-effects setLocale writes into the document/window so
+// downstream tests cannot inherit a stale locale from an earlier test.
 export function _resetLocaleForTesting() {
   currentLocale = null;
+  manualOverride = false;
   listeners.clear();
+  if (typeof document !== "undefined" && document.documentElement) {
+    document.documentElement.lang = "";
+  }
+  if (typeof window !== "undefined") {
+    delete window.__bootstrap;
+  }
 }

--- a/j2cl/lit/src/i18n/locale.js
+++ b/j2cl/lit/src/i18n/locale.js
@@ -21,8 +21,10 @@ export function normalizeLocale(raw) {
   // language code unless it's zh_TW (the only region-qualified locale we ship).
   const parts = trimmed.replace(/-/g, "_").split("_");
   const lang = parts[0].toLowerCase();
-  const region = parts[1] ? parts[1].toUpperCase() : "";
-  const candidate = region && lang === "zh" ? `${lang}_${region}` : lang;
+  // For zh (Chinese), derive the region from the last subtag so that
+  // zh-Hant-TW and zh_TW both normalize to zh_TW correctly.
+  const lastPart = parts.length > 1 ? parts[parts.length - 1].toUpperCase() : "";
+  const candidate = lastPart && lang === "zh" ? `${lang}_${lastPart}` : lang;
   return SUPPORTED_LOCALES.includes(candidate) ? candidate : null;
 }
 

--- a/j2cl/lit/src/i18n/locale.js
+++ b/j2cl/lit/src/i18n/locale.js
@@ -1,0 +1,75 @@
+// Locale module for the J2CL Lit shell.
+//
+// The active locale is derived once on first access from
+// `window.__bootstrap.session.locale` (emitted by J2clBootstrapServlet),
+// falling back to `<html lang>` and finally to "en". Components that call
+// `t()` should `subscribe()` from `connectedCallback` so they re-render
+// when the user changes the locale via <wavy-header>.
+
+export const SUPPORTED_LOCALES = ["en", "de", "es", "fr", "ru", "sl", "zh_TW"];
+const DEFAULT_LOCALE = "en";
+
+let currentLocale = null;
+const listeners = new Set();
+
+export function normalizeLocale(raw) {
+  if (raw == null) return null;
+  const trimmed = String(raw).trim();
+  if (!trimmed) return null;
+  // BCP-47 forms (de-DE, zh-TW) and Java forms (de_DE, zh_TW) both reduce to
+  // a canonical "lang" or "lang_REGION" key. Match the GWT locale set: bare
+  // language code unless it's zh_TW (the only region-qualified locale we ship).
+  const parts = trimmed.replace(/-/g, "_").split("_");
+  const lang = parts[0].toLowerCase();
+  const region = parts[1] ? parts[1].toUpperCase() : "";
+  const candidate = region && lang === "zh" ? `${lang}_${region}` : lang;
+  return SUPPORTED_LOCALES.includes(candidate) ? candidate : null;
+}
+
+function readBootstrapLocale() {
+  if (typeof window === "undefined") return null;
+  const bootstrap = window.__bootstrap;
+  if (!bootstrap || typeof bootstrap !== "object") return null;
+  const session = bootstrap.session;
+  if (!session || typeof session !== "object") return null;
+  return normalizeLocale(session.locale);
+}
+
+function readDocumentLocale() {
+  if (typeof document === "undefined" || !document.documentElement) return null;
+  return normalizeLocale(document.documentElement.lang);
+}
+
+export function getLocale() {
+  if (currentLocale) return currentLocale;
+  currentLocale = readBootstrapLocale() || readDocumentLocale() || DEFAULT_LOCALE;
+  return currentLocale;
+}
+
+export function setLocale(code) {
+  const next = normalizeLocale(code) || DEFAULT_LOCALE;
+  if (next === currentLocale) return next;
+  currentLocale = next;
+  for (const listener of listeners) {
+    try {
+      listener(next);
+    } catch (_err) {
+      // Listeners are best-effort; one component throwing must not stop others.
+    }
+  }
+  return next;
+}
+
+export function subscribe(listener) {
+  if (typeof listener !== "function") return () => {};
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+// Test-only: drop cached state so each unit test starts from a clean slate.
+export function _resetLocaleForTesting() {
+  currentLocale = null;
+  listeners.clear();
+}

--- a/j2cl/lit/src/i18n/t.js
+++ b/j2cl/lit/src/i18n/t.js
@@ -1,0 +1,20 @@
+import { getLocale } from "./locale.js";
+import { lookup } from "./catalog.js";
+
+const FALLBACK_LOCALE = "en";
+
+// Look up a localized string, falling back to the English catalog and then
+// the supplied English fallback. The fallback is mandatory so a missing key
+// can never render as `undefined` in the UI.
+export function t(key, fallback) {
+  if (typeof fallback !== "string") {
+    throw new Error(`t(${JSON.stringify(key)}): missing English fallback`);
+  }
+  const active = getLocale();
+  if (active !== FALLBACK_LOCALE) {
+    const hit = lookup(active, key);
+    if (hit != null) return hit;
+  }
+  const en = lookup(FALLBACK_LOCALE, key);
+  return en != null ? en : fallback;
+}

--- a/j2cl/lit/src/input/inline-shell-input.js
+++ b/j2cl/lit/src/input/inline-shell-input.js
@@ -27,6 +27,7 @@ export function createInlineShellInput(win) {
         address,
         role: normalizeRole(session.role),
         domain: typeof session.domain === "string" ? session.domain : "",
+        locale: typeof session.locale === "string" ? session.locale : "",
         idSeed: typeof session.idSeed === "string" ? session.idSeed : "",
         features: Array.isArray(session.features) ? [...session.features] : [],
         websocketAddress: wsAddress

--- a/j2cl/lit/src/input/json-shell-input.js
+++ b/j2cl/lit/src/input/json-shell-input.js
@@ -21,6 +21,7 @@ export function createJsonShellInput(win) {
         address,
         role: normalizeRole(session.role),
         domain: typeof session.domain === "string" ? session.domain : "",
+        locale: typeof session.locale === "string" ? session.locale : "",
         // /bootstrap.json intentionally does not provide a client ID seed.
         idSeed: "",
         features: Array.isArray(session.features) ? [...session.features] : [],

--- a/j2cl/lit/src/input/lit-shell-input.js
+++ b/j2cl/lit/src/input/lit-shell-input.js
@@ -4,6 +4,7 @@
  * @property {string} address
  * @property {"admin"|"owner"|"user"} role
  * @property {string} domain
+ * @property {string} locale
  * @property {string} idSeed
  * @property {string[]} features
  * @property {string} websocketAddress
@@ -17,6 +18,7 @@ export const EMPTY_SNAPSHOT = Object.freeze({
   address: "",
   role: "user",
   domain: "",
+  locale: "",
   idSeed: "",
   features: Object.freeze([]),
   websocketAddress: ""

--- a/j2cl/lit/test/i18n.test.js
+++ b/j2cl/lit/test/i18n.test.js
@@ -4,10 +4,14 @@ import {
   setLocale,
   subscribe,
   normalizeLocale,
+  SHIPPED_LOCALES,
+  SUPPORTED_LOCALES,
   _resetLocaleForTesting
 } from "../src/i18n/locale.js";
 import { t } from "../src/i18n/t.js";
 import { lookup, hasLocale } from "../src/i18n/catalog.js";
+import { en } from "../src/i18n/catalogs/en.js";
+import { de } from "../src/i18n/catalogs/de.js";
 import { localizedButton } from "../src/i18n/button.js";
 
 describe("i18n / locale", () => {
@@ -48,13 +52,33 @@ describe("i18n / locale", () => {
     expect(getLocale()).to.equal("en");
   });
 
-  it("setLocale notifies subscribers", () => {
+  it("getLocale prefers __bootstrap.session.locale over <html lang>", () => {
+    document.documentElement.lang = "fr";
+    window.__bootstrap = { session: { locale: "de" } };
+    expect(getLocale()).to.equal("de");
+  });
+
+  it("getLocale picks up __bootstrap that arrives AFTER first read", () => {
+    expect(getLocale()).to.equal("en");
+    window.__bootstrap = { session: { locale: "de" } };
+    expect(getLocale()).to.equal("de");
+  });
+
+  it("manual setLocale is honored even after __bootstrap changes", () => {
+    window.__bootstrap = { session: { locale: "de" } };
+    expect(getLocale()).to.equal("de");
+    setLocale("en");
+    window.__bootstrap = { session: { locale: "de" } };
+    expect(getLocale()).to.equal("en");
+  });
+
+  it("setLocale notifies subscribers (only on shipped-locale changes)", () => {
     const calls = [];
     subscribe((next) => calls.push(next));
     setLocale("de");
     setLocale("de"); // duplicate — no-op.
-    setLocale("zh_TW");
-    expect(calls).to.deep.equal(["de", "zh_TW"]);
+    setLocale("en");
+    expect(calls).to.deep.equal(["de", "en"]);
   });
 
   it("subscribe returns an unsubscribe function", () => {
@@ -62,8 +86,49 @@ describe("i18n / locale", () => {
     const unsubscribe = subscribe(() => calls++);
     setLocale("de");
     unsubscribe();
-    setLocale("fr");
+    setLocale("en");
     expect(calls).to.equal(1);
+  });
+
+  it("setLocale rejects locales without a registered catalog", () => {
+    setLocale("de");
+    expect(getLocale()).to.equal("de");
+    setLocale("fr"); // SUPPORTED but not SHIPPED
+    expect(getLocale()).to.equal("de");
+  });
+
+  it("setLocale(null) is a no-op rather than collapsing to en", () => {
+    setLocale("de");
+    setLocale(null);
+    setLocale("");
+    setLocale(undefined);
+    expect(getLocale()).to.equal("de");
+  });
+
+  it("setLocale syncs <html lang> for CSS :lang() / a11y", () => {
+    setLocale("zh_TW");
+    // setLocale only commits to shipped locales — zh_TW is unshipped, so
+    // <html lang> stays unchanged.
+    expect(document.documentElement.lang).to.equal("");
+    setLocale("de");
+    expect(document.documentElement.lang).to.equal("de");
+  });
+
+  it("a throwing subscriber does not stop other subscribers", () => {
+    let secondCalls = 0;
+    subscribe(() => {
+      throw new Error("boom");
+    });
+    subscribe(() => secondCalls++);
+    setLocale("de");
+    expect(secondCalls).to.equal(1);
+  });
+
+  it("SHIPPED_LOCALES is a subset of SUPPORTED_LOCALES", () => {
+    for (const code of SHIPPED_LOCALES) {
+      expect(SUPPORTED_LOCALES, `${code} must be in SUPPORTED`).to.include(code);
+      expect(hasLocale(code), `${code} must have a catalog`).to.equal(true);
+    }
   });
 });
 
@@ -82,6 +147,28 @@ describe("i18n / catalog", () => {
   it("lookup returns undefined for unknown keys", () => {
     expect(lookup("en", "nonsense.key")).to.equal(undefined);
     expect(lookup("xx", "any")).to.equal(undefined);
+  });
+
+  // Catalog parity gate: catch a regression where a contributor adds a
+  // German translation but forgets the matching English seed (the
+  // English catalog is the source of truth for what keys ship). The
+  // reverse direction is not gated — it is by design that some German
+  // keys are intentionally missing so they fall back to English.
+  it("every de.js key has a matching en.js entry", () => {
+    const missing = Object.keys(de).filter(
+      (key) => !Object.prototype.hasOwnProperty.call(en, key)
+    );
+    expect(missing, `de keys without en counterparts: ${missing.join(", ")}`)
+      .to.deep.equal([]);
+  });
+
+  it("no key in en or de renders as the empty string", () => {
+    for (const [k, v] of Object.entries(en)) {
+      expect(v, `en.${k} must not be empty`).to.be.a("string").and.to.have.length.greaterThan(0);
+    }
+    for (const [k, v] of Object.entries(de)) {
+      expect(v, `de.${k} must not be empty`).to.be.a("string").and.to.have.length.greaterThan(0);
+    }
   });
 });
 
@@ -103,7 +190,13 @@ describe("i18n / t", () => {
 
   it("falls back to en when the active locale lacks the key", () => {
     setLocale("de");
-    // scrollToNew.newSuffix is in en but intentionally absent from de.
+    // `scrollToNew.newSuffix` is seeded only in en.js (the German fallback
+    // chain serves the en value because the German UI uses a wholly
+    // different sentence). Asserting its presence in en and absence in
+    // de makes the en-fallback path observable in the test rather than
+    // implicit.
+    expect(en["scrollToNew.newSuffix"]).to.equal("new");
+    expect(de["scrollToNew.newSuffix"]).to.equal(undefined);
     expect(t("scrollToNew.newSuffix", "FALLBACK")).to.equal("new");
   });
 

--- a/j2cl/lit/test/i18n.test.js
+++ b/j2cl/lit/test/i18n.test.js
@@ -103,8 +103,8 @@ describe("i18n / t", () => {
 
   it("falls back to en when the active locale lacks the key", () => {
     setLocale("de");
-    // Synthetic key only present in en.
-    expect(t("waveActions.addParticipant", "FALLBACK")).to.not.equal("FALLBACK");
+    // scrollToNew.newSuffix is in en but intentionally absent from de.
+    expect(t("scrollToNew.newSuffix", "FALLBACK")).to.equal("new");
   });
 
   it("falls back to the supplied English when the key is absent everywhere", () => {

--- a/j2cl/lit/test/i18n.test.js
+++ b/j2cl/lit/test/i18n.test.js
@@ -1,0 +1,139 @@
+import { expect } from "@open-wc/testing";
+import {
+  getLocale,
+  setLocale,
+  subscribe,
+  normalizeLocale,
+  _resetLocaleForTesting
+} from "../src/i18n/locale.js";
+import { t } from "../src/i18n/t.js";
+import { lookup, hasLocale } from "../src/i18n/catalog.js";
+import { localizedButton } from "../src/i18n/button.js";
+
+describe("i18n / locale", () => {
+  beforeEach(() => {
+    _resetLocaleForTesting();
+    delete window.__bootstrap;
+    document.documentElement.lang = "";
+  });
+
+  afterEach(() => {
+    _resetLocaleForTesting();
+    delete window.__bootstrap;
+    document.documentElement.lang = "";
+  });
+
+  it("normalizes BCP-47 + Java forms", () => {
+    expect(normalizeLocale("de")).to.equal("de");
+    expect(normalizeLocale("de-DE")).to.equal("de");
+    expect(normalizeLocale("DE_de")).to.equal("de");
+    expect(normalizeLocale("zh-TW")).to.equal("zh_TW");
+    expect(normalizeLocale("zh_TW")).to.equal("zh_TW");
+    expect(normalizeLocale("xx")).to.equal(null);
+    expect(normalizeLocale(null)).to.equal(null);
+    expect(normalizeLocale("")).to.equal(null);
+  });
+
+  it("getLocale reads from window.__bootstrap.session.locale", () => {
+    window.__bootstrap = { session: { locale: "de_DE" } };
+    expect(getLocale()).to.equal("de");
+  });
+
+  it("getLocale falls back to <html lang> then 'en'", () => {
+    document.documentElement.lang = "de";
+    expect(getLocale()).to.equal("de");
+
+    _resetLocaleForTesting();
+    document.documentElement.lang = "";
+    expect(getLocale()).to.equal("en");
+  });
+
+  it("setLocale notifies subscribers", () => {
+    const calls = [];
+    subscribe((next) => calls.push(next));
+    setLocale("de");
+    setLocale("de"); // duplicate — no-op.
+    setLocale("zh_TW");
+    expect(calls).to.deep.equal(["de", "zh_TW"]);
+  });
+
+  it("subscribe returns an unsubscribe function", () => {
+    let calls = 0;
+    const unsubscribe = subscribe(() => calls++);
+    setLocale("de");
+    unsubscribe();
+    setLocale("fr");
+    expect(calls).to.equal(1);
+  });
+});
+
+describe("i18n / catalog", () => {
+  it("hasLocale reports en + de", () => {
+    expect(hasLocale("en")).to.equal(true);
+    expect(hasLocale("de")).to.equal(true);
+    expect(hasLocale("xx")).to.equal(false);
+  });
+
+  it("lookup returns a string for known keys", () => {
+    expect(lookup("en", "waveActions.addParticipant")).to.be.a("string");
+    expect(lookup("de", "waveActions.addParticipant")).to.be.a("string");
+  });
+
+  it("lookup returns undefined for unknown keys", () => {
+    expect(lookup("en", "nonsense.key")).to.equal(undefined);
+    expect(lookup("xx", "any")).to.equal(undefined);
+  });
+});
+
+describe("i18n / t", () => {
+  beforeEach(() => {
+    _resetLocaleForTesting();
+    delete window.__bootstrap;
+    document.documentElement.lang = "";
+  });
+
+  afterEach(() => {
+    _resetLocaleForTesting();
+  });
+
+  it("returns the active-locale value when present", () => {
+    setLocale("de");
+    expect(t("waveActions.addParticipant", "FALLBACK")).to.contain("Teilnehmer");
+  });
+
+  it("falls back to en when the active locale lacks the key", () => {
+    setLocale("de");
+    // Synthetic key only present in en.
+    expect(t("waveActions.addParticipant", "FALLBACK")).to.not.equal("FALLBACK");
+  });
+
+  it("falls back to the supplied English when the key is absent everywhere", () => {
+    setLocale("de");
+    expect(t("zzz.absent.key", "fallbackString")).to.equal("fallbackString");
+  });
+
+  it("throws when the fallback is missing", () => {
+    expect(() => t("anything")).to.throw();
+  });
+});
+
+describe("i18n / localizedButton", () => {
+  beforeEach(() => {
+    _resetLocaleForTesting();
+    setLocale("en");
+  });
+
+  afterEach(() => {
+    _resetLocaleForTesting();
+  });
+
+  it("returns matching label / ariaLabel / title", () => {
+    const out = localizedButton({
+      key: "waveActions.addParticipant",
+      fallback: "Add participant"
+    });
+    expect(out.label).to.be.a("string");
+    expect(out.label).to.equal(out.ariaLabel);
+    expect(out.label).to.equal(out.title);
+  });
+});

--- a/j2cl/lit/test/wavy-header.test.js
+++ b/j2cl/lit/test/wavy-header.test.js
@@ -1,7 +1,14 @@
 import { fixture, expect, html, oneEvent } from "@open-wc/testing";
 import "../src/elements/wavy-header.js";
+import { _resetLocaleForTesting } from "../src/i18n/locale.js";
 
 describe("<wavy-header>", () => {
+  // The locale picker now writes through to the module-level i18n state
+  // so other components can react. Tests that flip the picker would
+  // otherwise leak a non-en locale into siblings — reset on both ends.
+  beforeEach(() => _resetLocaleForTesting());
+  afterEach(() => _resetLocaleForTesting());
+
   it("registers the F-2.S3 wavy-header element", () => {
     expect(customElements.get("wavy-header")).to.exist;
   });

--- a/j2cl/lit/test/wavy-wave-header-actions-tooltips.test.js
+++ b/j2cl/lit/test/wavy-wave-header-actions-tooltips.test.js
@@ -1,0 +1,23 @@
+import { expect, fixture, html } from "@open-wc/testing";
+import "../src/elements/wavy-wave-header-actions.js";
+
+describe("wavy-wave-header-actions / tooltip parity", () => {
+  it("every header action button carries both aria-label and title", async () => {
+    const el = await fixture(html`
+      <wavy-wave-header-actions
+        source-wave-id="w+abc"
+      ></wavy-wave-header-actions>
+    `);
+    await el.updateComplete;
+
+    const buttons = el.shadowRoot.querySelectorAll("button[data-action]");
+    expect(buttons.length).to.equal(4);
+    for (const button of buttons) {
+      const aria = button.getAttribute("aria-label");
+      const title = button.getAttribute("title");
+      expect(aria, `${button.dataset.action} aria-label`).to.be.a("string").and.to.have.length.greaterThan(0);
+      expect(title, `${button.dataset.action} title`).to.be.a("string").and.to.have.length.greaterThan(0);
+      expect(title, `${button.dataset.action} title === aria-label`).to.equal(aria);
+    }
+  });
+});

--- a/wave/config/changelog.d/2026-05-10-j2cl-tooltips-i18n.json
+++ b/wave/config/changelog.d/2026-05-10-j2cl-tooltips-i18n.json
@@ -1,0 +1,18 @@
+{
+  "releaseId": "2026-05-10-j2cl-tooltips-i18n",
+  "version": "PR #1240",
+  "date": "2026-05-10",
+  "title": "J2CL shell: tooltips and i18n for all action buttons",
+  "summary": "Every interactive button in the J2CL Lit shell now carries both aria-label and title attributes, localized via a lightweight i18n primitive with English and German catalogs.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added t()/setLocale()/subscribe() i18n primitive for the J2CL Lit shell with English and German catalogs",
+        "All <button> elements in j2cl/lit/src/elements/ now have aria-label and title attributes for accessibility and tooltip support",
+        "User locale is surfaced from HumanAccountData through J2clBootstrapContract.SESSION_LOCALE to window.__bootstrap.session.locale",
+        "Added scripts/audit-buttons.mjs prebuild check that rejects any button missing aria-label or title"
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
@@ -39,6 +39,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.waveprotocol.box.common.J2clBootstrapContract;
 import org.waveprotocol.box.common.SessionConstants;
 import org.waveprotocol.box.server.CoreSettingsNames;
 import org.waveprotocol.box.server.account.AccountData;
@@ -589,13 +590,20 @@ public class WaveClientServlet extends HttpServlet {
       String address = (user != null) ? user.getAddress() : null;
       String sessionId = (new RandomBase64Generator()).next(10);
 
-      // Look up the user's role so the client knows if this is an admin
+      // Look up the user's role so the client knows if this is an admin,
+      // and their preferred locale so the J2CL shell can localize without
+      // an extra round-trip.
       String userRole = HumanAccountData.ROLE_USER;
+      String userLocale = "en";
       if (user != null) {
         try {
           AccountData acctData = accountStore.getAccount(user);
           if (acctData != null && acctData.isHuman()) {
             userRole = acctData.asHuman().getRole();
+            String accountLocale = acctData.asHuman().getLocale();
+            if (accountLocale != null && !accountLocale.trim().isEmpty()) {
+              userLocale = accountLocale.trim();
+            }
           }
         } catch (Exception e) {
           LOG.warning("Failed to look up role for session JSON: " + address, e);
@@ -606,7 +614,8 @@ public class WaveClientServlet extends HttpServlet {
           .put(SessionConstants.DOMAIN, domain)
           .putOpt(SessionConstants.ADDRESS, address)
           .putOpt(SessionConstants.ID_SEED, sessionId)
-          .put(SessionConstants.ROLE, userRole);
+          .put(SessionConstants.ROLE, userRole)
+          .put(J2clBootstrapContract.SESSION_LOCALE, userLocale);
       // Add enabled feature flags for this user
       if (address != null) {
         List<String> enabledFlags =

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clBootstrapServletTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clBootstrapServletTest.java
@@ -67,6 +67,10 @@ public final class J2clBootstrapServletTest {
     assertEquals("alice@example.com", session.getString(J2clBootstrapContract.SESSION_ADDRESS));
     assertEquals("example.com", session.getString(J2clBootstrapContract.SESSION_DOMAIN));
     assertEquals(HumanAccountData.ROLE_USER, session.getString(J2clBootstrapContract.SESSION_ROLE));
+    // J2CL i18n contract: the session payload always carries a locale code so
+    // window.__bootstrap.session.locale is the J2CL shell's source of truth.
+    assertTrue(session.has(J2clBootstrapContract.SESSION_LOCALE));
+    assertEquals("en", session.getString(J2clBootstrapContract.SESSION_LOCALE));
     assertFalse(session.has(SessionConstants.ID_SEED));
     assertTrue(session.has(J2clBootstrapContract.SESSION_FEATURES));
     assertFalse(session.isNull(J2clBootstrapContract.SESSION_FEATURES));
@@ -75,6 +79,7 @@ public final class J2clBootstrapServletTest {
             J2clBootstrapContract.SESSION_ADDRESS,
             J2clBootstrapContract.SESSION_DOMAIN,
             J2clBootstrapContract.SESSION_ROLE,
+            J2clBootstrapContract.SESSION_LOCALE,
             J2clBootstrapContract.SESSION_FEATURES),
         session.keySet());
 
@@ -126,11 +131,17 @@ public final class J2clBootstrapServletTest {
     JSONObject session = json.getJSONObject(J2clBootstrapContract.KEY_SESSION);
     assertEquals("example.com", session.getString(J2clBootstrapContract.SESSION_DOMAIN));
     assertEquals(HumanAccountData.ROLE_USER, session.getString(J2clBootstrapContract.SESSION_ROLE));
+    // Signed-out callers still get a locale (defaulted to "en") so the J2CL
+    // sign-in / sign-out chrome can localize without a second round-trip.
+    assertEquals("en", session.getString(J2clBootstrapContract.SESSION_LOCALE));
     assertFalse(session.has(SessionConstants.ID_SEED));
     assertFalse(session.has(J2clBootstrapContract.SESSION_ADDRESS));
     assertFalse(session.has(J2clBootstrapContract.SESSION_FEATURES));
     assertEquals(
-        Set.of(J2clBootstrapContract.SESSION_DOMAIN, J2clBootstrapContract.SESSION_ROLE),
+        Set.of(
+            J2clBootstrapContract.SESSION_DOMAIN,
+            J2clBootstrapContract.SESSION_ROLE,
+            J2clBootstrapContract.SESSION_LOCALE),
         session.keySet());
     assertEquals(
         "127.0.0.1:9898",

--- a/wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java
+++ b/wave/src/main/java/org/waveprotocol/box/common/J2clBootstrapContract.java
@@ -56,6 +56,7 @@ public final class J2clBootstrapContract {
   public static final String SESSION_ADDRESS = "address";
   public static final String SESSION_ROLE = "role";
   public static final String SESSION_FEATURES = "features";
+  public static final String SESSION_LOCALE = "locale";
 
   public static final String SOCKET_ADDRESS = "address";
 


### PR DESCRIPTION
## Summary
- Build a lightweight i18n primitive for the J2CL Lit shell (`t()`, locale module, JSON catalogs).
- Wire user locale through bootstrap (`HumanAccountData#getLocale()` → `J2clBootstrapContract.SESSION_LOCALE` → `window.__bootstrap.session.locale`).
- Add `title` attributes (mirroring `aria-label`) to every `<button>` across `j2cl/lit/src/elements/*.js`, all routed through `t()`.
- Seed catalogs with English + German; document how to add more locales.
- Restore parity with the GWT side for the wave-panel header action buttons (Add participant, New wave with participants, public/private, lock/unlock).
- Lock the parity in: `scripts/audit-buttons.mjs` runs as `prebuild` and refuses to ship if any `<button>` is rendered without both `aria-label` and `title`.

## Phases (all in this PR)
1. **i18n primitive** — `j2cl/lit/src/i18n/{locale,catalog,t,button}.js` + `catalogs/{en,de}.js`. `t(key, fallback)` falls through active → en → caller-supplied fallback so a missing key never renders `undefined`. Bootstrap surfaces locale; `<wavy-header>` picker calls `setLocale()` on change; `<wavy-wave-header-actions>` and `<wavy-header>` `subscribe()` for live re-render.
2. **Element sweep** — every `.js` under `j2cl/lit/src/elements/` that contained an `aria-label` (or icon-only `<button>`) now passes both `aria-label` and a matching `title`, with hard-coded English routed through `t("namespace.key", "fallback")`.
3. **Catalog seed + docs** — `de.js` reuses GWT translations from `wave/src/main/resources/.../*Messages_de.properties` verbatim where the same string already ships (online/offline, signout, archive, pin/unpin, etc.); strings we cannot verify are intentionally left in English so the fallback chain serves a clean string instead of mojibake. `j2cl/lit/src/i18n/README.md` documents how to add a locale and the long-term plan to generate JSON catalogs from the server `.properties` files.

## Verification
```
$ npm --prefix j2cl/lit run audit:buttons
audit-buttons: OK (46 files scanned)

$ npm --prefix j2cl/lit run build
…  ../../war/j2cl/assets/shell.js                      400.8kb
   ⚡ Done in 21ms

$ npm --prefix j2cl/lit test
Chromium: |██████████| 66/66 test files | 864 passed, 0 failed
Finished running tests in 2.8s, all tests passed!

$ sbt compile        # Java side — bootstrap contract + WaveClientServlet#getSessionJson
[success] Total time: 8 s
```

Local server smoke (Lit dev shell): not run — the wave SBT build's `Compile / managedResources` task fails on a missing `wave/config/changelog.json` unrelated to this change, so a full `runWaveServer` would fail in this worktree. The Lit-side change is fully exercised by the 864 unit tests + the new wavy-wave-header-actions tooltip fixture, and the Java compile succeeds. The deploy build will pick up the catalog change via the existing esbuild pipeline.

## Test plan
- [x] `npm --prefix j2cl/lit run audit:buttons` passes (0 violations across 46 element files).
- [x] `npm --prefix j2cl/lit run build` passes.
- [x] `npm --prefix j2cl/lit test` passes (864 tests, 2 new test files: `i18n.test.js`, `wavy-wave-header-actions-tooltips.test.js`).
- [x] Java `sbt compile` succeeds — `J2clBootstrapContract.SESSION_LOCALE` + `WaveClientServlet` change compile clean.
- [ ] In the deployed shell, hover each wave-panel header button — tooltip appears.
- [ ] Switch the locale picker to `de` — wave-panel tooltips re-render in German.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internationalization support with English and German language options
  * Users can now select preferred language in the app
  * Improved accessibility across the UI with proper labels and tooltips on all interactive elements

* **Chores**
  * Added automated checks to enforce accessibility standards for buttons during build process

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1240)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->