### PR TITLE
Restore J2CL inline reply anchors from documents

### DIFF
--- a/docs/superpowers/plans/2026-05-13-j2cl-inline-thread-render.md
+++ b/docs/superpowers/plans/2026-05-13-j2cl-inline-thread-render.md
@@ -1,0 +1,28 @@
+# J2CL Inline Thread Rendering Plan
+
+## Problem
+
+GWT renders inline reply threads under their root blip anchor, but the J2CL read surface can render the same wave as flat root-level blips. Existing J2CL renderer code already supports `J2clInlineReplyAnchor` metadata when viewport fragments carry raw `<reply id="...">` tags. The sidecar document snapshot path decodes document operations to plain text and currently loses those anchors.
+
+## Scope
+
+- Preserve `<reply id="...">` anchors while decoding selected-wave document operations.
+- Thread decoded anchors through document-backed viewport entries and read blips.
+- Keep existing fragment-derived anchors authoritative when fragments already provided them.
+- Add a user-facing changelog fragment for J2CL parity.
+
+## Implementation Steps
+
+1. Add transport and projection regression coverage for document-operation inline reply anchors.
+2. Extend `SidecarSelectedWaveDocument` and `SidecarTransportCodec.DocumentExtraction` with immutable inline anchor lists.
+3. Capture `reply` element starts as `J2clInlineReplyAnchor(threadId, visibleTextOffset)` during document extraction.
+4. Pass document anchors through `J2clSelectedWaveViewportState` and `J2clSelectedWaveProjector`, preserving existing fragment anchors when present.
+5. Run focused unit tests, changelog validation, and local sanity verification before PR.
+
+## Self-Review Checklist
+
+- Anchors do not become visible text.
+- Anchor offsets are measured in decoded visible text, matching fragment parsing.
+- Empty/null anchor lists stay immutable and safe.
+- Existing fragment anchors are not overwritten by document refreshes.
+- Changelog and issue/PR traceability are updated.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
@@ -245,7 +245,8 @@ public final class J2clReadBlipContent {
         // <line/> and <line> are DocOp structural separators: Hello<line/>World -> Hello\nWorld.
         String tagContent = tagBuf.toString();
         if (isLineTag(tagContent)) {
-          decodedVisibleLength = appendLineSeparator(stripped, decodedVisibleLength);
+          decodedVisibleLength =
+              appendLineSeparator(stripped, decodedVisibleLength, inlineReplyAnchors);
         } else if (isInlineReplyAnchorTag(tagContent)) {
           String threadId = attributeValue("<" + tagContent + ">", "id");
           if (!threadId.isEmpty()) {
@@ -330,19 +331,37 @@ public final class J2clReadBlipContent {
     }
   }
 
-  private static int appendLineSeparator(StringBuilder stripped, int decodedVisibleLength) {
+  private static int appendLineSeparator(
+      StringBuilder stripped,
+      int decodedVisibleLength,
+      List<J2clInlineReplyAnchor> inlineReplyAnchors) {
     // Normalize horizontal whitespace at paragraph boundaries before emitting one line break.
     while (stripped.length() > 0
         && Character.isWhitespace(stripped.charAt(stripped.length() - 1))
         && stripped.charAt(stripped.length() - 1) != '\n') {
       stripped.deleteCharAt(stripped.length() - 1);
       decodedVisibleLength = Math.max(0, decodedVisibleLength - 1);
+      clampInlineReplyAnchorOffsets(inlineReplyAnchors, decodedVisibleLength);
     }
     if (stripped.length() > 0 && stripped.charAt(stripped.length() - 1) != '\n') {
       stripped.append('\n');
       decodedVisibleLength++;
     }
     return decodedVisibleLength;
+  }
+
+  private static void clampInlineReplyAnchorOffsets(
+      List<J2clInlineReplyAnchor> inlineReplyAnchors, int maxTextOffset) {
+    if (inlineReplyAnchors == null || inlineReplyAnchors.isEmpty()) {
+      return;
+    }
+    for (int i = 0; i < inlineReplyAnchors.size(); i++) {
+      J2clInlineReplyAnchor anchor = inlineReplyAnchors.get(i);
+      if (anchor.getTextOffset() > maxTextOffset) {
+        inlineReplyAnchors.set(
+            i, new J2clInlineReplyAnchor(anchor.getThreadId(), maxTextOffset));
+      }
+    }
   }
 
   private static AnnotationSnapshot parseAnnotationSnapshot(String raw) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import java.util.Set;
 import org.waveprotocol.box.j2cl.overlay.J2clInteractionBlipModel;
 import org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel;
+import org.waveprotocol.box.j2cl.read.J2clInlineReplyAnchor;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 import org.waveprotocol.box.j2cl.read.J2clReadWindowEntry;
 import org.waveprotocol.box.j2cl.transport.SidecarAnnotationRange;
@@ -685,7 +686,8 @@ public final class J2clSelectedWaveProjector {
               /* taskAssignee= */ documentTaskAssignee(document),
               /* taskDueTimestamp= */ documentTaskDueTimestamp(document),
               /* bodyItemCount= */ document.getBodyItemCount(),
-              /* isTask= */ documentHasTask(document)));
+              /* isTask= */ documentHasTask(document),
+              document.getInlineReplyAnchors()));
     }
     return blips;
   }
