### PR TITLE
Fix GWT wave query route selection

### DIFF
--- a/wave/config/changelog.d/2026-05-13-gwt-route-wave-query.json
+++ b/wave/config/changelog.d/2026-05-13-gwt-route-wave-query.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-13-gwt-route-wave-query",
+  "version": "GWT route parity",
+  "date": "2026-05-13",
+  "title": "GWT wave deep-link route parity",
+  "summary": "Keeps GWT wave loading aligned with J2CL deep links that carry the selected wave in the URL query.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Makes the legacy GWT client honor the canonical wave= route parameter before falling back to the hash token, so J2CL-compatible wave links open the same selected wave in both views."
+      ]
+    }
+  ]
+}

--- a/wave/src/e2e/j2cl-gwt-parity/tests/visual-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/visual-parity.spec.ts
@@ -652,18 +652,28 @@ async function normalizeTaskOverlayChrome(region: Locator): Promise<void> {
   await normalizeRegionBounds(region, 320, 258);
   await region.evaluate((dialog) => {
     const root = dialog as HTMLElement;
-    root.style.position = "relative";
-    root.style.padding = "0";
-    root.style.margin = "0";
-    root.style.border = "0";
-    root.style.borderRadius = "0";
-    root.style.background = "#ffffff";
-    root.style.color = "transparent";
-    root.style.textShadow = "none";
-    root.style.boxShadow = "none";
-    root.style.outline = "0";
-    root.style.boxSizing = "border-box";
-    root.style.overflow = "hidden";
+    root.style.setProperty("display", "block", "important");
+    root.style.setProperty("position", "fixed", "important");
+    root.style.setProperty("left", "20px", "important");
+    root.style.setProperty("top", "20px", "important");
+    root.style.setProperty("z-index", "2147483647", "important");
+    root.style.setProperty("width", "320px", "important");
+    root.style.setProperty("height", "258px", "important");
+    root.style.setProperty("max-width", "320px", "important");
+    root.style.setProperty("max-height", "258px", "important");
+    root.style.setProperty("padding", "0", "important");
+    root.style.setProperty("margin", "0", "important");
+    root.style.setProperty("border", "0", "important");
+    root.style.setProperty("border-radius", "0", "important");
+    root.style.setProperty("background", "#ffffff", "important");
+    root.style.setProperty("background-color", "#ffffff", "important");
+    root.style.setProperty("opacity", "1", "important");
+    root.style.setProperty("color", "transparent", "important");
+    root.style.setProperty("text-shadow", "none", "important");
+    root.style.setProperty("box-shadow", "none", "important");
+    root.style.setProperty("outline", "0", "important");
+    root.style.setProperty("box-sizing", "border-box", "important");
+    root.style.setProperty("overflow", "hidden", "important");
 
     root.querySelectorAll("*").forEach((node) => {
       const el = node as HTMLElement;

--- a/wave/src/main/java/org/waveprotocol/box/webclient/client/WebClient.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/client/WebClient.java
@@ -75,6 +75,7 @@ import org.waveprotocol.wave.client.events.WaveCreationEvent;
 import org.waveprotocol.wave.client.events.WaveCreationEventHandler;
 import org.waveprotocol.wave.client.events.WaveSelectionEvent;
 import org.waveprotocol.wave.client.events.WaveSelectionEventHandler;
+import org.waveprotocol.wave.model.util.RouteWaveToken;
 import org.waveprotocol.wave.model.util.ThreadNavigationHistory;
 import org.waveprotocol.wave.client.wavepanel.event.EventDispatcherPanel;
 import org.waveprotocol.wave.client.wavepanel.event.WaveChangeHandler;
@@ -464,6 +465,7 @@ public class WebClient implements EntryPoint {
     setupStatistics();
 
     if (loggedIn) {
+      restoreInitialWaveFromRoute();
       restoreLastWaveFromStorage();
       History.fireCurrentHistoryState();
     }
@@ -798,6 +800,19 @@ public class WebClient implements EntryPoint {
         LOG.info("Saved last-wave token contains invalid path: " + savedToken);
         storage.removeItem(storageKey);
       }
+    }
+  }
+
+  private void restoreInitialWaveFromRoute() {
+    String historyToken = History.getToken();
+    String selectedToken =
+        RouteWaveToken.selectInitialToken(
+            historyToken,
+            Window.Location.getParameter("wave"),
+            Window.Location.getParameter("depth"),
+            GwtWaverefEncoder.INSTANCE);
+    if (selectedToken != null && !selectedToken.equals(historyToken)) {
+      History.newItem(selectedToken, false);
     }
   }
 

--- a/wave/src/main/java/org/waveprotocol/wave/model/util/RouteWaveToken.java
+++ b/wave/src/main/java/org/waveprotocol/wave/model/util/RouteWaveToken.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.wave.model.util;
+
+import org.waveprotocol.wave.model.id.WaveletId;
+import org.waveprotocol.wave.model.waveref.InvalidWaveRefException;
+import org.waveprotocol.wave.model.waveref.WaveRef;
+import org.waveprotocol.wave.model.waveref.WaverefEncoder;
+
+/**
+ * Normalizes route-selected waves for browser clients.
+ */
+public final class RouteWaveToken {
+
+  private static final String ROOT_CONVERSATION_WAVELET_ID = "conv+root";
+
+  private RouteWaveToken() {
+  }
+
+  public static String selectInitialToken(
+      String historyToken, String routeWave, String routeDepth, WaverefEncoder encoder) {
+    WaveRef routeRef = decodeRouteWave(routeWave, routeDepth, encoder);
+    if (routeRef == null) {
+      return historyToken;
+    }
+
+    String strippedHistoryToken = ThreadNavigationHistory.stripMetadata(historyToken);
+    WaveRef historyRef = decodeWave(strippedHistoryToken, encoder);
+    if (historyRef != null
+        && historyRef.getWaveId().equals(routeRef.getWaveId())
+        && preservesRouteRef(historyRef, routeRef)) {
+      return historyToken;
+    }
+    return encoder.encodeToUriPathSegment(routeRef);
+  }
+
+  private static boolean preservesRouteRef(WaveRef historyRef, WaveRef routeRef) {
+    return (!routeRef.hasWaveletId()
+        || (historyRef.hasWaveletId()
+            && historyRef.getWaveletId().equals(routeRef.getWaveletId())))
+        && (!routeRef.hasDocumentId()
+        || (historyRef.hasDocumentId()
+            && historyRef.getDocumentId().equals(routeRef.getDocumentId())));
+  }
+
+  private static WaveRef decodeRouteWave(
+      String routeWave, String routeDepth, WaverefEncoder encoder) {
+    WaveRef routeRef = decodeWave(routeWave, encoder);
+    if (routeRef == null || routeRef.hasDocumentId()) {
+      return routeRef;
+    }
+    String depth = normalizeDepth(routeDepth);
+    if (depth == null) {
+      return routeRef;
+    }
+    return WaveRef.of(
+        routeRef.getWaveId(),
+        routeRef.hasWaveletId()
+            ? routeRef.getWaveletId()
+            : WaveletId.of(routeRef.getWaveId().getDomain(), ROOT_CONVERSATION_WAVELET_ID),
+        depth);
+  }
+
+  private static WaveRef decodeWave(String token, WaverefEncoder encoder) {
+    if (token == null || token.isEmpty()) {
+      return null;
+    }
+    try {
+      return encoder.decodeWaveRefFromPath(ThreadNavigationHistory.stripMetadata(token));
+    } catch (InvalidWaveRefException e) {
+      return null;
+    }
+  }
+
+  private static String normalizeDepth(String depth) {
+    if (depth == null) {
+      return null;
+    }
+    String trimmed = depth.trim();
+    return trimmed.isEmpty()
+        || trimmed.indexOf(' ') >= 0
+        || trimmed.indexOf('&') >= 0
+        || trimmed.indexOf('=') >= 0
+        ? null
+        : trimmed;
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/util/GwtRouteWaveTokenTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/GwtRouteWaveTokenTest.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.box.server.util;
+
+import junit.framework.TestCase;
+
+import org.waveprotocol.wave.model.util.RouteWaveToken;
+import org.waveprotocol.wave.util.escapers.jvm.JavaWaverefEncoder;
+
+public final class GwtRouteWaveTokenTest extends TestCase {
+
+  public void testRouteWaveParameterWinsOverStaleHistoryToken() {
+    assertEquals(
+        "example.com/w+from-query",
+        RouteWaveToken.selectInitialToken(
+            "example.com/w+from-hash",
+            "example.com/w+from-query",
+            null,
+            JavaWaverefEncoder.INSTANCE));
+  }
+
+  public void testSameWavePreservesHistoryFocusMetadata() {
+    assertEquals(
+        "example.com/w+same/~/conv+root/b+child&focus=b+child&slide-nav=1",
+        RouteWaveToken.selectInitialToken(
+            "example.com/w+same/~/conv+root/b+child&focus=b+child&slide-nav=1",
+            "example.com/w+same",
+            null,
+            JavaWaverefEncoder.INSTANCE));
+  }
+
+  public void testRouteDepthWinsOverSameWaveHashWithoutFocus() {
+    assertEquals(
+        "example.com/w+same/~/conv+root/b+leaf",
+        RouteWaveToken.selectInitialToken(
+            "example.com/w+same",
+            "example.com/w+same",
+            "b+leaf",
+            JavaWaverefEncoder.INSTANCE));
+  }
+
+  public void testRouteDepthBuildsBlipTokenWhenHashIsMissing() {
+    assertEquals(
+        "example.com/w+from-query/~/conv+root/b+leaf",
+        RouteWaveToken.selectInitialToken(
+            "",
+            "example.com/w+from-query",
+            "b+leaf",
+            JavaWaverefEncoder.INSTANCE));
+  }
+
+  public void testRouteDepthPreservesRouteWavelet() {
+    assertEquals(
+        "example.com/w+from-query/~/conv+private/b+leaf",
+        RouteWaveToken.selectInitialToken(
+            "",
+            "example.com/w+from-query/~/conv+private",
+            "b+leaf",
+            JavaWaverefEncoder.INSTANCE));
+  }
+
+  public void testRouteWaveletWinsOverSameWaveHashWithDifferentWavelet() {
+    assertEquals(
+        "example.com/w+same/~/conv+private/b+leaf",
+        RouteWaveToken.selectInitialToken(
+            "example.com/w+same/~/conv+root/b+leaf",
+            "example.com/w+same/~/conv+private",
+            "b+leaf",
+            JavaWaverefEncoder.INSTANCE));
+  }
+
+  public void testRouteDepthRejectsHistoryMetadataSeparators() {
+    assertEquals(
+        "example.com/w+from-query",
+        RouteWaveToken.selectInitialToken(
+            "",
+            "example.com/w+from-query",
+            "b+leaf&focus=b+other",
+            JavaWaverefEncoder.INSTANCE));
+  }
+
+  public void testInvalidRouteWaveKeepsHistoryToken() {
+    assertEquals(
+        "example.com/w+from-hash",
+        RouteWaveToken.selectInitialToken(
+            "example.com/w+from-hash",
+            "not-a-wave",
+            null,
+            JavaWaverefEncoder.INSTANCE));
+  }
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelThreadFocusContractTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelThreadFocusContractTest.java
@@ -98,6 +98,7 @@ public final class WavePanelThreadFocusContractTest extends TestCase {
     assertTrue(historyListener.contains("encodedToken.equals(currentSelectedToken)"));
     assertTrue(webClient.contains("ThreadNavigationHistory.stripMetadata(savedToken)"));
     assertTrue(webClient.contains("ThreadNavigationHistory.stripMetadata(encodedToken)"));
+    assertTrue(webClient.contains("RouteWaveToken.selectInitialToken("));
     assertTrue(webClient.contains("HistoryChangeListener.setCurrentWaveToken("));
   }
 


### PR DESCRIPTION
## Summary
- Make GWT startup honor the canonical `wave=` route parameter before falling back to the legacy hash history token.
- Preserve existing same-wave hash/focus metadata and support `depth=` when the route supplies focused blip state.
- Add route normalization regression coverage, a changelog fragment, and a narrow parity-harness normalization fix for the GWT task overlay crop.

## Verification
- `python3 scripts/assemble-changelog.py`
- `sbt --batch "testOnly org.waveprotocol.box.server.util.GwtRouteWaveTokenTest org.waveprotocol.box.server.util.WavePanelThreadFocusContractTest"`
- `python3 scripts/validate-changelog.py`
- `sbt --batch compileGwt`
- `git diff --check`
- `cd wave/src/e2e/j2cl-gwt-parity && npm ci`
- `cd wave/src/e2e/j2cl-gwt-parity && npx tsc --noEmit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The legacy client now honors the canonical `wave=` route parameter when initializing waves, falling back to hash tokens only when needed, ensuring consistent deep-linking behavior across client implementations.

* **Tests**
  * Added comprehensive test coverage for route parameter handling and enhanced visual parity validation tests to ensure consistent rendering across implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1249)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->