### PR TITLE
J2CL: drop redundant editor border in new-blip edit mode

### DIFF
--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -444,14 +444,18 @@ export class WavyComposer extends LitElement {
       min-height: 32px;
       padding: 6px 8px;
       border-radius: var(--wavy-radius-card, 4px);
-      border: 1px solid var(--wavy-border-hairline, #e2e8f0);
+      /* Transparent placeholder so the drag-drop state below can paint a
+       * cyan outline without shifting layout. The static hairline that
+       * used to live here drew a redundant line across the middle of the
+       * compose card — wavy-compose-card already supplies the focus
+       * envelope. */
+      border: 1px solid transparent;
       background: #f8fafc;
       color: var(--wavy-text-body, #1a202c);
       outline: none;
       font: var(--wavy-type-body, 13px / 1.35 Arial, sans-serif);
     }
     [data-composer-body]:focus-visible {
-      border-color: #90cdf4;
       box-shadow: none;
       background: #ffffff;
     }

--- a/wave/config/changelog.d/2026-05-10-j2cl-composer-border.json
+++ b/wave/config/changelog.d/2026-05-10-j2cl-composer-border.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-10-j2cl-composer-border",
+  "version": "PR #1245",
+  "date": "2026-05-10",
+  "title": "J2CL: cleaner new-blip edit surface",
+  "summary": "Removed a redundant inner border on the J2CL inline composer that visually read as a horizontal line across the middle of a new blip in edit mode.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Drop the static hairline border on the contenteditable composer body; the surrounding compose card already provides the focus envelope, and the drop-target outline still renders on drag-over."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- The J2CL inline composer painted a 1px hairline `border` on `[data-composer-body]` inside `wavy-composer.js`. The outer `wavy-compose-card` already supplies its own card border + focus envelope, so the inner rule drew a redundant rectangle.
- With an empty draft (just `@` from the mention trigger, for example) the inner rectangle collapses to roughly one line tall and visually reads as a horizontal stripe across the middle of the new-blip edit surface — the user-reported "strikethrough" line.
- Replaced the static border with `1px solid transparent` so the existing `[data-composer-body][data-droptarget="true"]` rule can still paint a cyan outline on drag-over without shifting layout, and removed the now-redundant `border-color` override on `:focus-visible`.

## Test plan
- [x] `web-test-runner test/wavy-composer.test.js` — 56/56 passing.
- [ ] Reviewer: open a wave, start a new reply / inline reply, confirm the inner hairline rectangle around the contenteditable is gone while the surrounding compose card still shows its focus state.
- [ ] Reviewer: drag a file over the composer body, confirm the cyan drop-target outline still appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed redundant border line from the inline composer's edit surface, improving visual clarity while maintaining proper layout stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1245)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->