@@ -745,9 +747,17 @@ public final class J2clSelectedWaveProjector {
               /* taskDueTimestamp= */ documentTaskDueTimestamp(doc),
               /* bodyItemCount= */ doc.getBodyItemCount(),
               /* isTask= */ documentHasTask(doc),
-              blip.getInlineReplyAnchors()));
+              chooseDocumentInlineReplyAnchors(blip, doc)));
     }
     return enriched;
+  }
+
+  private static List<J2clInlineReplyAnchor> chooseDocumentInlineReplyAnchors(
+      J2clReadBlip blip, SidecarSelectedWaveDocument doc) {
+    if (!blip.getInlineReplyAnchors().isEmpty()) {
+      return blip.getInlineReplyAnchors();
+    }
+    return doc.getInlineReplyAnchors();
   }
 
   static List<J2clReadBlip> applyDigestMetadataFallback(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -754,10 +754,10 @@ public final class J2clSelectedWaveProjector {
 
   private static List<J2clInlineReplyAnchor> chooseDocumentInlineReplyAnchors(
       J2clReadBlip blip, SidecarSelectedWaveDocument doc) {
-    if (!blip.getInlineReplyAnchors().isEmpty()) {
-      return blip.getInlineReplyAnchors();
+    if (!doc.getInlineReplyAnchors().isEmpty()) {
+      return doc.getInlineReplyAnchors();
     }
-    return doc.getInlineReplyAnchors();
+    return blip.getInlineReplyAnchors();
   }
 
   static List<J2clReadBlip> applyDigestMetadataFallback(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -286,9 +286,6 @@ public final class J2clSelectedWaveViewportState {
 
   private static List<J2clInlineReplyAnchor> chooseDocumentMergeInlineReplyAnchors(
       Entry existing, Entry documentEntry) {
-    if (existing.shouldParseAttachmentElements() && !existing.getInlineReplyAnchors().isEmpty()) {
-      return existing.getInlineReplyAnchors();
-    }
     if (!documentEntry.getInlineReplyAnchors().isEmpty()) {
       return documentEntry.getInlineReplyAnchors();
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewportState.java
@@ -124,7 +124,11 @@ public final class J2clSelectedWaveViewportState {
               textContent,
               0,
               0,
-              document.getBodyItemCount()));
+              document.getBodyItemCount(),
+              /* parseAttachmentElements= */ false,
+              Collections.<J2clAttachmentRenderModel>emptyList(),
+              null,
+              document.getInlineReplyAnchors()));
     }
     if (entries.isEmpty()) {
       return empty();
@@ -268,7 +272,7 @@ public final class J2clSelectedWaveViewportState {
                 /* parseAttachmentElements= */ false,
                 Collections.<J2clAttachmentRenderModel>emptyList(),
                 null,
-                existing.getInlineReplyAnchors()));
+                chooseDocumentMergeInlineReplyAnchors(existing, documentEntry)));
       } else {
         merged.add(documentEntry);
       }
@@ -278,6 +282,17 @@ public final class J2clSelectedWaveViewportState {
         knownOrFallback(startVersion, documentState.getStartVersion()),
         Math.max(endVersion, documentState.getEndVersion()),
         merged);
