### PR TITLE
J2CL parity: scroll to last unread blip on wave open

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -91,6 +91,11 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   private String serverFirstMode;
   private double serverFirstMountedAtMs;
   private String lastRenderedWaveId = "";
+  // GWT parity (FocusBlipSelector.selectInitialBlip): when a wave is opened,
+  // scroll/focus to the last unread blip, falling back to the last blip.
+  // Set when lastRenderedWaveId transitions to a new (non-empty) wave; cleared
+  // once initial focus has been applied to a non-empty rendered surface.
+  private String pendingInitialFocusWaveId = "";
   // F-3.S3 (#1038, R-5.5): publisher installed by the root shell to
   // forward per-blip reaction snapshots to the compose controller.
   private ReactionSnapshotPublisher reactionSnapshotPublisher;
@@ -638,6 +643,10 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   }
 
   private void focusBlip(HTMLElement target) {
+    focusBlip(target, /* markRead= */ true);
+  }
+
+  private void focusBlip(HTMLElement target, boolean markRead) {
     if (target == null) {
       return;
     }
@@ -659,7 +668,9 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     FocusOptionsType focusOptions = FocusOptionsType.create();
     focusOptions.setPreventScroll(true);
     target.focus(focusOptions);
-    readSurface.markFocusedBlipReadNow(target);
+    if (markRead) {
+      readSurface.markFocusedBlipReadNow(target);
+    }
     ScrollIntoViewOptions scrollOptions = ScrollIntoViewOptions.create();
     scrollOptions.setBlock("center");
     scrollOptions.setInline("nearest");
@@ -721,6 +732,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     if (!renderedWaveId.equals(lastRenderedWaveId)) {
       readSurface.clearViewportScrollMemory();
       lastRenderedWaveId = renderedWaveId;
+      pendingInitialFocusWaveId = renderedWaveId;
     }
     publishReactionState(model);
     // F-2 (#1037, R-3.1) — surface the wave id on the content host so the
@@ -756,6 +768,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     }
     if (shouldPreserveServerFirstCard(model)) {
       renderPreservedServerFirstState(model);
+      maybeApplyInitialFocus(renderedWaveId, model);
       return;
     }
 
@@ -835,6 +848,47 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
             model.getSelectedWaveId() != null && !model.getSelectedWaveId().isEmpty());
       }
     }
+
+    if (hasRenderedReadSurface) {
+      maybeApplyInitialFocus(renderedWaveId, model);
+    }
+  }
+
+  /**
+   * GWT parity: on the first render of a freshly-opened wave, scroll/focus to
+   * the last unread blip (matching {@code FocusBlipSelector.selectLastUnread}).
+   * If every loaded blip is read, fall back to the last rendered blip
+   * ({@code FocusBlipSelector.selectInitialBlip} step 3). On a no-op render
+   * with no loaded blips yet, the pending flag is preserved so a subsequent
+   * render can apply the focus once content lands.
+   */
+  private void maybeApplyInitialFocus(String renderedWaveId, J2clSelectedWaveModel model) {
+    if (pendingInitialFocusWaveId.isEmpty()
+        || !pendingInitialFocusWaveId.equals(renderedWaveId)
+        || !model.hasSelection()) {
+      return;
+    }
+    List<HTMLElement> blips = renderedBlips();
+    if (blips.isEmpty()) {
+      return;
+    }
+    HTMLElement target = null;
+    for (int i = blips.size() - 1; i >= 0; i--) {
+      HTMLElement blip = blips.get(i);
+      if (blip.hasAttribute("unread")) {
+        target = blip;
+        break;
+      }
+    }
+    if (target == null) {
+      target = blips.get(blips.size() - 1);
+    }
+    pendingInitialFocusWaveId = "";
+    // Auto-focus on wave-open mirrors GWT's selectInitialBlip + FocusFramePresenter.focus.
+    // GWT marks blips read via dwell-based Reader observers, not on focus, so the
+    // J2CL parity path skips the immediate mark-read side effect; the first user
+    // action (next-unread key, click, or scroll dwell) takes that responsibility.
+    focusBlip(target, /* markRead= */ false);
   }
 
   private void publishTaskBinder(J2clSelectedWaveModel model) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -732,7 +732,9 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     if (!renderedWaveId.equals(lastRenderedWaveId)) {
       readSurface.clearViewportScrollMemory();
       lastRenderedWaveId = renderedWaveId;
-      pendingInitialFocusWaveId = renderedWaveId;
+      if (!renderedWaveId.isEmpty()) {
+        pendingInitialFocusWaveId = renderedWaveId;
+      }
     }
     publishReactionState(model);
     // F-2 (#1037, R-3.1) — surface the wave id on the content host so the

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -788,6 +788,41 @@ public class J2clSelectedWaveViewChromeTest {
   }
 
   @Test
