### PR TITLE
J2CL parity: restore @-mention popover on every inline composer surface

### DIFF
--- a/docs/superpowers/plans/2026-05-10-j2cl-mention-fix-plan.md
+++ b/docs/superpowers/plans/2026-05-10-j2cl-mention-fix-plan.md
@@ -1,0 +1,96 @@
+# J2CL @-mention popover restoration plan (2026-05-10)
+
+## Problem
+
+The J2CL inline composer's `@`-mention picker does not appear in the live UI,
+while the GWT version does. PR #1138 (G-PORT-5) shipped the popover code and
+PR #1135 fixed the controller-side participants timing. The `wavy-composer.js`
+unit test suite (56 tests, including the four R-5.3 mention cases) passes —
+which proves the popover trigger works when `<wavy-composer>.participants`
+is set. So the regression is at the integration seam between the J2CL Java
+view and the freshly-mounted inline `<wavy-composer>` element.
+
+## Root cause (by code inspection)
+
+`J2clComposeSurfaceView.openInlineComposer` mounts the inline composer and
+then calls `mirrorComposerStateFromReplyElement(composer)` to seed every
+property. For `participants`, that helper reads the value back off the
+**legacy** `<composer-inline-reply>` element, which gets the participants
+list set on it as a JS expando inside `render()` (line 437):
+
+```java
+setProperty(replyElement, "participants",
+    buildParticipantsArray(model.getParticipantAddresses()));
+```
+
+This works only when `render()` has been called at least once after the
+controller has populated `selectedWaveParticipantIds` AND the inline composer
+mounts AFTER that render. Two failure modes follow:
+
+1. Mount BEFORE first participants-bearing render. `replyElement.participants`
+   is undefined / empty; the inline composer is mounted with empty
+   `participants`; the popover renders an empty candidates list when `@`
+   is typed.
+2. The replyElement transport is fragile — any path that detaches/re-creates
+   `<composer-inline-reply>` or wipes its expandos drops participants.
+
+The mounted composer eventually picks up participants on the next full
+`render()` (line 684 in `mirrorComposerState`), but by then the user has
+already typed `@` and seen "no candidates", which reads as "the picker
+doesn't show".
+
+## Fix
+
+Stop relying on the legacy `<composer-inline-reply>` element as the
+participant transport. Add a direct accessor on the `Listener` interface
+that returns the controller's current participants list, and make
+`mirrorComposerStateFromReplyElement` prefer that accessor over the
+expando.
+
+### Files to change
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java`
+  - Add a default `getCurrentParticipantAddresses()` method on `Listener`
+    that returns an empty list (so existing test doubles compile unchanged).
+  - Override it in the controller's anonymous Listener at the
+    `J2clComposeSurfaceController.this` site to return
+    `participantsForCurrentSelection()`.
+
+- `j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java`
+  - In `mirrorComposerStateFromReplyElement(composer)`, query the listener
+    for participants first; only fall back to the replyElement expando
+    when the listener returns an empty / null list.
+  - This fixes the timing race by reading from the authoritative source
+    (the controller) instead of the snapshot left on the legacy element.
+
+### Tests
+
+- Existing `j2cl/lit/test/wavy-composer.test.js` (56 tests) must still pass —
+  the popover trigger contract is unchanged.
+- Existing `j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java`
+  (mention serialisation / abandonment cases) must still pass.
+
+### Verification
+
+- `cd j2cl/lit && npx web-test-runner --files "test/wavy-composer.test.js"`
+  → all green.
+- `sbt wave/compile` → green.
+- Manual: open a wave (welcome wave or freshly created one), click Reply on
+  any blip, type `@`. The popover must appear with the wave's participants
+  as candidates.
+
+## Out of scope
+
+- Visual / styling changes to the popover.
+- Mention chip serialisation (already covered by PR #1138 and exercised by
+  the controller tests).
+- Changing how `<composer-inline-reply>` exposes participants — the legacy
+  element's expando stays as a defensive fallback so any non-J2CL caller
+  still works.
+
+## Risks
+
+- Low blast radius: the change adds a single read path; the existing
+  expando read survives as a fallback.
+- The new listener method has a default empty implementation, so test
+  doubles (Mockito or hand-rolled) compile unchanged.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -254,6 +254,21 @@ public final class J2clComposeSurfaceController {
     }
 
     /**
+     * Returns the participant addresses for the currently selected wave so
+     * a freshly mounted inline {@code <wavy-composer>} can populate the
+     * mention popover candidate list at mount time. Without this direct
+     * read, the view has to pick the list off the legacy
+     * {@code <composer-inline-reply>} element's expando, which is empty
+     * until the controller's first participants-bearing render — so a
+     * user who types {@code @} between mount and that render sees an
+     * empty popover. Default returns an empty list so existing test
+     * doubles compile unchanged.
+     */
+    default List<String> getCurrentParticipantAddresses() {
+      return Collections.<String>emptyList();
+    }
+
+    /**
      * F-3.S4 (#1038, R-5.6 step 1): the user dropped files into the
      * composer body. The controller routes through the same plumbing
      * as {@link #onAttachmentFilesSelected} (default delegates) so
@@ -1016,6 +1031,11 @@ public final class J2clComposeSurfaceController {
             List<SidecarReactionEntry> s = reactionSnapshotsByBlip.get(blipId.trim());
             return s != null ? new ArrayList<SidecarReactionEntry>(s)
                 : Collections.<SidecarReactionEntry>emptyList();
+          }
+
+          @Override
+          public List<String> getCurrentParticipantAddresses() {
+            return J2clComposeSurfaceController.this.participantsForCurrentSelection();
           }
 
           @Override

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -694,17 +694,23 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     setProperty(composer, "activeCommand", propertyString(replyElement, "activeCommand"));
     setProperty(composer, "commandStatus", propertyString(replyElement, "commandStatus"));
     setProperty(composer, "commandError", propertyString(replyElement, "commandError"));
-    // G-PORT-5 (#1114): participants must mirror onto a freshly mounted
-    // inline composer at construction time, otherwise the user sees an
-    // empty popover when typing `@` in the gap between mount and the
-    // controller's next full render() — the gap most users notice
-    // because the inline composer is opened mid-render. The reply
-    // element carries the canonical participants list (set in render()
-    // above); forwarding it here makes the inline composer mention-
-    // ready from its first paint.
-    Object participants = property(replyElement, "participants");
-    if (participants != null) {
-      setProperty(composer, "participants", participants);
+    // Read participants directly from the controller. The legacy
+    // <composer-inline-reply> expando (set in render() above) is empty
+    // until the controller has projected its first participants-bearing
+    // render, so a user who clicks Reply and immediately types `@` saw
+    // an empty popover even though the wave's participants were known.
+    // The controller's own selection state is authoritative; fall back
+    // to the legacy element only if the listener is not bound or
+    // returns nothing.
+    List<String> direct =
+        listener == null ? null : listener.getCurrentParticipantAddresses();
+    if (direct != null && !direct.isEmpty()) {
+      setProperty(composer, "participants", buildParticipantsArray(direct));
+    } else {
+      Object participants = property(replyElement, "participants");
+      if (participants != null) {
+        setProperty(composer, "participants", participants);
+      }
     }
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -133,6 +133,29 @@ public class J2clComposeSurfaceControllerTest {
   }
 
   @Test
+  public void listenerExposesCurrentParticipantsToFreshlyMountedInlineComposer() {
+    // Regression for the @-mention popover failing on the wave-root /
+    // toolbar-Reply / per-blip continuation surfaces. When the inline
+    // <wavy-composer> mounts via openInlineComposer, the view used to
+    // pull participants off the legacy <composer-inline-reply> expando.
+    // That expando is empty until the controller's first participants-
+    // bearing render(), so a user clicking Reply and immediately typing
+    // `@` saw an empty popover. The view now reads from this listener
+    // method, which returns the controller's authoritative selection.
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(new FakeGateway(), view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onSelectedWaveComposeContextChanged(
+        "example.com/w+1", null, Arrays.asList("alice@example.com", "bob@example.com"));
+
+    Assert.assertEquals(
+        Arrays.asList("alice@example.com", "bob@example.com"),
+        view.listener.getCurrentParticipantAddresses());
+  }
+
+  @Test
   public void selectedWaveParticipantsClearOnDifferentSelectedWave() {
     FakeView view = new FakeView();
     J2clComposeSurfaceController controller =
@@ -4774,6 +4797,7 @@ public class J2clComposeSurfaceControllerTest {
 
   private static final class FakeView implements J2clComposeSurfaceController.View {
     private J2clComposeSurfaceModel model;
+    private J2clComposeSurfaceController.Listener listener;
     private int openAttachmentPickerCalls;
     private int focusReplyComposerCalls;
     private int focusCreateSurfaceCalls;
@@ -4782,6 +4806,7 @@ public class J2clComposeSurfaceControllerTest {
 
     @Override
     public void bind(J2clComposeSurfaceController.Listener listener) {
+      this.listener = listener;
     }
 
     @Override

--- a/wave/config/changelog.d/2026-05-10-j2cl-mention-popover-participants.json
+++ b/wave/config/changelog.d/2026-05-10-j2cl-mention-popover-participants.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-10-j2cl-mention-popover-participants",
+  "version": "J2CL parity",
+  "date": "2026-05-10",
+  "title": "J2CL @-mention popover now lists the wave's participants on every inline composer surface.",
+  "summary": "Typing @ inside a freshly-opened J2CL inline composer (toolbar-Reply, wave-root reply, per-blip Edit, or per-blip continuation) now opens the mention suggestion popover with the wave's participant list — matching the GWT client. The view used to read the participants list off the legacy <composer-inline-reply> element's expando, which was empty until the controller's first participants-bearing render(); a user who clicked Reply and immediately typed @ saw an empty popover. The view now reads from a new Listener.getCurrentParticipantAddresses() accessor that returns the controller's authoritative participantsForCurrentSelection() value, so the popover is mention-ready from the very first paint.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "J2clComposeSurfaceController.Listener gains a default getCurrentParticipantAddresses() returning the empty list; the controller's anonymous Listener overrides it to return participantsForCurrentSelection().",
+        "J2clComposeSurfaceView.mirrorComposerStateFromReplyElement now prefers the listener's participants list and falls back to the legacy <composer-inline-reply> expando only when the listener is not bound or returns nothing."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `Listener.getCurrentParticipantAddresses()` so the J2CL view can read the controller's authoritative `participantsForCurrentSelection()` directly when mounting a fresh inline `<wavy-composer>`.
- Switches `J2clComposeSurfaceView.mirrorComposerStateFromReplyElement` to prefer that listener over the legacy `<composer-inline-reply>` expando — fixing the empty-popover regression on toolbar-Reply, wave-root reply, per-blip Edit, and per-blip continuation surfaces.
- Keeps the expando read as a defensive fallback so test doubles that omit the listener still work.

The popover code itself shipped in #1138 (G-PORT-5) and the controller-side participants timing was fixed in #1135. The remaining gap was the view→composer seam: the legacy expando is empty until the controller's first participants-bearing render(), so a user who clicked Reply and immediately typed `@` saw an empty popover.

## Test plan

- [x] `cd j2cl/lit && npm test` — 879/879 lit tests pass.
- [x] `j2cl/mvnw -P search-sidecar test -Dtest='J2clComposeSurfaceControllerTest'` — 171/171 (was 170) pass; new test asserts the listener exposes the seeded participants list synchronously.
- [x] `sbt --batch j2clSearchBuild` — succeeds; bundle contains `getCurrentParticipantAddresses`.
- [x] Browser repro in `?view=j2cl-root` after creating a wave: typing `@` opens the popover with the wave's participants on toolbar-Reply, wave-root reply, and per-blip Edit composers; picking a candidate inserts a `wavy-mention-chip[data-mention-id]`.

Refs PR #1138 (G-PORT-5), PR #1135.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed @-mention suggestion popover in J2CL client to populate with wave participants immediately on all inline composer surfaces, including toolbar reply, wave-root reply, per-blip edit, and per-blip continuation.

* **Tests**
  * Added regression test to verify participants are available to newly mounted inline composer.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1247)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->