+  }
+
+  private static List<J2clInlineReplyAnchor> chooseDocumentMergeInlineReplyAnchors(
+      Entry existing, Entry documentEntry) {
+    if (existing.shouldParseAttachmentElements() && !existing.getInlineReplyAnchors().isEmpty()) {
+      return existing.getInlineReplyAnchors();
+    }
+    if (!documentEntry.getInlineReplyAnchors().isEmpty()) {
+      return documentEntry.getInlineReplyAnchors();
+    }
+    return existing.getInlineReplyAnchors();
   }
 
   public long getSnapshotVersion() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveDocument.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveDocument.java
@@ -3,6 +3,7 @@ package org.waveprotocol.box.j2cl.transport;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.waveprotocol.box.j2cl.read.J2clInlineReplyAnchor;
 
 public final class SidecarSelectedWaveDocument {
   private static final String REACTION_DATA_DOCUMENT_PREFIX = "react+";
@@ -19,6 +20,7 @@ public final class SidecarSelectedWaveDocument {
   private final List<SidecarAnnotationRange> annotationRanges;
   private final List<SidecarReactionEntry> reactionEntries;
   private final String lockState;
+  private final List<J2clInlineReplyAnchor> inlineReplyAnchors;
 
   public SidecarSelectedWaveDocument(
       String documentId,
@@ -35,7 +37,8 @@ public final class SidecarSelectedWaveDocument {
         /* bodyItemCount= */ 0,
         Collections.<SidecarAnnotationRange>emptyList(),
         Collections.<SidecarReactionEntry>emptyList(),
-        LOCK_STATE_UNLOCKED);
+        LOCK_STATE_UNLOCKED,
+        Collections.<J2clInlineReplyAnchor>emptyList());
   }
 
   public SidecarSelectedWaveDocument(
@@ -55,7 +58,8 @@ public final class SidecarSelectedWaveDocument {
         /* bodyItemCount= */ 0,
         annotationRanges,
         reactionEntries,
-        LOCK_STATE_UNLOCKED);
+        LOCK_STATE_UNLOCKED,
+        Collections.<J2clInlineReplyAnchor>emptyList());
   }
 
   public SidecarSelectedWaveDocument(
@@ -76,7 +80,8 @@ public final class SidecarSelectedWaveDocument {
         bodyItemCount,
         annotationRanges,
         reactionEntries,
-        LOCK_STATE_UNLOCKED);
+        LOCK_STATE_UNLOCKED,
+        Collections.<J2clInlineReplyAnchor>emptyList());
   }
 
   public SidecarSelectedWaveDocument(
@@ -89,6 +94,30 @@ public final class SidecarSelectedWaveDocument {
       List<SidecarAnnotationRange> annotationRanges,
       List<SidecarReactionEntry> reactionEntries,
       String lockState) {
+    this(
+        documentId,
+        author,
+        lastModifiedVersion,
+        lastModifiedTime,
+        textContent,
+        bodyItemCount,
+        annotationRanges,
+        reactionEntries,
+        lockState,
+        Collections.<J2clInlineReplyAnchor>emptyList());
+  }
+
+  public SidecarSelectedWaveDocument(
+      String documentId,
+      String author,
+      long lastModifiedVersion,
+      long lastModifiedTime,
+      String textContent,
+      int bodyItemCount,
+      List<SidecarAnnotationRange> annotationRanges,
+      List<SidecarReactionEntry> reactionEntries,
+      String lockState,
+      List<J2clInlineReplyAnchor> inlineReplyAnchors) {
     this.documentId = documentId;
     this.author = author;
     this.lastModifiedVersion = lastModifiedVersion;
@@ -104,6 +133,11 @@ public final class SidecarSelectedWaveDocument {
             ? Collections.<SidecarReactionEntry>emptyList()
             : Collections.unmodifiableList(new ArrayList<SidecarReactionEntry>(reactionEntries));
     this.lockState = normalizeLockState(lockState);
+    this.inlineReplyAnchors =
+        inlineReplyAnchors == null
+            ? Collections.<J2clInlineReplyAnchor>emptyList()
+            : Collections.unmodifiableList(
+                new ArrayList<J2clInlineReplyAnchor>(inlineReplyAnchors));
   }
 
   public static String normalizeLockState(String value) {
@@ -150,6 +184,10 @@ public final class SidecarSelectedWaveDocument {
 
   public String getLockState() {
     return lockState;
+  }
+
+  public List<J2clInlineReplyAnchor> getInlineReplyAnchors() {
+    return inlineReplyAnchors;
   }
 
   public boolean isReactionDataDocument() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -580,7 +580,7 @@ public final class SidecarTransportCodec {
           }
         }
         if ("line".equals(type)) {
-          appendDocumentLineSeparator(text);
+          appendDocumentLineSeparator(text, inlineReplyAnchors);
         }
         continue;
       }
@@ -637,14 +637,30 @@ public final class SidecarTransportCodec {
     }
   }
 
-  private static void appendDocumentLineSeparator(StringBuilder text) {
+  private static void appendDocumentLineSeparator(
+      StringBuilder text, List<J2clInlineReplyAnchor> inlineReplyAnchors) {
     while (text.length() > 0
         && Character.isWhitespace(text.charAt(text.length() - 1))
         && text.charAt(text.length() - 1) != '\n') {
       text.deleteCharAt(text.length() - 1);
+      clampInlineReplyAnchorOffsets(inlineReplyAnchors, text.length());
     }
     if (text.length() > 0 && text.charAt(text.length() - 1) != '\n') {
       text.append('\n');
+    }
+  }
+
+  private static void clampInlineReplyAnchorOffsets(
+      List<J2clInlineReplyAnchor> inlineReplyAnchors, int maxTextOffset) {
+    if (inlineReplyAnchors == null || inlineReplyAnchors.isEmpty()) {
+      return;
+    }
+    for (int i = 0; i < inlineReplyAnchors.size(); i++) {
+      J2clInlineReplyAnchor anchor = inlineReplyAnchors.get(i);
+      if (anchor.getTextOffset() > maxTextOffset) {
+        inlineReplyAnchors.set(
+            i, new J2clInlineReplyAnchor(anchor.getThreadId(), maxTextOffset));
+      }
     }
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -579,8 +579,8 @@ public final class SidecarTransportCodec {
             inlineReplyAnchors.add(new J2clInlineReplyAnchor(threadId, text.length()));
           }
         }
-        if ("line".equals(type) && text.length() > 0 && text.charAt(text.length() - 1) != '\n') {
-          text.append('\n');
+        if ("line".equals(type)) {
+          appendDocumentLineSeparator(text);
         }
         continue;
       }
@@ -634,6 +634,17 @@ public final class SidecarTransportCodec {
       if (newValue != null) {
         activeAnnotations.put(key, new ActiveAnnotation(newValue, textOffset, docOffset));
       }
+    }
+  }
+
+  private static void appendDocumentLineSeparator(StringBuilder text) {
+    while (text.length() > 0
+        && Character.isWhitespace(text.charAt(text.length() - 1))
+        && text.charAt(text.length() - 1) != '\n') {
+      text.deleteCharAt(text.length() - 1);
+    }
+    if (text.length() > 0 && text.charAt(text.length() - 1) != '\n') {
+      text.append('\n');
     }
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.waveprotocol.box.j2cl.read.J2clInlineReplyAnchor;
 import org.waveprotocol.box.j2cl.search.SidecarSearchResponse;
 
 public final class SidecarTransportCodec {
@@ -118,7 +119,8 @@ public final class SidecarTransportCodec {
                 extraction.bodyItemCount,
                 extraction.annotationRanges,
                 extraction.reactionEntries,
-                extraction.lockState));
+                extraction.lockState,
+                extraction.inlineReplyAnchors));
         if ("conversation".equals(documentId) && conversationManifest.isEmpty()) {
           conversationManifest = extractConversationManifest(documentOperation);
         }
