### PR TITLE
J2CL parity: restore per-blip continuation reply + drop bogus "Reply submitted" status

### DIFF
--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -810,12 +810,12 @@ export class WaveBlip extends LitElement {
           type="button"
           class="continuation-trigger"
           data-blip-continuation-trigger="true"
-          aria-label="Reply on the same level as this blip"
-          title="Reply on the same level as this blip"
+          aria-label=${t("blip.replyOnSameLevel", "Reply on the same level as this blip")}
+          title=${t("blip.replyOnSameLevel", "Reply on the same level as this blip")}
           @click=${this._onContinuationClick}
         >
           <span class="glyph" aria-hidden="true">↩</span>
-          <span class="label">Reply</span>
+          <span class="label">${t("blip.reply", "Reply")}</span>
         </button>
       </div>
     `;

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -332,6 +332,52 @@ export class WaveBlip extends LitElement {
       pointer-events: auto;
       visibility: visible;
     }
+    /* GWT parity: a per-blip continuation indicator below the blip body
+     * that reveals on hover or focus. Click creates a sibling reply at
+     * the same thread level (continuation), distinct from the toolbar
+     * reply icon which creates an inline (nested) reply. Mirrors GWT's
+     * ContinuationIndicator { opacity: 0; } + :hover { opacity: 1.0; }. */
+    .continuation-row {
+      display: flex;
+      margin: 4px 0 2px 3.35em;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity var(--wavy-motion-focus-duration, 180ms)
+        var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
+    }
+    :host(:hover) .continuation-row,
+    :host(:focus-within) .continuation-row,
+    :host([focused]) .continuation-row,
+    :host([tabindex="0"]) .continuation-row,
+    .continuation-row:focus-within {
+      opacity: 1;
+      pointer-events: auto;
+    }
+    .continuation-trigger {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 3px 10px;
+      font: var(--wavy-type-meta, 11px / 1.4 Arial, sans-serif);
+      color: #4a5568;
+      background: transparent;
+      border: 1px dashed #cbd5e0;
+      border-radius: var(--wavy-radius-sm, 4px);
+      cursor: pointer;
+    }
+    .continuation-trigger:hover {
+      background: #f0f4f8;
+      border-color: #90cdf4;
+      color: #2b6cb0;
+    }
+    .continuation-trigger:focus-visible {
+      outline: none;
+      box-shadow: var(--wavy-focus-ring, 0 0 0 2px rgba(0, 119, 182, 0.16));
+    }
+    .continuation-trigger .glyph {
+      font-size: 12px;
+      line-height: 1;
+    }
   `;
 
   constructor() {
@@ -521,8 +567,33 @@ export class WaveBlip extends LitElement {
 
   _onReplyClick(event) {
     event.stopPropagation();
+    // GWT parity: the toolbar reply icon creates an INLINE reply (a
+    // child thread under the parent blip). The compose surface routes
+    // this through `onReplySubmitted`, which uses the session's
+    // `replyManifestInsertPosition` to insert a new `<thread>` in the
+    // conversation manifest under the parent blip — matching GWT's
+    // `actions.reply(blipView)` "fallback to blip end" path when no
+    // editor selection is captured.
     this.dispatchEvent(
       new CustomEvent("wave-blip-reply-requested", {
+        bubbles: true,
+        composed: true,
+        detail: { blipId: this.blipId, waveId: this.waveId }
+      })
+    );
+  }
+
+  _onContinuationClick(event) {
+    event.stopPropagation();
+    // GWT parity: the per-blip continuation indicator (rendered below the
+    // blip body and revealed on hover) creates a SIBLING reply at the
+    // same thread level — the wave op appends a new <blip> directly to
+    // the parent thread. The compose surface routes this into
+    // `onContinuationSubmitted` so the delta factory uses
+    // `replyManifestSiblingInsertPosition` instead of the inline thread
+    // insert position.
+    this.dispatchEvent(
+      new CustomEvent("wave-blip-continuation-requested", {
         bubbles: true,
         composed: true,
         detail: { blipId: this.blipId, waveId: this.waveId }
@@ -729,6 +800,19 @@ export class WaveBlip extends LitElement {
         <slot name="blip-extension" slot="blip-extension"></slot>
         <slot name="reactions" slot="reactions"></slot>
       </wavy-blip-card>
+      <div class="continuation-row" data-blip-continuation-host="true">
+        <button
+          type="button"
+          class="continuation-trigger"
+          data-blip-continuation-trigger="true"
+          aria-label="Reply on the same level as this blip"
+          title="Reply on the same level as this blip"
+          @click=${this._onContinuationClick}
+        >
+          <span class="glyph" aria-hidden="true">↩</span>
+          <span class="label">Reply</span>
+        </button>
+      </div>
     `;
   }
 }

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -342,8 +342,10 @@ export class WaveBlip extends LitElement {
       margin: 4px 0 2px 3.35em;
       opacity: 0;
       pointer-events: none;
+      visibility: hidden;
       transition: opacity var(--wavy-motion-focus-duration, 180ms)
-        var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
+          var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1)),
+        visibility 0ms var(--wavy-motion-focus-duration, 180ms);
     }
     :host(:hover) .continuation-row,
     :host(:focus-within) .continuation-row,
@@ -352,6 +354,9 @@ export class WaveBlip extends LitElement {
     .continuation-row:focus-within {
       opacity: 1;
       pointer-events: auto;
+      visibility: visible;
+      transition: opacity var(--wavy-motion-focus-duration, 180ms)
+        var(--wavy-easing-focus, cubic-bezier(0.2, 0, 0.2, 1));
     }
     .continuation-trigger {
       display: inline-flex;

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -1785,6 +1785,14 @@ export class WavyComposer extends LitElement {
     if (this.mode === "edit") return t("composer.editBlip", "Edit blip");
     if (this.mode === "wave-root") return t("composer.replyToWave", "Reply to wave");
     if (this.mode === "create") return t("composer.newWave", "New wave");
+    // GWT parity: a continuation reply lands as a sibling at the same
+    // thread level (not a nested child), so the SR label clarifies the
+    // placement.
+    if (this.mode === "continuation") {
+      return this.targetLabel
+        ? `${t("composer.replyOnSameLevelPrefix", "Reply on the same level as")} ${this.targetLabel}`
+        : t("composer.replyOnSameLevelGeneric", "Reply on the same thread level");
+    }
     return this.targetLabel
       ? `${t("composer.replyToPrefix", "Reply to")} ${this.targetLabel}`
       : t("composer.replyLabel", "Reply");
@@ -2866,6 +2874,8 @@ export class WavyComposer extends LitElement {
     const verb =
       this.mode === "edit"
         ? "Editing"
+        : this.mode === "continuation"
+        ? "Replying after"
         : "Replying to";
     const label = this._replyHeaderLabel();
     const time = this._replyHeaderTime();

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -145,13 +145,27 @@ describe("<wave-blip>", () => {
     expect(ev.detail.waveId).to.equal("w4");
   });
 
-  it("does not render a redundant below-blip continuation + beside the Reply action", async () => {
+  // GWT parity: the toolbar Reply icon creates an INLINE reply (nested
+  // child thread under the parent blip via replyManifestInsertPosition);
+  // a separate hover-revealed indicator BELOW the blip body creates a
+  // SIBLING reply at the same thread level via
+  // replyManifestSiblingInsertPosition. Both affordances coexist — they
+  // map to two different wave-model operations and PR #1220's removal of
+  // the below-blip indicator left the J2CL UI without any way to start
+  // a same-level continuation.
+  it("renders a hover-revealed continuation trigger that emits wave-blip-continuation-requested", async () => {
     const el = await fixture(html`
       <wave-blip data-blip-id="b4" data-wave-id="w4" author-name="A"></wave-blip>
     `);
     await el.updateComplete;
     const button = el.renderRoot.querySelector("[data-blip-continuation-trigger]");
-    expect(button).to.not.exist;
+    expect(button).to.exist;
+    expect(button.getAttribute("aria-label")).to.equal(
+      "Reply on the same level as this blip"
+    );
+    setTimeout(() => button.click(), 0);
+    const ev = await oneEvent(el, "wave-blip-continuation-requested");
+    expect(ev.detail).to.deep.equal({ blipId: "b4", waveId: "w4" });
   });
 
   it("re-emits wave-blip-edit-requested when toolbar Edit fires", async () => {

--- a/j2cl/lit/test/wavy-composer-inline-mount.test.js
+++ b/j2cl/lit/test/wavy-composer-inline-mount.test.js
@@ -133,13 +133,25 @@ describe("F-3.S1 inline composer mount integration", () => {
     }
   });
 
-  it("does not expose the redundant continuation + affordance", async () => {
+  // GWT parity: the toolbar Reply icon creates an INLINE reply (nested
+  // child thread); the per-blip continuation trigger below the body
+  // creates a SIBLING reply at the same thread level. PR #1220 dropped
+  // the continuation trigger as "redundant", but it is the only J2CL UI
+  // for same-level replies — the wave-model already exposes
+  // onContinuationSubmitted on the controller. Restore the affordance
+  // and assert it is present and aria-labeled.
+  it("renders the per-blip continuation trigger for same-level (sibling) replies", async () => {
     const blip = await fixture(html`
       <wave-blip data-blip-id="b99" data-wave-id="w1" author-name="A" posted-at="1m">
       </wave-blip>
     `);
     await blip.updateComplete;
-    expect(blip.renderRoot.querySelector("[data-blip-continuation-trigger]")).to.not.exist;
+    const trigger =
+        blip.renderRoot.querySelector("[data-blip-continuation-trigger]");
+    expect(trigger).to.exist;
+    expect(trigger.getAttribute("aria-label")).to.equal(
+      "Reply on the same level as this blip"
+    );
   });
 
   it("removes the composer on wavy-composer-cancelled (R-5.1 step 7)", async () => {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -2413,7 +2413,10 @@ public final class J2clComposeSurfaceController {
       // Reuse the controller so reply batches do not rebuild attachment lifecycle state.
       attachmentController.cancelAndReset();
     }
-    replyStatusText = "Reply submitted. Waiting for the opened wave to update.";
+    // GWT does not surface a "Reply submitted" status — the open wave just
+    // refreshes when the new blip lands. Mirror that by clearing the line
+    // instead of leaving it stamped on the closing composer.
+    replyStatusText = "";
     replyErrorText = "";
     replyStaleBasis = false;
     replyStaleWaveId = null;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -217,6 +217,13 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
       DomGlobal.document.body.addEventListener(
           "wave-blip-reply-requested",
           event -> openInlineComposer(eventDetailString(event, "blipId"), "reply"));
+      // GWT parity (continuation reply): wave-blip's hover-revealed
+      // indicator below the body creates a SIBLING reply at the same
+      // thread level. Open the inline composer in "continuation" mode so
+      // the reply-submit handler routes through onContinuationSubmitted.
+      DomGlobal.document.body.addEventListener(
+          "wave-blip-continuation-requested",
+          event -> openInlineComposer(eventDetailString(event, "blipId"), "continuation"));
       DomGlobal.document.body.addEventListener(
           "wave-blip-edit-requested",
           event -> openInlineComposer(eventDetailString(event, "blipId"), "edit"));
@@ -519,12 +526,33 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           // non-empty, route through onReplySubmittedWithComponents so
           // the controller preserves the user's formatting; otherwise
           // fall through to the plain-text path.
+          //
+          // GWT parity for continuation reply: when the composer is in
+          // "continuation" mode (mounted by the per-blip continuation
+          // indicator) the submit must route to onContinuationSubmitted
+          // so the delta factory uses replyManifestSiblingInsertPosition
+          // and the new blip lands as a same-level sibling instead of
+          // an inline child thread.
+          String currentMode = propertyString(composer, "mode");
+          if (currentMode == null || currentMode.isEmpty()) {
+            currentMode = composer.getAttribute("mode");
+          }
+          boolean continuation = "continuation".equals(currentMode);
           List<J2clComposeSurfaceController.SubmittedComponent> components =
               decodeSubmittedComponents(event);
           if (components.isEmpty()) {
-            listener.onReplySubmitted(propertyString(composer, "draft"), key);
+            String draft = propertyString(composer, "draft");
+            if (continuation) {
+              listener.onContinuationSubmitted(draft, key);
+            } else {
+              listener.onReplySubmitted(draft, key);
+            }
           } else {
-            listener.onReplySubmittedWithComponents(components, key);
+            if (continuation) {
+              listener.onContinuationSubmittedWithComponents(components, key);
+            } else {
+              listener.onReplySubmittedWithComponents(components, key);
+            }
           }
         });
     composer.addEventListener(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSidecarComposeController.java
@@ -323,7 +323,8 @@ public final class J2clSidecarComposeController {
     }
     replySubmitting = false;
     replyDraft = "";
-    replyStatusText = "Reply submitted. Waiting for the opened wave to update.";
+    // GWT shows no "Reply submitted" line — the wave just refreshes. Match that.
+    replyStatusText = "";
     replyErrorText = "";
     render();
     if (replySuccessHandler != null

--- a/wave/config/changelog.d/2026-05-10-j2cl-blip-continuation-reply.json
+++ b/wave/config/changelog.d/2026-05-10-j2cl-blip-continuation-reply.json
@@ -1,0 +1,21 @@
+{
+  "releaseId": "2026-05-10-j2cl-blip-continuation-reply",
+  "version": "J2CL parity",
+  "date": "2026-05-10",
+  "title": "Restore the per-blip continuation reply indicator and drop the bogus \"Reply submitted\" status in the J2CL client.",
+  "summary": "The J2CL read surface now renders a hover-revealed \"Reply\" indicator below each blip — clicking it opens an inline composer that submits as a same-level (sibling) continuation, matching the GWT wave client. The toolbar Reply icon continues to create an inline (nested) child thread, so both GWT-style affordances coexist. The J2CL inline composer also no longer surfaces a \"Reply submitted. Waiting for the opened wave to update.\" status after submit (GWT showed nothing here — the wave just refreshes when the blip lands).",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Per-blip continuation indicator below the blip body in the J2CL read surface emits wave-blip-continuation-requested and routes through onContinuationSubmitted so the wave op uses replyManifestSiblingInsertPosition (sibling reply), distinct from the toolbar Reply icon which creates an inline (nested) reply."
+      ]
+    },
+    {
+      "type": "fix",
+      "items": [
+        "J2CL inline composer no longer leaves the \"Reply submitted. Waiting for the opened wave to update.\" status stamped on the closing composer after a successful reply or continuation."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

GWT parity for replies in the J2CL read surface. Two distinct issues:

1. **Continuation reply UI was missing.** GWT shows a hover-revealed "Reply" indicator below each blip; clicking it appends a same-level (sibling) blip to the parent thread. PR #1220 removed the J2CL equivalent as "redundant beside the toolbar Reply", but those are two different operations:
   - **Toolbar Reply icon** → INLINE reply (nested child thread under the blip via `replyManifestInsertPosition`).
   - **Below-blip "↩ Reply" indicator** → SIBLING reply at the same thread level via `replyManifestSiblingInsertPosition`.

   The model and the controller's `onContinuationSubmitted` entry point already existed; only the UI affordance was missing. This PR re-renders the per-blip indicator (revealed on hover/focus) inside `wave-blip`'s shadow DOM, emits `wave-blip-continuation-requested`, the compose view opens the inline composer in `mode="continuation"`, and the `reply-submit` handler routes through `onContinuationSubmitted` / `onContinuationSubmittedWithComponents` based on the composer's mode.

2. **Bogus post-submit status.** The J2CL inline composer surfaced `"Reply submitted. Waiting for the opened wave to update."` after a successful reply / continuation. GWT shows nothing — the wave just refreshes when the new blip lands. Cleared in both `J2clComposeSurfaceController.handleReplyResponse` and `J2clSidecarComposeController.handleReplyResponse`.

Cursor-precise inline-anchor positioning (insert `<reply id="...">` element in the parent blip body at the user's text-selection offset, matching GWT's `WaveletBasedConversationBlip.addReplyThread(int location)`) is **deferred** — the current J2CL inline-reply path already creates a child thread, matching GWT's "no-selection fallback to blip end" path. Cursor anchoring needs non-trivial delta-factory work (line-count → item-offset math, parent-blip body op insertion) and warrants its own design + PR.

## Test plan

- [x] `cd j2cl/lit && npx web-test-runner` — **875/875 lit tests pass**, including the two previously-negative assertions in `wave-blip.test.js` and `wavy-composer-inline-mount.test.js` flipped to assert the trigger DOES render and DOES emit the expected event payload.
- [x] `cd j2cl && ./mvnw -P search-sidecar test` — **1078/1078 J2CL Java tests pass**.
- [x] Local server boot via `bash scripts/worktree-boot.sh --port 9905` then `wave-smoke.sh start`. Registered fresh user, navigated to `?view=j2cl-root`.
- [x] Browser probe: programmatically created a `<wave-blip>`, captured shadow-DOM snapshot — both the toolbar Reply icon AND the new continuation trigger render. The trigger has `aria-label="Reply on the same level as this blip"` and the visible `↩ Reply` label.
- [x] Click event probe: clicked `[data-blip-continuation-trigger]`, captured the bubbled `wave-blip-continuation-requested` event with `{blipId, waveId}` in the detail.
- [x] `grep -c "Reply submitted" war/j2cl-search/sidecar/*.js` → **0**. The shipped J2CL sidecar bundle no longer contains the GWT-foreign status line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per‑blip continuation reply affordance revealed on hover/focus, enabling same‑level (sibling) replies distinct from the toolbar’s nested reply.

* **Bug Fixes**
  * Removed the post‑reply status message; replies now rely on the wave refresh to indicate completion.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1242)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->