### PR TITLE
fix(j2cl): preserve text selection across toolbar Reply (caret-anchored inline replies)

### DIFF
--- a/j2cl/lit/src/elements/wave-blip-toolbar.js
+++ b/j2cl/lit/src/elements/wave-blip-toolbar.js
@@ -115,6 +115,24 @@ export class WaveBlipToolbar extends LitElement {
         data-toolbar-action="reply"
         aria-label=${replyAction}
         title=${replyAction}
+        @mousedown=${(e) => {
+          // Preserve the user's text selection in the parent blip body
+          // so _onReplyClick can read it via window.getSelection(). Without
+          // preventDefault the button takes focus on mousedown and the
+          // browser collapses the selection, defeating caret-anchored
+          // inline reply (#1243).
+          e.preventDefault();
+          // Bubble a pre-click signal so wave-blip can capture the caret
+          // offset *before* the click handler runs, even on browsers that
+          // mutate the selection despite preventDefault.
+          this.dispatchEvent(
+            new CustomEvent("wave-blip-toolbar-reply-mousedown", {
+              bubbles: true,
+              composed: true,
+              detail: { blipId: this.blipId, waveId: this.waveId }
+            })
+          );
+        }}
         @click=${() => this._emit("wave-blip-toolbar-reply")}
       >
         <span class="glyph" aria-hidden="true">↩</span><span class="label">${t("blipToolbar.reply", "Reply")}</span>

--- a/j2cl/lit/src/elements/wave-blip-toolbar.js
+++ b/j2cl/lit/src/elements/wave-blip-toolbar.js
@@ -104,6 +104,19 @@ export class WaveBlipToolbar extends LitElement {
     );
   }
 