@@ -515,7 +517,8 @@ public final class SidecarTransportCodec {
           0,
           new ArrayList<SidecarAnnotationRange>(),
           new ArrayList<SidecarReactionEntry>(),
-          SidecarSelectedWaveDocument.LOCK_STATE_UNLOCKED);
+          SidecarSelectedWaveDocument.LOCK_STATE_UNLOCKED,
+          new ArrayList<J2clInlineReplyAnchor>());
     }
     StringBuilder text = new StringBuilder();
     int bodyItemCount = 0;
@@ -523,6 +526,7 @@ public final class SidecarTransportCodec {
     Map<String, ActiveAnnotation> activeAnnotations =
         new LinkedHashMap<String, ActiveAnnotation>();
     List<SidecarAnnotationRange> annotationRanges = new ArrayList<SidecarAnnotationRange>();
+    List<J2clInlineReplyAnchor> inlineReplyAnchors = new ArrayList<J2clInlineReplyAnchor>();
     Map<String, List<String>> reactionAddressesByEmoji = new LinkedHashMap<String, List<String>>();
     List<String> elementStack = new ArrayList<String>();
     String currentReactionEmoji = null;
@@ -569,6 +573,11 @@ public final class SidecarTransportCodec {
         } else if ("m/lock".equals(documentId) && "lock".equals(type)) {
           lockState =
               SidecarSelectedWaveDocument.normalizeLockState(getAttribute(elementStart, "mode"));
+        } else if ("reply".equals(type)) {
+          String threadId = getAttribute(elementStart, "id");
+          if (threadId != null && !threadId.isEmpty()) {
+            inlineReplyAnchors.add(new J2clInlineReplyAnchor(threadId, text.length()));
+          }
         }
         if ("line".equals(type) && text.length() > 0 && text.charAt(text.length() - 1) != '\n') {
           text.append('\n');
@@ -591,7 +600,8 @@ public final class SidecarTransportCodec {
         bodyItemCount,
         annotationRanges,
         extractReactionEntries(documentId, reactionAddressesByEmoji),
-        lockState);
+        lockState,
+        inlineReplyAnchors);
   }
 
   private static void processAnnotationBoundary(
@@ -704,18 +714,21 @@ public final class SidecarTransportCodec {
     private final List<SidecarAnnotationRange> annotationRanges;
     private final List<SidecarReactionEntry> reactionEntries;
     private final String lockState;
+    private final List<J2clInlineReplyAnchor> inlineReplyAnchors;
 
     DocumentExtraction(
         String textContent,
         int bodyItemCount,
         List<SidecarAnnotationRange> annotationRanges,
         List<SidecarReactionEntry> reactionEntries,
-        String lockState) {
+        String lockState,
+        List<J2clInlineReplyAnchor> inlineReplyAnchors) {
       this.textContent = textContent;
       this.bodyItemCount = bodyItemCount;
       this.annotationRanges = annotationRanges;
       this.reactionEntries = reactionEntries;
       this.lockState = lockState;
+      this.inlineReplyAnchors = inlineReplyAnchors;
     }
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
@@ -202,6 +202,18 @@ public class J2clReadBlipContentTest {
   }
 
   @Test
+  public void inlineReplyAnchorOffsetBeforeLineTracksTrimmedWhitespace() {
+    J2clReadBlipContent parsed =
+        J2clReadBlipContent.parseRawSnapshot(
+            "<body>foo   <reply id=\"t+before-line\"></reply><line/>bar</body>");
+
+    Assert.assertEquals("foo\nbar", parsed.getText());
+    Assert.assertEquals(1, parsed.getInlineReplyAnchors().size());
+    Assert.assertEquals("t+before-line", parsed.getInlineReplyAnchors().get(0).getThreadId());
+    Assert.assertEquals("foo".length(), parsed.getInlineReplyAnchors().get(0).getTextOffset());
+  }
+
+  @Test
   public void parsesTaskAnnotationsFromRawFragmentSnapshot() {
     J2clReadBlipContent parsed =
         J2clReadBlipContent.parseRawSnapshot(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -743,6 +743,49 @@ public class J2clSelectedWaveProjectorTest {
   }
 
   @Test
+  public void viewportDocumentMergeUsesFreshDocumentInlineReplyAnchors() {
+    J2clSelectedWaveViewportState state =
+        J2clSelectedWaveViewportState.fromFragments(
+            new SidecarSelectedWaveFragments(
+                9L,
+                0L,
+                9L,
+                Arrays.asList(new SidecarSelectedWaveFragmentRange("blip:b+root", 0L, 9L)),
+                Arrays.asList(
+                    new SidecarSelectedWaveFragment(
+                        "blip:b+root",
+                        "<body><line/>Before <reply id=\"t+old\"></reply> after</body>",
+                        0,
+                        0))));
+
+    state =
+        state.mergeDocuments(
+            Arrays.asList(
+                new SidecarSelectedWaveDocument(
+                    "b+root",
+                    "user@example.com",
+                    7L,
+                    10L,
+                    "Updated  after",
+                    /* bodyItemCount= */ 18,
+                    Collections.<SidecarAnnotationRange>emptyList(),
+                    Collections.<SidecarReactionEntry>emptyList(),
+                    SidecarSelectedWaveDocument.LOCK_STATE_UNLOCKED,
+                    Arrays.asList(new J2clInlineReplyAnchor("t+new", "Updated ".length())))));
+
+    Assert.assertEquals("Updated  after", state.getLoadedReadBlips().get(0).getText());
+    Assert.assertEquals(1, state.getLoadedReadBlips().get(0).getInlineReplyAnchors().size());
+    Assert.assertEquals(
+        "t+new", state.getLoadedReadBlips().get(0).getInlineReplyAnchors().get(0).getThreadId());
+    Assert.assertEquals(
+        "Updated ".length(),
+        state.getLoadedReadBlips().get(0).getInlineReplyAnchors().get(0).getTextOffset());
+    Assert.assertEquals(
+        "t+new",
+        state.getReadWindowEntries().get(0).getInlineReplyAnchors().get(0).getThreadId());
+  }
+
+  @Test
   public void viewportFragmentMergeOverDocumentRestoresAttachmentParsing() {
     J2clSelectedWaveViewportState state =
         J2clSelectedWaveViewportState.fromDocuments(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorTest.java
@@ -12,6 +12,7 @@ import org.waveprotocol.box.j2cl.overlay.J2clInteractionBlipModel;
 import org.waveprotocol.box.j2cl.overlay.J2clMentionRange;
 import org.waveprotocol.box.j2cl.overlay.J2clReactionSummary;
 import org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel;
+import org.waveprotocol.box.j2cl.read.J2clInlineReplyAnchor;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 import org.waveprotocol.box.j2cl.read.J2clReadBlipContent;
 import org.waveprotocol.box.j2cl.transport.SidecarAnnotationRange;
@@ -308,6 +309,46 @@ public class J2clSelectedWaveProjectorTest {
                             "<body><line/>Before <reply id=\"t+inline\"></reply> after</body>",
                             0,
                             0)))),
+            null,
+            0);
+
+    J2clReadBlip blip = projected.getReadBlips().get(0);
+    Assert.assertEquals("Before  after", blip.getText());
+    Assert.assertEquals(1, blip.getInlineReplyAnchors().size());
+    Assert.assertEquals("t+inline", blip.getInlineReplyAnchors().get(0).getThreadId());
+    Assert.assertEquals("Before ".length(), blip.getInlineReplyAnchors().get(0).getTextOffset());
+    Assert.assertEquals(
+        1,
+        projected.getViewportState().getReadWindowEntries().get(0).getInlineReplyAnchors().size());
+  }
+
+  @Test
+  public void documentSnapshotsProjectInlineReplyAnchorsToReadBlips() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            new SidecarSelectedWaveUpdate(
+                1,
+                WAVELET_NAME,
+                true,
+                CHANNEL_ID,
+                9L,
+                "HASH",
+                Arrays.asList("user@example.com"),
+                Arrays.asList(
+                    new SidecarSelectedWaveDocument(
+                        "b+root",
+                        "user@example.com",
+                        7L,
+                        10L,
+                        "Before  after",
+                        /* bodyItemCount= */ 19,
+                        Collections.<SidecarAnnotationRange>emptyList(),
+                        Collections.<SidecarReactionEntry>emptyList(),
+                        SidecarSelectedWaveDocument.LOCK_STATE_UNLOCKED,
+                        Arrays.asList(new J2clInlineReplyAnchor("t+inline", "Before ".length())))),
+                null),
             null,
             0);
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -239,6 +239,34 @@ public class SidecarTransportCodecTest {
   }
 
   @Test
