### PR TITLE
J2CL parity: anchor toolbar-Reply inline replies at the caret position

### DIFF
--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -666,18 +666,36 @@ export class WaveBlip extends LitElement {
 
     let domOffset = 0;
     let lineCount = 0;
+    // Count all text chars and newlines in a subtree unconditionally.
+    const countSubtree = (n) => {
+      if (n.nodeType === Node.TEXT_NODE) {
+        const t = n.nodeValue || "";
+        for (let i = 0; i < t.length; i++) {
+          if (t.charCodeAt(i) === 10) lineCount++;
+        }
+        domOffset += t.length;
+      } else if (n.nodeType === Node.ELEMENT_NODE) {
+        for (const child of n.childNodes) countSubtree(child);
+      }
+    };
     for (const root of roots) {
       const visit = (node) => {
         if (node === anchor) {
-          const text = node.nodeValue || "";
-          const localOffset = Math.max(
-            0,
-            Math.min(range.startOffset || 0, text.length)
-          );
-          for (let i = 0; i < localOffset; i++) {
-            if (text.charCodeAt(i) === 10) lineCount++;
+          if (node.nodeType === Node.ELEMENT_NODE) {
+            // startOffset is a child-node index, not a character offset.
+            const stopAt = Math.min(range.startOffset || 0, node.childNodes.length);
+            for (let i = 0; i < stopAt; i++) countSubtree(node.childNodes[i]);
+          } else {
+            const text = node.nodeValue || "";
+            const localOffset = Math.max(
+              0,
+              Math.min(range.startOffset || 0, text.length)
+            );
+            for (let i = 0; i < localOffset; i++) {
+              if (text.charCodeAt(i) === 10) lineCount++;
+            }
+            domOffset += localOffset;
           }
-          domOffset += localOffset;
           return true;
         }
         if (node.nodeType === Node.TEXT_NODE) {

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -666,6 +666,7 @@ export class WaveBlip extends LitElement {
 
     let domOffset = 0;
     let lineCount = 0;
+    let crossedReplyAnchors = 0;
     // Count all text chars and newlines in a subtree unconditionally.
     const countSubtree = (n) => {
       if (n.nodeType === Node.TEXT_NODE) {
@@ -675,7 +676,11 @@ export class WaveBlip extends LitElement {
         }
         domOffset += t.length;
       } else if (n.nodeType === Node.ELEMENT_NODE) {
-        for (const child of n.childNodes) countSubtree(child);
+        if (n.tagName.toLowerCase() === "reply") {
+          crossedReplyAnchors++;
+        } else {
+          for (const child of n.childNodes) countSubtree(child);
+        }
       }
     };
     for (const root of roots) {
@@ -707,15 +712,17 @@ export class WaveBlip extends LitElement {
           return false;
         }
         if (node.nodeType !== Node.ELEMENT_NODE) return false;
+        if (node.tagName.toLowerCase() === "reply") {
+          crossedReplyAnchors++;
+          return false;
+        }
         for (const child of node.childNodes) {
           if (visit(child)) return true;
         }
         return false;
       };
       if (visit(root)) {
-        const existingAnchors =
-          this._countExistingReplyAnchorsBefore(domOffset);
-        return 1 + domOffset + lineCount + 2 * existingAnchors;
+        return 1 + domOffset + lineCount + 2 * crossedReplyAnchors;
       }
     }
     return -1;

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -572,20 +572,148 @@ export class WaveBlip extends LitElement {
 
   _onReplyClick(event) {
     event.stopPropagation();
-    // GWT parity: the toolbar reply icon creates an INLINE reply (a
-    // child thread under the parent blip). The compose surface routes
-    // this through `onReplySubmitted`, which uses the session's
-    // `replyManifestInsertPosition` to insert a new `<thread>` in the
-    // conversation manifest under the parent blip — matching GWT's
-    // `actions.reply(blipView)` "fallback to blip end" path when no
-    // editor selection is captured.
+    // GWT parity: the toolbar reply icon creates an INLINE reply anchored
+    // at the user's caret/selection inside the blip body. We capture the
+    // wave-doc item offset of the caret here so the compose surface can
+    // emit a parent-blip body op that inserts a `<reply id="...">` anchor
+    // at that exact position — matching GWT's
+    // `WaveletBasedConversationBlip.addReplyThread(int location)`.
+    //
+    // When no caret/selection lies inside this blip we send `-1`, which
+    // the controller treats as the GWT "fallback to blip end" path: the
+    // wave op still creates the child thread in the manifest, but no
+    // anchor is inserted, so the reply renders as a flat child below
+    // the body (legacy J2CL behavior).
+    const anchorItemOffset = this._currentSelectionItemOffsetWithinBody();
     this.dispatchEvent(
       new CustomEvent("wave-blip-reply-requested", {
         bubbles: true,
         composed: true,
-        detail: { blipId: this.blipId, waveId: this.waveId }
+        detail: {
+          blipId: this.blipId,
+          waveId: this.waveId,
+          anchorItemOffset,
+          parentBodyItemCount: this.bodySize || 0
+        }
       })
     );
+  }
+
+  /**
+   * Returns the wave-doc item offset of the user's current caret /
+   * selection inside this blip's rendered body, or -1 when there is no
+   * caret/selection inside this blip's body.
+   *
+   * The conversion from DOM text offset to wave-doc item offset accounts
+   * for:
+   * - The leading `<body>` element_start (1 item).
+   * - Each rendered `\n` representing a `<line/>` tag, which is 2
+   *   wave-doc items but 1 DOM character.
+   * - Each pre-existing inline-reply anchor (`<reply>` element) before
+   *   the caret, which is 2 wave-doc items but 0 DOM characters.
+   */
+  _currentSelectionItemOffsetWithinBody() {
+    if (typeof window === "undefined" || !this.shadowRoot) {
+      return -1;
+    }
+    // The blip body's rendered text lives in light-DOM children
+    // slotted into the shadow body's `<slot>`. Walking the shadow
+    // body div directly would also pick up the template's static
+    // whitespace text nodes (Lit preserves indentation between
+    // `<slot>` and `</div>`), inflating the offset by ~20 items.
+    // Walk the slot's flattened assigned nodes instead so the offset
+    // reflects only the rendered text the user can actually click.
+    const slot = this.shadowRoot.querySelector(".body slot");
+    const roots =
+        slot && typeof slot.assignedNodes === "function"
+            ? slot.assignedNodes({ flatten: true })
+            : [];
+    if (!roots || roots.length === 0) {
+      return -1;
+    }
+    // The blip body content is slotted from the light DOM, so the
+    // user's caret lives in light-DOM text nodes. `window.getSelection`
+    // is the right entry point — `ShadowRoot.getSelection()` (Chrome
+    // experimental) only sees selections inside the shadow root and
+    // would miss the slotted caret. Try it as a defense-in-depth
+    // fallback for browsers that proxy slotted ranges into the shadow.
+    let selection = null;
+    try {
+      const w = window.getSelection ? window.getSelection() : null;
+      if (w && w.rangeCount > 0) selection = w;
+    } catch (_e) {}
+    if (!selection && this.shadowRoot && this.shadowRoot.getSelection) {
+      try {
+        const s = this.shadowRoot.getSelection();
+        if (s && s.rangeCount > 0) selection = s;
+      } catch (_e) {}
+    }
+    if (!selection || selection.rangeCount === 0) {
+      return -1;
+    }
+    const range = selection.getRangeAt(0);
+    const anchor = range.startContainer;
+    if (!anchor) return -1;
+    // Caret must be inside (or equal to) one of the slotted roots.
+    let inSlotted = false;
+    for (const root of roots) {
+      if (root === anchor || (root.contains && root.contains(anchor))) {
+        inSlotted = true;
+        break;
+      }
+    }
+    if (!inSlotted) return -1;
+
+    let domOffset = 0;
+    let lineCount = 0;
+    for (const root of roots) {
+      const visit = (node) => {
+        if (node === anchor) {
+          const text = node.nodeValue || "";
+          const localOffset = Math.max(
+            0,
+            Math.min(range.startOffset || 0, text.length)
+          );
+          for (let i = 0; i < localOffset; i++) {
+            if (text.charCodeAt(i) === 10) lineCount++;
+          }
+          domOffset += localOffset;
+          return true;
+        }
+        if (node.nodeType === Node.TEXT_NODE) {
+          const text = node.nodeValue || "";
+          for (let i = 0; i < text.length; i++) {
+            if (text.charCodeAt(i) === 10) lineCount++;
+          }
+          domOffset += text.length;
+          return false;
+        }
+        if (node.nodeType !== Node.ELEMENT_NODE) return false;
+        for (const child of node.childNodes) {
+          if (visit(child)) return true;
+        }
+        return false;
+      };
+      if (visit(root)) {
+        const existingAnchors =
+          this._countExistingReplyAnchorsBefore(domOffset);
+        return 1 + domOffset + lineCount + 2 * existingAnchors;
+      }
+    }
+    return -1;
+  }
+
+  _countExistingReplyAnchorsBefore(domOffset) {
+    const raw = this.getAttribute("data-inline-reply-anchors") || "";
+    if (!raw) return 0;
+    let n = 0;
+    for (const entry of raw.split(",")) {
+      const at = entry.lastIndexOf("@");
+      if (at < 0) continue;
+      const off = parseInt(entry.substring(at + 1), 10);
+      if (Number.isFinite(off) && off < domOffset) n++;
+    }
+    return n;
   }
 
   _onContinuationClick(event) {

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -652,7 +652,14 @@ export class WaveBlip extends LitElement {
       return -1;
     }
     const range = selection.getRangeAt(0);
-    const anchor = range.startContainer;
+    // For non-collapsed selections use focusNode/focusOffset (the active/caret
+    // end) rather than range.start*, which equals the anchor end when the user
+    // drags forward but the focus end when dragging backward.
+    const anchor = selection.focusNode || range.startContainer;
+    const anchorOffset =
+        typeof selection.focusOffset === "number"
+            ? selection.focusOffset
+            : range.startOffset;
     if (!anchor) return -1;
     // Caret must be inside (or equal to) one of the slotted roots.
     let inSlotted = false;
@@ -688,13 +695,13 @@ export class WaveBlip extends LitElement {
         if (node === anchor) {
           if (node.nodeType === Node.ELEMENT_NODE) {
             // startOffset is a child-node index, not a character offset.
-            const stopAt = Math.min(range.startOffset || 0, node.childNodes.length);
+            const stopAt = Math.min(anchorOffset || 0, node.childNodes.length);
             for (let i = 0; i < stopAt; i++) countSubtree(node.childNodes[i]);
           } else {
             const text = node.nodeValue || "";
             const localOffset = Math.max(
               0,
-              Math.min(range.startOffset || 0, text.length)
+              Math.min(anchorOffset || 0, text.length)
             );
             for (let i = 0; i < localOffset; i++) {
               if (text.charCodeAt(i) === 10) lineCount++;

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -145,6 +145,116 @@ describe("<wave-blip>", () => {
     expect(ev.detail.waveId).to.equal("w4");
   });
 
+  // GWT parity: when the user has no caret/selection inside the blip
+  // body, anchorItemOffset is -1 (legacy "no anchor" inline reply
+  // path); parentBodyItemCount is forwarded from the host attribute
+  // so the controller can compute the trailing retain in the
+  // parent-blip body op.
+  it("includes anchorItemOffset and parentBodyItemCount on wave-blip-reply-requested", async () => {
+    const el = await fixture(html`
+      <wave-blip
+        data-blip-id="b4"
+        data-wave-id="w4"
+        author-name="A"
+        data-blip-doc-size="42"
+      ></wave-blip>
+    `);
+    await el.updateComplete;
+    const toolbar = el.renderRoot.querySelector("wave-blip-toolbar");
+    await toolbar.updateComplete;
+    const replyBtn = toolbar.renderRoot.querySelector("[data-toolbar-action='reply']");
+    setTimeout(() => replyBtn.click(), 0);
+    const ev = await oneEvent(el, "wave-blip-reply-requested");
+    // No caret was placed inside the body in this fixture, so the
+    // offset is -1 (the wave-doc anchor op is suppressed downstream).
+    expect(ev.detail.anchorItemOffset).to.equal(-1);
+    expect(ev.detail.parentBodyItemCount).to.equal(42);
+  });
+
+  // GWT parity: with a caret placed inside a text node of the blip
+  // body, _currentSelectionItemOffsetWithinBody must convert the DOM
+  // text offset into a wave-doc item offset, accounting for the
+  // leading <body> element_start (1 item) plus any line-break items
+  // (\n in DOM text → 2 items in wave-doc) before the caret. The
+  // walker only counts text in slotted (rendered) light-DOM children
+  // — Lit's template whitespace around the body's `<slot>` element
+  // is excluded.
+  // GWT parity: with a caret placed inside a slotted text node of
+  // the blip body, _currentSelectionItemOffsetWithinBody must convert
+  // the DOM text offset into a wave-doc item offset, accounting for:
+  //   - 1 leading <body> element_start item.
+  //   - Each \n in DOM text → 1 extra item (the <line/> tag is 2
+  //     wave-doc items but 1 DOM char).
+  //   - 2 items per existing inline-reply anchor before the caret.
+  //
+  // The production J2CL renderer creates blip content via
+  // `document.createElement` and appends directly, with no template
+  // whitespace between wave-blip and its slotted children. We mirror
+  // that here so the offset matches what the wave-doc actually has.
+  function attachBlipContent(blip, text) {
+    const span = document.createElement("span");
+    span.setAttribute("data-blip-content", "true");
+    span.appendChild(document.createTextNode(text));
+    blip.appendChild(span);
+    return span;
+  }
+
+  it("computes the wave-doc item offset of a caret placed inside the blip body", async () => {
+    const el = await fixture(html`<wave-blip
+      data-blip-id="b4"
+      data-wave-id="w4"
+      author-name="A"
+    ></wave-blip>`);
+    await el.updateComplete;
+    const span = attachBlipContent(el, "Hello world");
+    const textNode = span.firstChild;
+    // Place the caret between "Hello" and " world" → DOM offset 5.
+    const range = document.createRange();
+    range.setStart(textNode, 5);
+    range.collapse(true);
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+    // 1 (body element_start) + 5 (DOM offset, no \n before) + 0 (no
+    // existing reply anchors) = 6.
+    expect(el._currentSelectionItemOffsetWithinBody()).to.equal(6);
+  });
+
+  it("accounts for line breaks before the caret when computing the item offset", async () => {
+    const el = await fixture(html`<wave-blip
+      data-blip-id="b5"
+      data-wave-id="w5"
+      author-name="A"
+    ></wave-blip>`);
+    await el.updateComplete;
+    const span = attachBlipContent(el, "Hi\nthere");
+    const textNode = span.firstChild;
+    // Caret right after "there" → DOM offset 7 ("Hi\nthere" is 7 chars),
+    // 1 newline before.
+    const range = document.createRange();
+    range.setStart(textNode, 7);
+    range.collapse(true);
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+    // 1 (body start) + 7 (DOM) + 1 (one line tag = 1 extra item) = 9.
+    expect(el._currentSelectionItemOffsetWithinBody()).to.equal(9);
+  });
+
+  // No selection / caret outside the blip body → -1, telling the
+  // controller to fall back to the legacy "no anchor" path.
+  it("returns -1 when no caret lies inside the blip body", async () => {
+    const el = await fixture(html`<wave-blip
+      data-blip-id="b6"
+      data-wave-id="w6"
+      author-name="A"
+    ></wave-blip>`);
+    await el.updateComplete;
+    attachBlipContent(el, "Body");
+    window.getSelection().removeAllRanges();
+    expect(el._currentSelectionItemOffsetWithinBody()).to.equal(-1);
+  });
+
   // GWT parity: the toolbar Reply icon creates an INLINE reply (nested
   // child thread under the parent blip via replyManifestInsertPosition);
   // a separate hover-revealed indicator BELOW the blip body creates a

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -171,14 +171,6 @@ describe("<wave-blip>", () => {
     expect(ev.detail.parentBodyItemCount).to.equal(42);
   });
 
-  // GWT parity: with a caret placed inside a text node of the blip
-  // body, _currentSelectionItemOffsetWithinBody must convert the DOM
-  // text offset into a wave-doc item offset, accounting for the
-  // leading <body> element_start (1 item) plus any line-break items
-  // (\n in DOM text → 2 items in wave-doc) before the caret. The
-  // walker only counts text in slotted (rendered) light-DOM children
-  // — Lit's template whitespace around the body's `<slot>` element
-  // is excluded.
   // GWT parity: with a caret placed inside a slotted text node of
   // the blip body, _currentSelectionItemOffsetWithinBody must convert
   // the DOM text offset into a wave-doc item offset, accounting for:

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -1062,6 +1062,7 @@ public final class J2clComposeSurfaceController {
     commandStatusText = "";
     commandErrorText = "";
     resetAttachmentState();
+    clearPendingInlineAnchor();
     // F-3.S3 (#1038, R-5.5): drop cached reaction snapshots so a
     // post-sign-out toggle cannot project against the prior session's
     // state. Clear the published user address so the view's aria-pressed
@@ -1205,9 +1206,12 @@ public final class J2clComposeSurfaceController {
    */
   public void onInlineReplyAnchorRequested(
       String blipId, int anchorItemOffset, int parentBodyItemCount) {
+    int normalizedBodyItemCount = Math.max(0, parentBodyItemCount);
     pendingInlineAnchorBlipId = blipId == null ? "" : blipId;
-    pendingInlineAnchorItemOffset = anchorItemOffset;
-    pendingInlineAnchorParentBodyItemCount = Math.max(0, parentBodyItemCount);
+    pendingInlineAnchorItemOffset =
+        (anchorItemOffset >= 1 && anchorItemOffset < normalizedBodyItemCount)
+            ? anchorItemOffset : -1;
+    pendingInlineAnchorParentBodyItemCount = normalizedBodyItemCount;
   }
 
   private void clearPendingInlineAnchor() {
@@ -3249,6 +3253,7 @@ public final class J2clComposeSurfaceController {
   }
 
   private void resetAttachmentState() {
+    clearPendingInlineAnchor();
     J2clAttachmentComposerController previousController = attachmentController;
     attachmentController = null;
     insertedAttachments.clear();

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -156,6 +156,24 @@ public final class J2clComposeSurfaceController {
       onContinuationSubmitted(builder.toString(), replyTargetBlipId);
     }
 
+    /**
+     * GWT parity (cursor-anchored inline reply): wave-blip captured the
+     * caret's wave-doc item offset inside the parent body before the
+     * reply request was dispatched. The controller stashes it (and the
+     * parent's body item count) until the next reply submit so the
+     * delta factory can emit a parent-blip body op that inserts a
+     * {@code <reply id="...">} anchor at that exact position — matching
+     * GWT's {@code WaveletBasedConversationBlip.addReplyThread(int location)}.
+     *
+     * <p>{@code anchorItemOffset == -1} means "no caret inside this
+     * blip" — fall back to the legacy "no anchor" inline reply (the
+     * child thread is created in the manifest, but no anchor element
+     * is inserted in the parent body, so the reply renders as a flat
+     * child below the parent body).
+     */
+    default void onInlineReplyAnchorRequested(
+        String blipId, int anchorItemOffset, int parentBodyItemCount) {}
+
     void onAttachmentFilesSelected(List<AttachmentFileSelection> selections);
 
     void onPastedImage(Object imagePayload);
@@ -409,6 +427,31 @@ public final class J2clComposeSurfaceController {
         J2clSidecarWriteSession session,
         String draftText,
         J2clComposerDocument document);
+
+    /**
+     * GWT-parity overload that carries the cursor-anchored inline-reply
+     * position captured by wave-blip. {@code inlineAnchorItemOffset >= 1}
+     * (i.e. inside the parent body) tells the rich-content factory to
+     * emit an additional parent-blip body op inserting a
+     * {@code <reply id="...">} element at that wave-doc item offset, so
+     * the resulting reply renders inline at the caret's position —
+     * matching GWT's
+     * {@code WaveletBasedConversationBlip.addReplyThread(int location)}.
+     *
+     * <p>The default implementation forwards to the legacy 4-arg
+     * overload, ignoring the anchor params, so plain-text factories
+     * and unit-test doubles keep compiling. Production wiring goes
+     * through the rich-content factory which overrides this method.
+     */
+    default SidecarSubmitRequest createReplyRequest(
+        String address,
+        J2clSidecarWriteSession session,
+        String draftText,
+        J2clComposerDocument document,
+        int inlineAnchorItemOffset,
+        int parentBodyItemCount) {
+      return createReplyRequest(address, session, draftText, document);
+    }
 
     /**
      * F-3.S2 (#1038, R-5.4): build a stand-alone toggle request for a
@@ -673,6 +716,20 @@ public final class J2clComposeSurfaceController {
   // components instead of the legacy single-annotation-on-whole-draft
   // path. Cleared on submit success / failure / wave change.
   private List<SubmittedComponent> pendingSubmittedComponents;
+  // GWT parity (cursor-anchored inline reply): wave-blip captured the
+  // caret's wave-doc item offset inside the parent body before
+  // dispatching the reply request. Stash it (and the parent's body
+  // item count) here so the next submitReply call passes both to the
+  // delta factory, which emits an additional parent-blip body op
+  // inserting a `<reply id="...">` element at the offset — matching
+  // GWT's WaveletBasedConversationBlip.addReplyThread(int location).
+  // -1 means "no caret captured" → fall back to legacy "no anchor".
+  // The triple is bound to a single blip id; if the user clicks Reply
+  // on a different blip, the offset captured for the previous blip is
+  // discarded by onInlineReplyAnchorRequested overwriting it.
+  private String pendingInlineAnchorBlipId = "";
+  private int pendingInlineAnchorItemOffset = -1;
+  private int pendingInlineAnchorParentBodyItemCount = 0;
   private String commandStatusText = "";
   private String commandErrorText = "";
   private J2clAttachmentComposerController attachmentController;
@@ -883,6 +940,13 @@ public final class J2clComposeSurfaceController {
               List<SubmittedComponent> components, String replyTargetBlipId) {
             J2clComposeSurfaceController.this.onContinuationSubmittedWithComponents(
                 components, replyTargetBlipId);
+          }
+
+          @Override
+          public void onInlineReplyAnchorRequested(
+              String blipId, int anchorItemOffset, int parentBodyItemCount) {
+            J2clComposeSurfaceController.this.onInlineReplyAnchorRequested(
+                blipId, anchorItemOffset, parentBodyItemCount);
           }
 
           @Override
@@ -1129,6 +1193,27 @@ public final class J2clComposeSurfaceController {
     replyStaleBasis = false;
     replyStaleWaveId = null;
     render();
+  }
+
+  /**
+   * GWT parity (cursor-anchored inline reply): record the caret's
+   * wave-doc item offset captured by wave-blip when the user clicked
+   * the toolbar Reply icon, so the next reply submit emits a
+   * parent-blip body op inserting a {@code <reply id="...">} anchor
+   * at that exact position. {@code anchorItemOffset == -1} clears any
+   * prior pending anchor (no caret was inside the blip).
+   */
+  public void onInlineReplyAnchorRequested(
+      String blipId, int anchorItemOffset, int parentBodyItemCount) {
+    pendingInlineAnchorBlipId = blipId == null ? "" : blipId;
+    pendingInlineAnchorItemOffset = anchorItemOffset;
+    pendingInlineAnchorParentBodyItemCount = Math.max(0, parentBodyItemCount);
+  }
+
+  private void clearPendingInlineAnchor() {
+    pendingInlineAnchorBlipId = "";
+    pendingInlineAnchorItemOffset = -1;
+    pendingInlineAnchorParentBodyItemCount = 0;
   }
 
   public void onReplySubmitted(String draft) {
@@ -2336,6 +2421,20 @@ public final class J2clComposeSurfaceController {
     final String submittedAnnotationCommandId = annotationCommandId;
     final int generation = ++replyGeneration;
     final J2clSidecarWriteSession capturedSubmitSession = submitSession;
+    // GWT parity: only forward the cursor anchor when this submit
+    // targets the same blip the caret was captured for, AND we're
+    // creating an inline (non-continuation) reply. Otherwise the wave-
+    // model still needs the inline-thread or sibling op without a
+    // body-anchor element.
+    final boolean useAnchor =
+        !continuation
+            && pendingInlineAnchorItemOffset >= 1
+            && pendingInlineAnchorParentBodyItemCount > 0
+            && replyTargetBlipId != null
+            && replyTargetBlipId.equals(pendingInlineAnchorBlipId);
+    final int submittedAnchorItemOffset = useAnchor ? pendingInlineAnchorItemOffset : -1;
+    final int submittedAnchorParentBodyItemCount =
+        useAnchor ? pendingInlineAnchorParentBodyItemCount : 0;
     render();
     gateway.fetchRootSessionBootstrap(
         bootstrap -> {
@@ -2350,7 +2449,9 @@ public final class J2clComposeSurfaceController {
                     bootstrap.getAddress(),
                     capturedSubmitSession,
                     submittedDraft,
-                    buildDocument(submittedDraft, true, submittedAnnotationCommandId, true));
+                    buildDocument(submittedDraft, true, submittedAnnotationCommandId, true),
+                    submittedAnchorItemOffset,
+                    submittedAnchorParentBodyItemCount);
           } catch (RuntimeException e) {
             handleReplyFailure(generation, messageOrDefault(e, "Unable to build the reply request."));
             return;
@@ -2403,6 +2504,10 @@ public final class J2clComposeSurfaceController {
     // forwarded by the inline composer; failures preserve it so a
     // retry submits the same formatting.
     pendingSubmittedComponents = null;
+    // GWT parity: a successful submit consumes the cursor-anchor
+    // (mirroring the mention/component lists) so the next reply on a
+    // different blip starts from a clean slate.
+    clearPendingInlineAnchor();
     // A sent reply closes the attachment batch; failures preserve size and attachments for retry.
     attachmentDisplaySize = J2clAttachmentComposerController.DisplaySize.MEDIUM;
     activeCommandId = "";
@@ -2806,6 +2911,18 @@ public final class J2clComposeSurfaceController {
           String draftText,
           J2clComposerDocument document) {
         return factory.createReplyRequest(address, session, document);
+      }
+
+      @Override
+      public SidecarSubmitRequest createReplyRequest(
+          String address,
+          J2clSidecarWriteSession session,
+          String draftText,
+          J2clComposerDocument document,
+          int inlineAnchorItemOffset,
+          int parentBodyItemCount) {
+        return factory.createReplyRequest(
+            address, session, document, inlineAnchorItemOffset, parentBodyItemCount);
       }
 
       @Override

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -216,7 +216,22 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     if (inlineRichComposerEnabled) {
       DomGlobal.document.body.addEventListener(
           "wave-blip-reply-requested",
-          event -> openInlineComposer(eventDetailString(event, "blipId"), "reply"));
+          event -> {
+            // GWT parity: wave-blip captures the caret/selection's
+            // wave-doc item offset inside the parent body so the next
+            // reply submit can insert a `<reply id="...">` anchor at
+            // that exact position. anchorItemOffset == -1 means the
+            // user had no caret inside this blip — fall back to the
+            // legacy J2CL "manifest-only" inline reply (no anchor).
+            String blipId = eventDetailString(event, "blipId");
+            int anchorItemOffset = eventDetailInt(event, "anchorItemOffset", -1);
+            int parentBodyItemCount = eventDetailInt(event, "parentBodyItemCount", 0);
+            if (listener != null) {
+              listener.onInlineReplyAnchorRequested(
+                  blipId, anchorItemOffset, parentBodyItemCount);
+            }
+            openInlineComposer(blipId, "reply");
+          });
       // GWT parity (continuation reply): wave-blip's hover-revealed
       // indicator below the body creates a SIBLING reply at the same
       // thread level. Open the inline composer in "continuation" mode so

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -977,6 +977,35 @@ public final class J2clRichContentDeltaFactory {
 
   public SidecarSubmitRequest createReplyRequest(
       String address, J2clSidecarWriteSession session, J2clComposerDocument document) {
+    return createReplyRequest(address, session, document, -1, 0);
+  }
+
+  /**
+   * GWT parity (cursor-anchored inline reply): when
+   * {@code inlineAnchorItemOffset >= 1} and the request targets a
+   * specific parent blip, emit a third document op that inserts a
+   * {@code <reply id="threadId">} element at that wave-doc item
+   * offset inside the parent blip's body, mirroring GWT's
+   * {@code WaveletBasedConversationBlip.addReplyThread(int location)}.
+   *
+   * <p>The anchor op is only emitted for the inline-thread path
+   * (i.e. when {@code shouldCreateRegularReply == false} so a new
+   * {@code <thread>} is being inserted in the manifest). Continuation
+   * (sibling) replies and depth-limited replies do not use a body
+   * anchor — they live as siblings in the parent thread, so a body
+   * anchor would not have a thread to point at.
+   *
+   * <p>{@code inlineAnchorItemOffset == -1} or
+   * {@code parentBodyItemCount <= 0} disables the anchor op, falling
+   * back to the legacy "manifest-only" inline reply that the previous
+   * J2CL implementation produced.
+   */
+  public SidecarSubmitRequest createReplyRequest(
+      String address,
+      J2clSidecarWriteSession session,
+      J2clComposerDocument document,
+      int inlineAnchorItemOffset,
+      int parentBodyItemCount) {
     requirePresent(session, "Missing write session.");
     requirePresent(document, "Missing composer document.");
     String normalizedAddress = normalizeAddress(address);
@@ -997,6 +1026,7 @@ public final class J2clRichContentDeltaFactory {
           "Unable to submit continuation reply: missing insert position for blip "
               + session.getReplyTargetBlipId() + ".");
     }
+    String replyThreadId = null;
     if (shouldCreateRegularReply(session)) {
       operationsJson =
           buildConversationRegularReplyOperation(
@@ -1006,7 +1036,7 @@ public final class J2clRichContentDeltaFactory {
               + ","
               + operationsJson;
     } else if (session.getReplyManifestInsertPosition() >= 0) {
-      String replyThreadId = nextToken("t+");
+      replyThreadId = nextToken("t+");
       operationsJson =
           buildConversationReplyThreadOperation(
                   session.getReplyManifestInsertPosition(),
@@ -1015,6 +1045,26 @@ public final class J2clRichContentDeltaFactory {
                   replyBlipId)
               + ","
               + operationsJson;
+    }
+    // GWT parity: when an inline thread is being created AND the user
+    // had a caret in the parent body, also insert a `<reply id=…>`
+    // anchor element at the captured wave-doc offset so the read
+    // surface renders the new thread inline at that exact position
+    // rather than as a flat child below the parent body.
+    if (replyThreadId != null
+        && inlineAnchorItemOffset >= 1
+        && parentBodyItemCount > 0) {
+      String parentBlipId = session.getReplyTargetBlipId();
+      if (parentBlipId != null && !parentBlipId.isEmpty()) {
+        operationsJson =
+            operationsJson
+                + ","
+                + buildInlineReplyAnchorOperation(
+                    parentBlipId,
+                    inlineAnchorItemOffset,
+                    parentBodyItemCount,
+                    replyThreadId);
+      }
     }
     String deltaJson =
         buildDeltaJson(
@@ -1090,6 +1140,33 @@ public final class J2clRichContentDeltaFactory {
       appendRetain(components, trailingRetain);
     }
     return buildRawDocumentOperation("conversation", components.toString());
+  }
+
+  /**
+   * Builds the parent-blip body op that inserts a
+   * {@code <reply id="threadId">…</reply>} anchor element at
+   * {@code insertItemOffset} in a body of {@code bodyItemCount} items.
+   * The anchor is an empty element (start + end, 2 items), so the
+   * post-insert document grows by 2 items.
+   */
+  private String buildInlineReplyAnchorOperation(
+      String parentBlipId, int insertItemOffset, int bodyItemCount, String threadId) {
+    if (insertItemOffset < 1 || insertItemOffset > bodyItemCount) {
+      throw new IllegalArgumentException(
+          "Reply failed: the inline anchor offset is outside the parent body.");
+    }
+    StringBuilder components = new StringBuilder();
+    appendRetain(components, insertItemOffset);
+    appendComponentSeparator(components);
+    appendElementStartWithAttr(components, "reply", "id", threadId);
+    appendComponentSeparator(components);
+    appendElementEnd(components);
+    int trailingRetain = bodyItemCount - insertItemOffset;
+    if (trailingRetain > 0) {
+      appendComponentSeparator(components);
+      appendRetain(components, trailingRetain);
+    }
+    return buildRawDocumentOperation(parentBlipId, components.toString());
   }
 
   private String buildDocumentOperation(String documentId, J2clComposerDocument document) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -1151,7 +1151,7 @@ public final class J2clRichContentDeltaFactory {
    */
   private String buildInlineReplyAnchorOperation(
       String parentBlipId, int insertItemOffset, int bodyItemCount, String threadId) {
-    if (insertItemOffset < 1 || insertItemOffset > bodyItemCount) {
+    if (insertItemOffset < 1 || insertItemOffset >= bodyItemCount) {
       throw new IllegalArgumentException(
           "Reply failed: the inline anchor offset is outside the parent body.");
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -1053,7 +1053,8 @@ public final class J2clRichContentDeltaFactory {
     // rather than as a flat child below the parent body.
     if (replyThreadId != null
         && inlineAnchorItemOffset >= 1
-        && parentBodyItemCount > 0) {
+        && parentBodyItemCount > 0
+        && inlineAnchorItemOffset < parentBodyItemCount) {
       String parentBlipId = session.getReplyTargetBlipId();
       if (parentBlipId != null && !parentBlipId.isEmpty()) {
         operationsJson =

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
@@ -189,6 +189,123 @@ public class J2clRichContentDeltaFactoryTest {
   }
 
   @Test
+  public void cursorAnchoredInlineReplyEmitsParentBlipBodyOpInsertingReplyElement() {
+    // GWT parity: when wave-blip captures the user's caret inside the
+    // parent body, the delta carries an additional document op that
+    // inserts a `<reply id="threadId">` element at the captured
+    // wave-doc item offset, so the new thread renders inline at that
+    // position instead of as a flat child below the body.
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession(
+            "example.com/w+reply", "chan-7", 44L, "ABCD", "b+parent", 6, 8);
+    J2clComposerDocument document =
+        J2clComposerDocument.builder().text("Inline at caret").build();
+
+    SidecarSubmitRequest request =
+        factory.createReplyRequest(
+            "user@example.com",
+            session,
+            document,
+            /* inlineAnchorItemOffset= */ 4,
+            /* parentBodyItemCount= */ 12);
+    String deltaJson = request.getDeltaJson();
+
+    Assert.assertEquals("b+seedA", request.getClientCreatedBlipId());
+    // Manifest op still inserts the new <thread>+<blip>.
+    assertContains(
+        deltaJson,
+        "{\"3\":{\"1\":\"thread\",\"2\":[{\"1\":\"id\",\"2\":\"t+seedB\"}]}}",
+        "{\"3\":{\"1\":\"blip\",\"2\":[{\"1\":\"id\",\"2\":\"b+seedA\"}]}}");
+    // Parent-blip body op: retain 4, insert <reply id=t+seedB>, end, retain 8.
+    assertContains(
+        deltaJson,
+        "\"1\":\"b+parent\"",
+        "{\"5\":4}",
+        "{\"3\":{\"1\":\"reply\",\"2\":[{\"1\":\"id\",\"2\":\"t+seedB\"}]}}",
+        "{\"4\":true}",
+        "{\"5\":8}");
+    // The reply thread id appears in BOTH the manifest <thread> and
+    // the parent-body <reply> anchor — so the two ops point at the
+    // same thread, mirroring GWT's createInlineReplyAnchor + manifest
+    // append pair.
+    Assert.assertTrue(
+        "reply thread id must appear in both manifest and parent body op",
+        countOccurrences(deltaJson, "t+seedB") >= 2);
+  }
+
+  @Test
+  public void cursorAnchoredInlineReplyOmitsBodyOpForContinuationReply() {
+    // Continuation (sibling) replies do not produce a new <thread>, so
+    // there is nothing for a parent-body <reply> anchor to point at —
+    // the anchor op MUST be suppressed even when the caller passes a
+    // valid offset (defense-in-depth: the Java controller already
+    // guards against this, but the factory must not silently emit a
+    // dangling <reply id=…> referring to a non-existent thread).
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession baseSession =
+        new J2clSidecarWriteSession(
+            "example.com/w+reply",
+            "chan-7",
+            44L,
+            "ABCD",
+            "b+root",
+            Collections.<String>emptyList(),
+            6,
+            10,
+            7,
+            1,
+            Collections.singletonMap("b+root", Integer.valueOf(6)),
+            Collections.singletonMap("b+root", Integer.valueOf(7)),
+            Collections.singletonMap("b+root", Integer.valueOf(1)));
+    J2clSidecarWriteSession session = baseSession.forContinuationTarget("b+root");
+    J2clComposerDocument document =
+        J2clComposerDocument.builder().text("Continuation").build();
+
+    SidecarSubmitRequest request =
+        factory.createReplyRequest(
+            "user@example.com",
+            session,
+            document,
+            /* inlineAnchorItemOffset= */ 4,
+            /* parentBodyItemCount= */ 12);
+    String deltaJson = request.getDeltaJson();
+
+    Assert.assertFalse(
+        "continuation reply must not insert a <reply id=…> anchor in the parent body",
+        deltaJson.contains("\"1\":\"reply\""));
+  }
+
+  @Test
+  public void cursorAnchoredInlineReplyFallsBackToNoAnchorWhenOffsetMissing() {
+    // Legacy behavior: when wave-blip had no caret in the parent body
+    // (anchorItemOffset == -1), the factory must not emit a body op —
+    // the inline thread is created in the manifest only, mirroring the
+    // pre-anchor J2CL implementation. This keeps existing flows (e.g.
+    // keyboard-only reply with no selection) working.
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession(
+            "example.com/w+reply", "chan-7", 44L, "ABCD", "b+parent", 6, 8);
+    J2clComposerDocument document = J2clComposerDocument.builder().text("No anchor").build();
+
+    SidecarSubmitRequest request =
+        factory.createReplyRequest(
+            "user@example.com",
+            session,
+            document,
+            /* inlineAnchorItemOffset= */ -1,
+            /* parentBodyItemCount= */ 0);
+    String deltaJson = request.getDeltaJson();
+
+    Assert.assertFalse(
+        "no anchor → no parent-body <reply> element",
+        deltaJson.contains("\"1\":\"reply\""));
+    // Manifest op still creates the inline thread.
+    assertContains(deltaJson, "\"1\":\"thread\"");
+  }
+
+  @Test
   public void replyRequestAtInlineDepthLimitFallsBackToRegularSiblingReply() {
     J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
     J2clSidecarWriteSession session =

--- a/wave/config/changelog.d/2026-05-10-j2cl-cursor-anchored-inline-reply.json
+++ b/wave/config/changelog.d/2026-05-10-j2cl-cursor-anchored-inline-reply.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-10-j2cl-cursor-anchored-inline-reply",
+  "version": "J2CL parity",
+  "date": "2026-05-10",
+  "title": "J2CL inline replies now anchor at the user's caret inside the parent blip — matching the GWT client.",
+  "summary": "Clicking the toolbar Reply icon while the caret is inside a blip's body now creates an INLINE reply anchored at the caret's exact position, mirroring the GWT wave client. PR #1242 restored the per-blip continuation indicator (sibling reply) but the toolbar Reply still produced an unanchored child thread that rendered as a flat blip below the parent body. Now wave-blip captures the caret's wave-doc item offset (DOM text offset + leading <body> + line-tag items + existing anchor items), forwards it through the compose surface controller into J2clRichContentDeltaFactory, which emits an additional parent-blip body op inserting a <reply id=\"…\"> anchor element at that offset — exactly what GWT's WaveletBasedConversationBlip.addReplyThread(int location) does. Replies with no caret inside the blip body fall back to the legacy \"no anchor\" path so existing flows keep working.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "wave-blip's toolbar Reply now captures the caret's wave-doc item offset inside the parent body and forwards it on the wave-blip-reply-requested event detail (alongside parentBodyItemCount).",
+        "J2clRichContentDeltaFactory.createReplyRequest gains a 6-arg overload that emits a parent-blip body op inserting a <reply id=\"threadId\"> anchor element at the captured offset, paired with the existing manifest <thread> insert. Continuation (sibling) replies still suppress the anchor op since they have no thread to point at."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

GWT inserts a `<reply id="threadId">` anchor element into the parent blip's body XML at the user's caret position, so the new thread renders **inline at the caret's exact position** — see the user's GWT screenshot below where "test inline" appears mid-body. PR #1242 restored the per-blip continuation indicator (sibling reply) but the toolbar Reply icon still produced an unanchored child thread that rendered as a flat blip below the parent body — visible in the J2CL screenshot the user shared, where every reply lands as a sibling at the bottom.

This PR threads the caret offset all the way to the wave-doc op and emits the parent-body anchor element, mirroring GWT's `WaveletBasedConversationBlip.addReplyThread(int location)`.

### End-to-end pipeline

1. **`wave-blip.js`** — captures the caret's **wave-doc item offset** inside the rendered body (slotted text), accounting for:
   - 1 leading `<body>` element_start item.
   - Each rendered `\n` (= a `<line/>` tag in the wave-doc body) → 2 wave-doc items but 1 DOM char.
   - Each pre-existing inline-reply anchor before the caret → 2 items, 0 DOM chars (read off `data-inline-reply-anchors`).

   The walker iterates the body slot's flattened `assignedNodes` rather than the shadow body div, so Lit's template whitespace is excluded.

2. **`J2clComposeSurfaceView.java`** — extracts `anchorItemOffset` and `parentBodyItemCount` from the event detail and forwards them through a new `Listener` default method `onInlineReplyAnchorRequested(blipId, offset, bodyItemCount)`.

3. **`J2clComposeSurfaceController.java`** — stashes the triple until the next reply submit. Forwards the anchor to the factory only when the submit targets the **same blip** AND is **non-continuation**. Cleared after a successful submit.

4. **`J2clRichContentDeltaFactory.java`** — gains a 6-arg overload that emits an additional parent-blip body op:
   ```
   retain N | element_start "reply" id=threadId | element_end | retain (bodyItemCount - N)
   ```
   paired with the existing manifest `<thread>` + `<blip>` insert. Continuation (sibling) and depth-limited replies suppress the body op (no thread for the anchor to point at). The legacy 4-arg overload still works for the plain-text factory and unit-test doubles via a default forwarding impl, so no test mocks needed updating.

5. **No-caret fallback** — sends `-1` / `0` and the factory treats it as the legacy "no anchor" inline reply, keeping keyboard-only flows identical.

## Test plan

- [x] `cd j2cl/lit && npx web-test-runner` — **879/879 lit tests pass**, including 3 new `wave-blip` cases covering offset math, line-tag accounting, and the no-caret fallback.
- [x] `cd j2cl && ./mvnw -P search-sidecar test` — **1081/1081 J2CL Java tests pass**, including 3 new `J2clRichContentDeltaFactoryTest` cases asserting:
  - the parent-body op shape (retain offset + `<reply id=t+seedB>` + element_end + retain remainder),
  - the anchor op is suppressed for continuation/sibling replies,
  - the anchor op is suppressed when offset is -1 (legacy fallback path).
- [x] **Local browser probe**: registered fresh user, navigated to `?view=j2cl-root`. Programmatically constructed a `<wave-blip data-blip-doc-size="24">`, slotted in a body span with text "Hello world", placed a caret at DOM offset 5, clicked the toolbar Reply button. Captured event detail: `{blipId, waveId, anchorItemOffset: 6, parentBodyItemCount: 24}` — confirming `1 (body element_start) + 5 (DOM offset) + 0 (no \n before caret) = 6`. With no caret set, `anchorItemOffset: -1` (fallback).

## Follow-up to recent PRs

- Builds on [#1242](https://github.com/vega113/supawave/pull/1242) (continuation indicator restored). The toolbar Reply icon and the below-blip continuation trigger now produce **two distinct wave-model operations** matching GWT exactly:
  - **Toolbar Reply** → inline reply, anchored at the caret's exact position via the new parent-body op.
  - **Below-blip "↩ Reply"** → sibling reply at the same thread level via `replyManifestSiblingInsertPosition`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline replies now anchor at the user’s cursor inside a parent message so new threads appear inline at the caret; legacy behavior is used when no caret is found or for continuation/sibling replies.
* **Tests**
  * Added coverage validating cursor-to-offset calculations, line-break handling, fallback when no caret exists, and anchoring vs. continuation behavior.
* **Chores**
  * Added changelog entry documenting cursor-anchored inline replies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1243)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->