### PR TITLE
Fix J2CL initial viewport root blip visibility

### DIFF
--- a/wave/config/changelog.d/2026-05-18-j2cl-root-blip-initial-window.json
+++ b/wave/config/changelog.d/2026-05-18-j2cl-root-blip-initial-window.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-18-j2cl-root-blip-initial-window",
+  "version": "J2CL parity",
+  "date": "2026-05-18",
+  "title": "J2CL now keeps the root title blip visible when a wave opens.",
+  "summary": "The J2CL wave panel now includes the editable root blip in the initial viewport window, so the text used as the wave title is also shown as a normal blip like it is in GWT.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Initial J2CL viewport windows now order the root blip before generated numeric blips instead of hiding the title source behind later messages."
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
@@ -564,6 +564,12 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
   }
 
   private static int compareBlipIdsNaturally(String left, String right) {
+    if ("b+root".equals(left) && !"b+root".equals(right)) {
+      return -1;
+    }
+    if ("b+root".equals(right) && !"b+root".equals(left)) {
+      return 1;
+    }
     String leftPrefix = trailingNumberPrefix(left);
     String rightPrefix = trailingNumberPrefix(right);
     if (leftPrefix.equals(rightPrefix)) {

--- a/wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcViewportHintsTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcViewportHintsTest.java
@@ -153,6 +153,21 @@ public final class WaveClientRpcViewportHintsTest {
   }
 
   @Test
+  public void viewportHintsKeepRootBlipInInitialSnapshotWindow() {
+    ProtocolWaveletUpdate update =
+        openWithRpc(
+            makeWaveClientRpcWithBlipIds("b+2", "b+root", "b+1", "b+3"),
+            viewportHintRequest(null, "forward", 2));
+
+    assertTrue(update.hasFragments());
+    assertEquals(Arrays.asList("b+root", "b+1", "b+2"),
+        blipRangeIds(update.getFragments()));
+    assertTrue(hasBlipFragment(update.getFragments(), "b+root"));
+    assertTrue(hasBlipFragment(update.getFragments(), "b+1"));
+    assertFalse(hasBlipFragment(update.getFragments(), "b+2"));
+  }
+
+  @Test
   public void viewportHintsMissingStartFallsBackToFirstWindow() {
     ProtocolWaveletUpdate update =
         openWithRpc(


### PR DESCRIPTION
## Summary
- Keep the root title blip first in the J2CL snapshot-backed initial viewport window.
- Add a regression test proving viewport-hinted opens include b+root before generated numeric blips.
- Add a changelog fragment for the J2CL parity fix.

## Root Cause
J2CL opens selected waves with viewport hints. The server snapshot fallback sorted blip document ids naturally, which put b+root after generated numeric ids such as b+1/b+2. The initial viewport window could therefore omit the root blip while still using its text as the panel title. GWT renders from the conversation root thread, so it kept that blip visible/editable.

## Verification
- RED check: with the comparator fix removed, sbt "testOnly org.waveprotocol.box.server.frontend.WaveClientRpcViewportHintsTest" failed at viewportHintsKeepRootBlipInInitialSnapshotWindow: expected [b+root, b+1, b+2] but got [b+1, b+2, b+3].
- python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json
- sbt "testOnly org.waveprotocol.box.server.frontend.WaveClientRpcViewportHintsTest" (20 tests passed)
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where the root blip was unavailable in the initial wave viewport. The root blip now appears as an editable element in the initial view alongside other blips.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->