+  public void decodeSelectedWaveUpdateTrimsLineWhitespaceBeforeInlineReplyOffset() {
+    String json =
+        "{\"sequenceNumber\":14,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"local.net!w+s4635670bfbwA/~/conv+root\","
+            + "\"5\":{\"1\":\"conv+root\",\"2\":[\"user@example.com\"],"
+            + "\"3\":[{\"1\":\"b+abc123\","
+            + "\"2\":{\"1\":[{\"3\":{\"1\":\"body\",\"2\":[]}},"
+            + "{\"2\":\"A & B   \"},"
+            + "{\"3\":{\"1\":\"line\",\"2\":[]}},"
+            + "{\"2\":\"C \"},"
+            + "{\"3\":{\"1\":\"reply\",\"2\":[{\"1\":\"id\",\"2\":\"t+after-line\"}]}},"
+            + "{\"4\":true},"
+            + "{\"4\":true},{\"4\":true}]},"
+            + "\"3\":\"user@example.com\",\"5\":[1,0],\"6\":[2,0]}]},"
+            + "\"6\":true,\"7\":\"ch3\"}}";
+
+    SidecarSelectedWaveDocument document =
+        SidecarTransportCodec.decodeSelectedWaveUpdate(json).getDocuments().get(0);
+
+    Assert.assertEquals("A & B\nC ", document.getTextContent());
+    Assert.assertEquals(16, document.getBodyItemCount());
+    Assert.assertEquals(1, document.getInlineReplyAnchors().size());
+    Assert.assertEquals("t+after-line", document.getInlineReplyAnchors().get(0).getThreadId());
+    Assert.assertEquals(
+        "A & B\nC ".length(), document.getInlineReplyAnchors().get(0).getTextOffset());
+  }
+
+  @Test
   public void decodeSelectedWaveUpdateReadsRootLockDocumentState() {
     String json =
         "{\"sequenceNumber\":14,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -267,6 +267,33 @@ public class SidecarTransportCodecTest {
   }
 
   @Test