+  public void initialRenderFocusesLastUnreadBlip() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+    view.render(navigationModel());
+
+    // navigationModel has b+1 (read), b+2 (unread), b+3 (read). The last unread is b+2.
+    HTMLElement expected = (HTMLElement) host.querySelector("wave-blip[data-blip-id='b+2']");
+    Assert.assertNotNull("Unread blip b+2 must be in the DOM", expected);
+    Assert.assertEquals(
+        "Initial wave open must focus the last unread blip",
+        expected,
+        DomGlobal.document.activeElement);
+  }
+
+  @Test
+  public void initialRenderDoesNotMarkUnreadBlipRead() {
+    assumeBrowserDom();
+    HTMLElement host = createHost();
+    J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+    final List<String> markedRead = new ArrayList<String>();
+    view.setMarkBlipReadHandler((blipId, onError) -> markedRead.add(blipId));
+    view.render(navigationModel());
+
+    Assert.assertTrue(
+        "Auto-focus on wave open must not trigger mark-read (GWT defers read to dwell observers)",
+        markedRead.isEmpty());
+    HTMLElement unreadBlip = (HTMLElement) host.querySelector("wave-blip[data-blip-id='b+2']");
+    Assert.assertNotNull("Unread blip b+2 must be in the DOM", unreadBlip);
+    Assert.assertTrue(
+        "Auto-focus on wave open must not clear the unread attribute",
+        unreadBlip.hasAttribute("unread"));
+  }
+
+  @Test
   public void selectedWaveRefreshEventInvokesRefreshHandler() {
     assumeBrowserDom();
     HTMLElement host = createHost();

--- a/wave/config/changelog.d/2026-05-10-j2cl-scroll-to-last-unread-blip.json
+++ b/wave/config/changelog.d/2026-05-10-j2cl-scroll-to-last-unread-blip.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-10-j2cl-scroll-to-last-unread-blip",
+  "version": "PR #1244",
+  "date": "2026-05-10",
+  "title": "J2CL parity: scroll to last unread blip on wave open",
+  "summary": "Opening a wave in the J2CL client now focuses and scrolls to the last unread blip (falling back to the last rendered blip when everything is read), matching GWT's FocusBlipSelector.selectInitialBlip behavior.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "J2clSelectedWaveView tracks the wave-id transition already used to clear viewport scroll memory, and after the first render that produces content scans rendered blips right-to-left for the `unread` DOM marker, focusing that blip (or the last rendered blip if none are unread) and scrolling it into view via the existing focusBlip path.",
+        "Skips the immediate mark-read side effect on auto-focus — GWT's Reader marks via dwell observers — so on wave open J2CL positions only and leaves read-marking to the user's first interaction."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- GWT's `FocusBlipSelector.selectInitialBlip` scrolls and focuses the **last unread** blip when a wave is opened, falling back to the last blip when everything is read. J2CL only anchored to whatever the server pre-rendered first, leaving readers landing at the top of the wave instead of at the natural "where I left off" position.
- On the first render of a freshly-opened wave, scan rendered blips right-to-left for the `unread` DOM marker the read renderer already sets, then focus + `scrollIntoView` that blip (or the last rendered blip if none are unread).
- Auto-focus skips the immediate `markFocusedBlipReadNow` side-effect — GWT's `Reader` marks blips via dwell observers, not on focus, so on auto-scroll we position only and leave read-marking to the user's first interaction (next-unread key, click, scroll dwell).

## Implementation notes
- `pendingInitialFocusWaveId` is set whenever `lastRenderedWaveId` transitions to a new wave (mirroring the existing scroll-memory clear). It is cleared only after a render produces content and we apply the focus, so transient renders that happen before any blips load do not lose the focus intent.
- `focusBlip` gained an overload that takes a `markRead` flag; existing keyboard / click paths still mark-read instantly. Only the wave-open auto-focus path passes `markRead=false`.
- Both the cold-mount render path and the server-first preserved-card branch invoke `maybeApplyInitialFocus`, so wave swaps that reuse server-rendered cards behave identically to fresh client renders.

## Test plan
- [ ] `./mvnw test -Dtest='J2clSelectedWaveView*Test'` (passes locally — 54 run, 0 failures, 42 skipped pre-existing)
- [ ] Open a wave with several unread blips; viewport should land at the most recent unread, matching GWT
- [ ] Open a fully-read wave; viewport should land at the last blip
- [ ] Switch between two waves repeatedly; each switch re-applies the auto-scroll
- [ ] Live update on the currently open wave does not re-jump focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initial focus/scroll behavior when opening a conversation: the client now jumps to the last unread item, falling back to the last rendered item if none are unread.
  * Adjusted auto-focus so it no longer immediately marks items as read; read status is preserved until user interaction.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1244)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->