### PR TITLE
Round 6: restore J2CL toolbar 8px top gap for GWT parity (#1240)

### DIFF
--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -116,6 +116,25 @@ shell-root-signed-out > [slot="main"] {
   overflow: hidden;
 }
 
+/* GWT parity (round 6, #1240): restore the 8px vertical gap between
+ * the outer dark-blue compact topbar (shell-header[compact-gwt-topbar])
+ * and the inner blue toolbar strips of the search rail
+ * (wavy-search-rail .panel-title) and the wave panel
+ * (.sidecar-selected-title). The legacy GWT WebClient.ui.xml uses
+ * `margin: 8px 0 0` on .searchPanel/.wavePanel against the page
+ * background; the J2CL grid has row-gap 0 so the inner blue strips
+ * butted directly against the dark-blue topbar. Scope to
+ * compact-gwt-topbar mode so the signed-out / future non-compact
+ * modes (which already render against a flat white shell) are
+ * unaffected. The splitter is the visible col-resize affordance and
+ * keeps its full-height stretch — only the panel content rows pick
+ * up the top inset. */
+shell-root:has(> shell-header[compact-gwt-topbar]) > [slot="nav"],
+shell-root:has(> shell-header[compact-gwt-topbar]) > [slot="main"] {
+  box-sizing: border-box;
+  padding-top: 8px;
+}
+
 .j2cl-shell-splitter {
   box-sizing: border-box;
   align-self: stretch;

--- a/wave/config/changelog.d/2026-05-10-j2cl-parity-round6.json
+++ b/wave/config/changelog.d/2026-05-10-j2cl-parity-round6.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-10-j2cl-parity-round6",
+  "version": "Issue #1240",
+  "date": "2026-05-10",
+  "title": "J2CL parity round 6: restore the 8px gap between the dark-blue compact topbar and the inner blue panel toolbars.",
+  "summary": "Round 6 parity work after user testing of round 5. The legacy GWT WebClient gives the search rail and wave panel an 8px top margin so the inner blue title strips don't butt directly up against the outer dark-blue app topbar (WebClient.ui.xml `.searchPanel { margin: 8px 0 0 8px; }` / `.wavePanel { margin: 8px 0 0 0; }` against the `#f0f4f8` page bg). The J2CL shell-root grid had row-gap 0 between the header row and the nav/main rows, so the inner blue toolbar strips (wavy-search-rail .panel-title, .sidecar-selected-title) sat flush against shell-header[compact-gwt-topbar]. Round 6 adds an 8px top inset to the nav and main slot wrappers when the shell is in compact-gwt-topbar mode, restoring the visual separation users see in the GWT client.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Add `padding-top: 8px` to shell-root's nav and main slot wrappers when shell-header is in compact-gwt-topbar mode so the inner blue toolbar strips no longer butt against the outer dark-blue topbar — matches the 8px margin GWT WebClient.ui.xml puts on .searchPanel / .wavePanel."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- The J2CL root shell's inner blue panel-title strips (`wavy-search-rail .panel-title` and `.sidecar-selected-title`) sit flush against the dark-blue compact topbar (`shell-header[compact-gwt-topbar]`), but GWT's `WebClient.ui.xml` gives `.searchPanel` / `.wavePanel` a `margin: 8px 0 0 …` so the page background shows through an 8px gap above each panel. The J2CL shell-root grid had `gap: 0` between the header row and the nav/main rows, so the gap was missing.
- This change adds `padding-top: 8px` (with `box-sizing: border-box`) to `shell-root > [slot="nav"]` and `shell-root > [slot="main"]`, scoped via `shell-root:has(> shell-header[compact-gwt-topbar])` so signed-out shells and any future non-compact mode are unaffected.
- Single-file CSS change plus a round-6 changelog fragment. No JS / Java code changes.

Round 6 follow-on to PRs #1235 (round 3) → #1239 (round 5b).

## Visual

Before: inner blue title strips butt directly against the dark-blue topbar (no separation).
After (J2CL `?view=j2cl-root` on Chromium):

![J2CL after fix](https://github.com/user-attachments/assets/round6-j2cl-after.png)

GWT `/` for parity check (~8px gap visible above the inner blue strip):

![GWT for comparison](https://github.com/user-attachments/assets/round6-gwt-comparison.png)

## Implementation

`j2cl/lit/src/tokens/shell-tokens.css`:

```css
shell-root:has(> shell-header[compact-gwt-topbar]) > [slot="nav"],
shell-root:has(> shell-header[compact-gwt-topbar]) > [slot="main"] {
  box-sizing: border-box;
  padding-top: 8px;
}
```

Specificity (0,2,2) beats the existing `shell-main-region { padding: 0 }` rule (0,0,1).

## Test plan

- [x] `npm test` (j2cl/lit) — 851 tests pass on Chromium
- [x] `npm run build` — esbuild bundle clean; new rule appears in `war/j2cl/assets/shell.css`
- [x] Local server verification on `?view=j2cl-root`:
  - DevTools `getComputedStyle` for `[slot="nav"]` and `[slot="main"]` → `padding-top: 8px`
  - `shell-header` bottom = 40, `.sidecar-selected-title` top = 48 → 8px gap restored
- [x] Visual check vs GWT root at `/` — same ~8px gap above inner blue panel strips
- [ ] CI green
- [ ] CodeRabbit / Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)