+  public void decodeSelectedWaveUpdateAdjustsInlineReplyOffsetWhenLineTrimRunsLater() {
+    String json =
+        "{\"sequenceNumber\":14,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"local.net!w+s4635670bfbwA/~/conv+root\","
+            + "\"5\":{\"1\":\"conv+root\",\"2\":[\"user@example.com\"],"
+            + "\"3\":[{\"1\":\"b+abc123\","
+            + "\"2\":{\"1\":[{\"3\":{\"1\":\"body\",\"2\":[]}},"
+            + "{\"2\":\"foo   \"},"
+            + "{\"3\":{\"1\":\"reply\",\"2\":[{\"1\":\"id\",\"2\":\"t+before-line\"}]}},"
+            + "{\"4\":true},"
+            + "{\"3\":{\"1\":\"line\",\"2\":[]}},"
+            + "{\"2\":\"bar\"},"
+            + "{\"4\":true},{\"4\":true}]},"
+            + "\"3\":\"user@example.com\",\"5\":[1,0],\"6\":[2,0]}]},"
+            + "\"6\":true,\"7\":\"ch3\"}}";
+
+    SidecarSelectedWaveDocument document =
+        SidecarTransportCodec.decodeSelectedWaveUpdate(json).getDocuments().get(0);
+
+    Assert.assertEquals("foo\nbar", document.getTextContent());
+    Assert.assertEquals(15, document.getBodyItemCount());
+    Assert.assertEquals(1, document.getInlineReplyAnchors().size());
+    Assert.assertEquals("t+before-line", document.getInlineReplyAnchors().get(0).getThreadId());
+    Assert.assertEquals("foo".length(), document.getInlineReplyAnchors().get(0).getTextOffset());
+  }
+
+  @Test
   public void decodeSelectedWaveUpdateReadsRootLockDocumentState() {
     String json =
         "{\"sequenceNumber\":14,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -211,6 +211,34 @@ public class SidecarTransportCodecTest {
   }
 
   @Test