+  _onReplyMouseDown(e) {
+    // Preserve the user's text selection in the parent blip body
+    // so _onReplyClick can read it via window.getSelection(). Without
+    // preventDefault the button takes focus on mousedown and the
+    // browser collapses the selection, defeating caret-anchored
+    // inline reply (#1243).
+    e.preventDefault();
+    // Bubble a pre-click signal so wave-blip can capture the caret
+    // offset *before* the click handler runs, even on browsers that
+    // mutate the selection despite preventDefault.
+    this._emit("wave-blip-toolbar-reply-mousedown");
+  }
+
   render() {
     const replyAction = t("blipToolbar.replyAction", "Reply to this blip");
     const editAction = t("blipToolbar.editAction", "Edit this blip");
@@ -115,24 +128,7 @@ export class WaveBlipToolbar extends LitElement {
         data-toolbar-action="reply"
         aria-label=${replyAction}
         title=${replyAction}
-        @mousedown=${(e) => {
-          // Preserve the user's text selection in the parent blip body
-          // so _onReplyClick can read it via window.getSelection(). Without
-          // preventDefault the button takes focus on mousedown and the
-          // browser collapses the selection, defeating caret-anchored
-          // inline reply (#1243).
-          e.preventDefault();
-          // Bubble a pre-click signal so wave-blip can capture the caret
-          // offset *before* the click handler runs, even on browsers that
-          // mutate the selection despite preventDefault.
-          this.dispatchEvent(
-            new CustomEvent("wave-blip-toolbar-reply-mousedown", {
-              bubbles: true,
-              composed: true,
-              detail: { blipId: this.blipId, waveId: this.waveId }
-            })
-          );
-        }}
+        @mousedown=${this._onReplyMouseDown}
         @click=${() => this._emit("wave-blip-toolbar-reply")}
       >
         <span class="glyph" aria-hidden="true">↩</span><span class="label">${t("blipToolbar.reply", "Reply")}</span>

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -412,6 +412,8 @@ export class WaveBlip extends LitElement {
     this.dataBlipFocused = null;
     this._participants = [];
     this.authorAvatarUrl = "";
+    this._capturedReplyAnchorOffset = undefined;
+    this._capturedReplyAnchorCapturedAt = undefined;
   }
 
   /**
@@ -591,7 +593,10 @@ export class WaveBlip extends LitElement {
     // with preventDefault on some engines — so the click-time selection
     // may already be gone. The mousedown capture runs *before* any
     // selection mutation and is the authoritative anchor.
-    let anchorItemOffset = this._capturedReplyAnchorOffset;
+    const hasFreshCapture =
+      typeof this._capturedReplyAnchorCapturedAt === "number" &&
+      Date.now() - this._capturedReplyAnchorCapturedAt < 1000;
+    let anchorItemOffset = hasFreshCapture ? this._capturedReplyAnchorOffset : undefined;
     if (
       typeof anchorItemOffset !== "number" ||
       !Number.isFinite(anchorItemOffset)
@@ -599,6 +604,7 @@ export class WaveBlip extends LitElement {
       anchorItemOffset = this._currentSelectionItemOffsetWithinBody();
     }
     this._capturedReplyAnchorOffset = undefined;
+    this._capturedReplyAnchorCapturedAt = undefined;
     this.dispatchEvent(
       new CustomEvent("wave-blip-reply-requested", {
         bubbles: true,
@@ -622,7 +628,8 @@ export class WaveBlip extends LitElement {
     // ignores the preventDefault on cross-shadow buttons.
     event.stopPropagation();
     this._capturedReplyAnchorOffset =
-        this._currentSelectionItemOffsetWithinBody();
+      this._currentSelectionItemOffsetWithinBody();
+    this._capturedReplyAnchorCapturedAt = Date.now();
   }
 
   /**

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -584,7 +584,21 @@ export class WaveBlip extends LitElement {
     // wave op still creates the child thread in the manifest, but no
     // anchor is inserted, so the reply renders as a flat child below
     // the body (legacy J2CL behavior).
-    const anchorItemOffset = this._currentSelectionItemOffsetWithinBody();
+    //
+    // Prefer the offset captured on the toolbar Reply button's mousedown
+    // (see _onReplyToolbarMouseDown). The browser collapses non-editable
+    // text selections when a button receives focus on mousedown — even
+    // with preventDefault on some engines — so the click-time selection
+    // may already be gone. The mousedown capture runs *before* any
+    // selection mutation and is the authoritative anchor.
+    let anchorItemOffset = this._capturedReplyAnchorOffset;
+    if (
+      typeof anchorItemOffset !== "number" ||
+      !Number.isFinite(anchorItemOffset)
+    ) {
+      anchorItemOffset = this._currentSelectionItemOffsetWithinBody();
+    }
+    this._capturedReplyAnchorOffset = undefined;
     this.dispatchEvent(
       new CustomEvent("wave-blip-reply-requested", {
         bubbles: true,
@@ -597,6 +611,18 @@ export class WaveBlip extends LitElement {
         }
       })
     );
+  }
+
+  _onReplyToolbarMouseDown(event) {
+    // Capture the caret/selection offset the instant the user presses the
+    // toolbar Reply button — *before* the browser shifts focus and
+    // potentially collapses the selection. The toolbar's mousedown handler
+    // calls preventDefault to discourage the focus shift, but we still
+    // capture defensively so this works even if a future browser change
+    // ignores the preventDefault on cross-shadow buttons.
+    event.stopPropagation();
+    this._capturedReplyAnchorOffset =
+        this._currentSelectionItemOffsetWithinBody();
   }
 
   /**
@@ -952,6 +978,7 @@ export class WaveBlip extends LitElement {
             data-blip-id=${this.blipId}
             data-wave-id=${this.waveId}
             data-variant=${visuallyFocused ? "focused" : "default"}
+            @wave-blip-toolbar-reply-mousedown=${this._onReplyToolbarMouseDown}
             @wave-blip-toolbar-reply=${this._onReplyClick}
             @wave-blip-toolbar-edit=${this._onEditClick}
             @wave-blip-toolbar-link=${this._onLinkClick}

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -233,6 +233,52 @@ describe("<wave-blip>", () => {
     expect(el._currentSelectionItemOffsetWithinBody()).to.equal(9);
   });
 
+  // GWT parity: when the user has a text selection inside the parent
+  // blip body and clicks the toolbar Reply button, the browser collapses
+  // the selection on mousedown (the button receives focus). We capture
+  // the offset on the toolbar button's mousedown — *before* the focus
+  // shift — and use that captured value at click time, so the resulting
+  // wave-blip-reply-requested event still carries the correct anchor.
+  it(
+    "uses the mousedown-captured offset on click even when selection is cleared",
+    async () => {
+      const el = await fixture(html`<wave-blip
+        data-blip-id="b7"
+        data-wave-id="w7"
+        author-name="A"
+        data-blip-doc-size="50"
+      ></wave-blip>`);
+      await el.updateComplete;
+      const span = attachBlipContent(el, "Hello world");
+      const textNode = span.firstChild;
+      // Place a caret at DOM offset 5 → wave-doc item offset 6.
+      const range = document.createRange();
+      range.setStart(textNode, 5);
+      range.collapse(true);
+      const selection = window.getSelection();
+      selection.removeAllRanges();
+      selection.addRange(range);
+
+      const toolbar = el.renderRoot.querySelector("wave-blip-toolbar");
+      await toolbar.updateComplete;
+      const replyBtn = toolbar.renderRoot.querySelector(
+        "[data-toolbar-action='reply']"
+      );
+
+      // Simulate the real browser sequence: mousedown captures offset,
+      // then the browser collapses the selection (we clear it manually
+      // here), then click fires.
+      replyBtn.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true, composed: true })
+      );
+      window.getSelection().removeAllRanges();
+      setTimeout(() => replyBtn.click(), 0);
+      const ev = await oneEvent(el, "wave-blip-reply-requested");
+      expect(ev.detail.anchorItemOffset).to.equal(6);
+      expect(ev.detail.parentBodyItemCount).to.equal(50);
+    }
+  );
+
   // No selection / caret outside the blip body → -1, telling the
   // controller to fall back to the legacy "no anchor" path.
   it("returns -1 when no caret lies inside the blip body", async () => {

--- a/wave/config/changelog.d/2026-05-10-j2cl-toolbar-reply-preserve-selection.json
+++ b/wave/config/changelog.d/2026-05-10-j2cl-toolbar-reply-preserve-selection.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-10-j2cl-toolbar-reply-preserve-selection",
+  "version": "J2CL parity",
+  "date": "2026-05-10",
+  "title": "J2CL toolbar Reply now preserves the text selection so caret-anchored inline replies actually land at the caret.",
+  "summary": "PR #1243 wired the caret-anchor plumbing end-to-end (wave-blip captures the offset, the controller forwards it, the factory emits the body op), but the toolbar Reply button only had an @click handler. The blip body is not contenteditable, so when the user pressed the button the browser's default mousedown moved focus to the button and collapsed the text selection BEFORE @click ran — making _currentSelectionItemOffsetWithinBody return -1 every time and routing through the legacy \"no anchor\" fallback (the blip rendered at the bottom of the thread instead of inline at \"draw\"). The toolbar Reply now calls preventDefault on mousedown to keep the selection alive, and wave-blip captures the caret offset on mousedown as defense-in-depth for browsers that ignore preventDefault on cross-shadow buttons.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "wave-blip-toolbar's Reply button calls event.preventDefault() on mousedown so the user's text selection in the (non-contenteditable) parent blip body is preserved across the click — matching the well-established rich-text-editor toolbar pattern. The button still receives the click event normally.",
+        "wave-blip captures the caret's wave-doc item offset on mousedown (via a new wave-blip-toolbar-reply-mousedown event) and uses that captured value at click time, falling back to the live selection only when the mousedown capture didn't fire. This keeps caret-anchored inline reply working even on engines that mutate the selection despite preventDefault."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Bug: PR #1243 wired the caret-anchor plumbing end-to-end, but selecting a word in a J2CL blip body and clicking the toolbar Reply icon still produced a blip pinned to the bottom of the thread instead of an inline reply embedded at the selection.
- Root cause: the blip body is **not** contenteditable, so the browser's default mousedown on the Reply button moved focus to the button and **collapsed the user's text selection** before `@click` ran. By click time `_currentSelectionItemOffsetWithinBody()` returned -1, the controller routed through the legacy "no anchor" fallback, and the new blip rendered as a flat child below the parent body.
- Fix: standard rich-text-editor toolbar pattern — `event.preventDefault()` on the button's `mousedown` to stop the focus shift, plus a defensive on-mousedown capture of the caret offset (via a new `wave-blip-toolbar-reply-mousedown` event) so this works even if a future engine ignores `preventDefault` on cross-shadow buttons.

## Repro (before this PR)
1. Open a wave in J2CL.
2. Select a word inside a parent blip body (e.g. "draw").
3. Click the toolbar **Reply** icon.
4. Type something and submit.
5. **Before:** new blip appears at the bottom of the thread (unanchored child).
6. **After (matches GWT):** new blip renders inline, embedded at the "draw" selection inside the parent body.

## Files
- [j2cl/lit/src/elements/wave-blip-toolbar.js](https://github.com/vega113/supawave/blob/claude/pedantic-goldstine-bad15e/j2cl/lit/src/elements/wave-blip-toolbar.js) — Reply button: `@mousedown` handler calls `preventDefault()` and emits `wave-blip-toolbar-reply-mousedown`.
- [j2cl/lit/src/elements/wave-blip.js](https://github.com/vega113/supawave/blob/claude/pedantic-goldstine-bad15e/j2cl/lit/src/elements/wave-blip.js) — `_onReplyToolbarMouseDown` stashes the offset; `_onReplyClick` prefers the stashed value, falls back to the live selection.
- [j2cl/lit/test/wave-blip.test.js](https://github.com/vega113/supawave/blob/claude/pedantic-goldstine-bad15e/j2cl/lit/test/wave-blip.test.js) — regression test reproducing the failing sequence.
- `wave/config/changelog.d/2026-05-10-j2cl-toolbar-reply-preserve-selection.json` — changelog entry.

## Test plan
- [x] `npx web-test-runner` — all 880/880 lit tests pass; new test covers the exact failing browser sequence (caret placed → mousedown → selection cleared → click → event must still carry the correct offset).
- [x] No Java changes; existing J2CL Java tests unaffected.
- [ ] Manual smoke in browser: select a word in a blip, click Reply, type and submit, confirm new blip is embedded inline at the selection (matches GWT screenshot in the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reply now preserves the user's text selection/caret so inline replies land at the intended position even if selection changes between initiating and confirming the reply.

* **Tests**
  * Added a test ensuring reply behavior still captures the correct anchor when selection is cleared between mousedown and click.

* **Documentation**
  * Added changelog entry describing the Reply preservation fix.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1246)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->