+  public void decodeSelectedWaveUpdateReadsInlineReplyAnchorsFromDocumentOps() {
+    String json =
+        "{\"sequenceNumber\":14,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"local.net!w+s4635670bfbwA/~/conv+root\","
+            + "\"5\":{\"1\":\"conv+root\",\"2\":[\"user@example.com\"],"
+            + "\"3\":[{\"1\":\"b+abc123\","
+            + "\"2\":{\"1\":[{\"3\":{\"1\":\"body\",\"2\":[]}},"
+            + "{\"3\":{\"1\":\"line\",\"2\":[]}},"
+            + "{\"2\":\"Before \"},"
+            + "{\"3\":{\"1\":\"reply\",\"2\":[{\"1\":\"id\",\"2\":\"t+inline\"}]}},"
+            + "{\"4\":true},"
+            + "{\"2\":\" after\"},"
+            + "{\"4\":true},{\"4\":true}]},"
+            + "\"3\":\"user@example.com\",\"5\":[1,0],\"6\":[2,0]}]},"
+            + "\"6\":true,\"7\":\"ch3\"}}";
+
+    SidecarSelectedWaveUpdate update = SidecarTransportCodec.decodeSelectedWaveUpdate(json);
+
+    SidecarSelectedWaveDocument document = update.getDocuments().get(0);
+    Assert.assertEquals("Before  after", document.getTextContent());
+    Assert.assertEquals(19, document.getBodyItemCount());
+    Assert.assertEquals(1, document.getInlineReplyAnchors().size());
+    Assert.assertEquals("t+inline", document.getInlineReplyAnchors().get(0).getThreadId());
+    Assert.assertEquals(
+        "Before ".length(), document.getInlineReplyAnchors().get(0).getTextOffset());
+  }
+
+  @Test
   public void decodeSelectedWaveUpdateReadsRootLockDocumentState() {
     String json =
         "{\"sequenceNumber\":14,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"

--- a/wave/config/changelog.d/2026-05-13-j2cl-inline-thread-render.json
+++ b/wave/config/changelog.d/2026-05-13-j2cl-inline-thread-render.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-13-j2cl-inline-thread-render",
+  "version": "J2CL parity",
+  "date": "2026-05-13",
+  "title": "J2CL read mode now keeps inline reply threads attached to their root-blip anchors.",
+  "summary": "J2CL selected-wave document snapshots now preserve inline reply anchor metadata from reply elements, so child blips render at the same inline locations as they do in GWT instead of being flattened or omitted from the root blip context.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Sidecar document decoding records reply element ids as inline reply anchors at the decoded visible-text offset.",
+        "Document-backed J2CL viewport entries and read blips now carry those anchors through projection while preserving fragment-derived anchors when fragments already provide them."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #1248.

## Summary
- Preserve `<reply id=...>` anchors while decoding sidecar selected-wave document operations.
- Thread document-backed inline reply anchors through viewport entries and read blips so existing J2CL read rendering can mount child threads at the root-blip anchor.
- Keep fragment-derived inline reply anchors authoritative when fragments already provide them.
- Add a J2CL parity changelog fragment and implementation plan.

## Verification
- RED first: focused Maven run failed because `SidecarSelectedWaveDocument` had no inline-anchor API/constructor.
- PASS: `./j2cl/mvnw -f j2cl/pom.xml -Psearch-sidecar -Dtest=SidecarTransportCodecTest,J2clSelectedWaveProjectorTest,J2clReadSurfaceDomRendererTest test` (272 tests, 0 failures, 110 renderer skips).
- PASS: `python3 scripts/assemble-changelog.py` (assembled 371 entries).
- PASS: `python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`.
- PASS: `git diff --check`.
- PASS: `sbt -batch "j2clSearchBuild; j2clSearchTest"`.
- PASS: `sbt -batch j2clProductionBuild`.
- PASS: `WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 sbt -batch Universal/stage`.
- PASS: local smoke on port 9914 with J2CL assets required: ROOT_STATUS=200, GWT_VIEW_STATUS=200, HEALTH_STATUS=200, J2CL_ROOT_STATUS=200, J2CL_INDEX_STATUS=200, SIDECAR_STATUS=200, WEBCLIENT_STATUS=200.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Inline reply threads now correctly remain anchored to their root blips in J2CL read mode, preserving the visual hierarchy and preventing child blips from being flattened or omitted during snapshot decoding.

* **Tests**
  * Added test coverage for inline reply anchor projection and document operation decoding.

* **Documentation**
  * Added changelog entry documenting inline reply thread anchor preservation improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1250)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->