### PR TITLE
Align J2CL search toolbar with GWT

### DIFF
--- a/j2cl/lit/src/elements/wavy-search-rail.js
+++ b/j2cl/lit/src/elements/wavy-search-rail.js
@@ -2,8 +2,14 @@ import { LitElement, css, html } from "lit";
 import { t } from "../i18n/t.js";
 import {
   SEARCH_RAIL_ICON_REFRESH,
-  SEARCH_RAIL_ICON_SORT,
-  SEARCH_RAIL_ICON_FILTER
+  SEARCH_RAIL_ICON_NEW_WAVE,
+  SEARCH_RAIL_ICON_MANAGE_SAVED,
+  SEARCH_RAIL_ICON_INBOX,
+  SEARCH_RAIL_ICON_MENTIONS,
+  SEARCH_RAIL_ICON_TASKS,
+  SEARCH_RAIL_ICON_PUBLIC,
+  SEARCH_RAIL_ICON_ARCHIVE,
+  SEARCH_RAIL_ICON_PINNED
 } from "../icons/search-rail-icons.js";
 
 /**
@@ -15,24 +21,12 @@ import {
  * `?view=j2cl-root` as on `?view=gwt`:
  *
  *   - query textbox + waveform glyph + help-trigger ("?")
- *   - panel-level action row [Refresh] [Sort] [Filter] (G-PORT-2 new)
- *   - New Wave + Manage saved searches buttons
- *   - Saved-search folder list (Inbox/Mentions/Tasks/Public/Archive/Pinned)
- *   - Filter-chip strip (collapsed under the Filter button)
+ *   - panel-level action row matching the GWT toolbar:
+ *     [New Wave] [Manage saved searches] [Inbox] [Mentions]
+ *     [Tasks] [Public] [Archive] [Pinned] [Refresh]
+ *   - Filter-chip strip below results for explicit advanced filtering
  *   - Result count
  *   - Slot for <wavy-search-rail-card> digest cards
- *
- * The G-PORT-2 action-row is the headline change: the row carries
- * `data-digest-action-row` so the parity test resolves it on both
- * views with one selector, and each button carries
- * `data-digest-action="refresh|sort|filter"`. The buttons emit:
- *
- *   - refresh → wavy-search-refresh-requested (existing event)
- *   - sort    → wavy-search-sort-requested with the selected orderby
- *               token, plus wavy-search-submit when the query changes
- *   - filter  → wavy-search-filter-toggle-requested (G-PORT-2 new;
- *               toggles the existing <details> filter chip strip
- *               open / closed)
  *
  * All previously-existing events still fire (wavy-search-submit,
  * wavy-search-help-toggle, wavy-new-wave-requested,
@@ -55,13 +49,6 @@ export class WavySearchRail extends LitElement {
     savedSearchesLoading: { state: true },
     savedSearchesError: { state: true },
     savedSearchesDirty: { state: true },
-    sortOpen: { state: true },
-    /**
-     * G-PORT-2: track whether the filter chip strip is open. The
-     * panel-level Filter action button toggles this. The user-driven
-     * <details> open state still works because we drive `open` via a
-     * reactive binding, not a one-shot init.
-     */
     filtersOpen: { type: Boolean, attribute: "filters-open", reflect: true }
   };
 
@@ -78,13 +65,6 @@ export class WavySearchRail extends LitElement {
     { id: "unread", label: "Unread only", token: "is:unread" },
     { id: "attachments", label: "With attachments", token: "has:attachment" },
     { id: "from-me", label: "From me", token: "from:me" }
-  ];
-
-  static SORTS = [
-    { id: "datedesc", label: "Newest activity", token: "orderby:datedesc", default: true },
-    { id: "dateasc", label: "Oldest activity", token: "orderby:dateasc" },
-    { id: "createddesc", label: "Newest created", token: "orderby:createddesc" },
-    { id: "createdasc", label: "Oldest created", token: "orderby:createdasc" }
   ];
 
   static styles = css`
@@ -194,14 +174,15 @@ export class WavySearchRail extends LitElement {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 28px;
+      width: 24px;
       height: 28px;
       border: 0;
-      border-radius: 50%;
+      border-radius: 3px;
       background: transparent;
       color: var(--wavy-text-body, #1a202c);
       cursor: pointer;
       padding: 0;
+      position: relative;
     }
     .action-row button:hover,
     .action-row button:focus-visible {
@@ -213,119 +194,16 @@ export class WavySearchRail extends LitElement {
       background: rgba(0, 119, 182, 0.10);
       color: var(--wavy-signal-cyan, #0077b6);
     }
-    .sort-wrap {
-      position: relative;
-      display: inline-flex;
-    }
-    .sort-menu {
-      position: absolute;
-      z-index: 20;
-      top: calc(100% + 4px);
-      left: 0;
-      min-width: 180px;
-      padding: 6px;
-      border: 1px solid var(--wavy-border-hairline, #cbd5e1);
-      border-radius: 10px;
-      background: #ffffff;
-      box-shadow: 0 12px 24px rgba(15, 23, 42, 0.16);
-    }
-    .sort-option {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      width: 100%;
-      min-height: 30px;
-      padding: 5px 8px;
-      border: 0;
-      border-radius: 7px;
-      background: transparent;
-      color: var(--wavy-text-body, #1a202c);
-      font: var(--wavy-type-body, 13px / 1.35 Arial, sans-serif);
-      cursor: pointer;
-      text-align: left;
-    }
-    .sort-option:hover,
-    .sort-option:focus-visible,
-    .sort-option[aria-checked="true"] {
-      background: rgba(0, 119, 182, 0.08);
+    .action-row button[aria-current="page"] {
+      background: rgba(0, 119, 182, 0.12);
       color: var(--wavy-signal-cyan, #0077b6);
+      box-shadow: inset 0 -2px 0 var(--wavy-signal-cyan, #0077b6);
     }
-    .sort-option:focus-visible {
-      outline: 2px solid var(--wavy-signal-cyan, #0077b6);
-      outline-offset: 1px;
+    .toolbar-spacer {
+      flex: 1 1 auto;
+      min-width: 8px;
     }
 
-    .actions {
-      display: flex;
-      gap: 6px;
-      padding: 8px;
-      margin-bottom: 0;
-      border-bottom: 1px solid var(--wavy-border-hairline, #e2e8f0);
-    }
-    .new-wave {
-      flex: 1 1 auto;
-      background: var(--wavy-signal-cyan, #0077b6);
-      color: #ffffff;
-      border: 1px solid var(--wavy-signal-cyan, #0077b6);
-      border-radius: var(--wavy-radius-pill, 9999px);
-      padding: 6px 12px;
-      font: var(--wavy-type-label, 11px / 1.35 Arial, sans-serif);
-      font-weight: 600;
-      cursor: pointer;
-    }
-    .manage-saved {
-      flex: 0 0 auto;
-      background: transparent;
-      color: var(--wavy-text-muted, #64748b);
-      border: 1px solid var(--wavy-border-hairline, #e2e8f0);
-      border-radius: var(--wavy-radius-pill, 9999px);
-      padding: 6px 10px;
-      font: var(--wavy-type-label, 11px / 1.35 Arial, sans-serif);
-      cursor: pointer;
-    }
-    .folders-header {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      margin: 8px 8px 4px;
-    }
-    .folders-header h2 {
-      margin: 0;
-      font: var(--wavy-type-label, 11px / 1.35 Arial, sans-serif);
-      color: var(--wavy-text-muted, #64748b);
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-    }
-    ul.folders {
-      list-style: none;
-      margin: 0 0 8px;
-      padding: 0;
-    }
-    .folder {
-      width: 100%;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: var(--wavy-spacing-2, 8px);
-      background: transparent;
-      color: var(--wavy-text-body, #1a202c);
-      border: 0;
-      padding: var(--wavy-spacing-1, 4px) var(--wavy-spacing-2, 8px);
-      border-radius: 4px;
-      cursor: pointer;
-      font: var(--wavy-type-body, 13px / 1.35 Arial, sans-serif);
-      text-align: left;
-    }
-    .folder[aria-current="page"] {
-      background: rgba(0, 119, 182, 0.10);
-      color: var(--wavy-signal-cyan, #0077b6);
-      font-weight: 600;
-    }
-    .folder:hover,
-    .folder:focus-visible {
-      outline: none;
-      background: rgba(0, 119, 182, 0.06);
-    }
     .custom-searches {
       margin: 0 0 8px;
       padding: 0;
@@ -366,22 +244,28 @@ export class WavySearchRail extends LitElement {
       text-overflow: ellipsis;
     }
     .dot.mentions-dot {
+      position: absolute;
+      top: 2px;
+      right: 2px;
       width: 8px;
       height: 8px;
       border-radius: 50%;
       background: #e53e3e;
     }
     .chip.tasks-chip {
+      position: absolute;
+      top: 1px;
+      right: 0;
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      min-width: 18px;
-      height: 16px;
-      padding: 0 6px;
+      min-width: 14px;
+      height: 12px;
+      padding: 0 4px;
       border-radius: 9999px;
       background: var(--wavy-signal-amber, #9a6700);
       color: #ffffff;
-      font: var(--wavy-type-meta, 11px / 1.4 Arial, sans-serif);
+      font: 700 9px / 12px Arial, sans-serif;
       font-weight: 600;
     }
     p.result-count {
@@ -553,15 +437,11 @@ export class WavySearchRail extends LitElement {
     this.savedSearchesLoading = false;
     this.savedSearchesError = "";
     this.savedSearchesDirty = false;
-    this.sortOpen = false;
     this._savedSearchReturnFocus = null;
     this._savedSearchesLoaded = false;
     this._savedSearchesLoadPromise = null;
     this._savedSearchRows = [];
     this._savedSearchesHadInvalidRows = false;
-    this._documentListenersAttached = false;
-    this._boundDocumentClick = (evt) => this._onDocumentClick(evt);
-    this._boundDocumentKeydown = (evt) => this._onDocumentKeydown(evt);
   }
 
   connectedCallback() {
@@ -572,7 +452,6 @@ export class WavySearchRail extends LitElement {
   }
 
   disconnectedCallback() {
-    this._releaseDocumentListeners();
     super.disconnectedCallback();
   }
 
@@ -634,7 +513,9 @@ export class WavySearchRail extends LitElement {
     if (!this.renderRoot) {
       return;
     }
-    const target = this.renderRoot.querySelector('button.folder[aria-current="page"]');
+    const target = this.renderRoot.querySelector(
+      'button[data-folder-id][aria-current="page"]'
+    );
     if (target && typeof target.focus === "function") {
       target.focus();
     }
@@ -685,149 +566,6 @@ export class WavySearchRail extends LitElement {
       .split(/\s+/)
       .map((t) => t.trim())
       .filter((t) => t.length > 0);
-  }
-
-  /** G-PORT-2: panel-level Filter button toggles the chip-strip details. */
-  _toggleFilterPanel() {
-    this.filtersOpen = !this.filtersOpen;
-    this._emit("wavy-search-filter-toggle-requested", {
-      open: this.filtersOpen
-    });
-  }
-
-  _toggleSortMenu() {
-    this._setSortOpen(!this.sortOpen);
-    if (this.sortOpen) {
-      this.updateComplete.then(() => {
-        const active =
-          this.renderRoot?.querySelector('.sort-option[aria-checked="true"]') ||
-          this.renderRoot?.querySelector(".sort-option");
-        if (active && typeof active.focus === "function") {
-          active.focus();
-        }
-      });
-    }
-  }
-
-  _setSortOpen(open) {
-    this.sortOpen = open;
-    if (open) {
-      this._ensureDocumentListeners();
-    } else {
-      this._releaseDocumentListeners();
-    }
-  }
-
-  _ensureDocumentListeners() {
-    if (this._documentListenersAttached) {
-      return;
-    }
-    document.addEventListener("click", this._boundDocumentClick);
-    document.addEventListener("keydown", this._boundDocumentKeydown);
-    this._documentListenersAttached = true;
-  }
-
-  _releaseDocumentListeners() {
-    if (!this._documentListenersAttached) {
-      return;
-    }
-    document.removeEventListener("click", this._boundDocumentClick);
-    document.removeEventListener("keydown", this._boundDocumentKeydown);
-    this._documentListenersAttached = false;
-  }
-
-  _onDocumentClick(evt) {
-    if (!this.sortOpen) {
-      return;
-    }
-    const path = typeof evt.composedPath === "function" ? evt.composedPath() : [];
-    if (path.includes(this)) {
-      return;
-    }
-    this._setSortOpen(false);
-  }
-
-  _onDocumentKeydown(evt) {
-    if (evt.key !== "Escape") {
-      return;
-    }
-    if (this.sortOpen) {
-      evt.preventDefault();
-      this._setSortOpen(false);
-      const sort = this.renderRoot?.querySelector('[data-digest-action="sort"]');
-      if (sort && typeof sort.focus === "function") {
-        sort.focus();
-      }
-    }
-  }
-
-  _onSortMenuKeydown(evt) {
-    if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(evt.key)) {
-      return;
-    }
-    const options = Array.from(evt.currentTarget.querySelectorAll(".sort-option"));
-    if (options.length === 0) {
-      return;
-    }
-    const active = this.renderRoot?.activeElement || document.activeElement;
-    const current = Math.max(0, options.indexOf(active));
-    let next = -1;
-    if (evt.key === "ArrowDown") {
-      next = (current + 1) % options.length;
-    } else if (evt.key === "ArrowUp") {
-      next = (current - 1 + options.length) % options.length;
-    } else if (evt.key === "Home") {
-      next = 0;
-    } else if (evt.key === "End") {
-      next = options.length - 1;
-    }
-    if (next >= 0) {
-      evt.preventDefault();
-      options[next].focus();
-    }
-  }
-
-  _onSortMenuFocusout(evt) {
-    const next = evt.relatedTarget;
-    if (next && evt.currentTarget.contains(next)) {
-      return;
-    }
-    this._setSortOpen(false);
-  }
-
-  _explicitSortToken() {
-    const token = this._tokenize(this.query).find((part) =>
-      part.toLowerCase().startsWith("orderby:")
-    );
-    return token || "";
-  }
-
-  _applySort(sort) {
-    const explicitSort = this._explicitSortToken().toLowerCase();
-    const sortToken = sort.token.toLowerCase();
-    if ((explicitSort && explicitSort === sortToken) || (!explicitSort && sort.default)) {
-      this._setSortOpen(false);
-      this._focusSortTrigger();
-      return;
-    }
-    const composed = this._queryWithToken(
-      sort.token,
-      (token) => token.toLowerCase().startsWith("orderby:")
-    );
-    this.query = composed;
-    this._setSortOpen(false);
-    this._focusSortTrigger();
-    this._emit("wavy-search-sort-requested", { sortId: sort.id, token: sort.token, query: composed });
-    this._emit("wavy-search-submit", { query: composed });
-  }
-
-  _focusSortTrigger() {
-    this.updateComplete.then(() => {
-      const sort = this.renderRoot?.querySelector('[data-digest-action="sort"]');
-      if (sort && typeof sort.focus === "function") {
-        sort.focus();
-      }
-    });
   }
 
   _normalizeSavedSearch(item) {
@@ -960,8 +698,8 @@ export class WavySearchRail extends LitElement {
 
   _openSavedSearches() {
     this._emit("wavy-manage-saved-searches-requested");
-    this._savedSearchReturnFocus = this.renderRoot?.querySelector(".manage-saved") || null;
-    this._setSortOpen(false);
+    this._savedSearchReturnFocus =
+      this.renderRoot?.querySelector('[data-digest-action="manage-saved"]') || null;
     this.savedSearchesOpen = true;
     this._loadSavedSearches();
     this.updateComplete.then(() => {
@@ -1103,11 +841,6 @@ export class WavySearchRail extends LitElement {
   }
 
   render() {
-    const explicitSort = this._explicitSortToken().toLowerCase();
-    const defaultSort = (
-      WavySearchRail.SORTS.find((sort) => sort.default) || WavySearchRail.SORTS[0]
-    ).token.toLowerCase();
-    const effectiveSort = explicitSort || defaultSort;
     const pinnedSearches = this.savedSearches.filter((item) => item.pinned);
     return html`
       <h2
@@ -1148,6 +881,73 @@ export class WavySearchRail extends LitElement {
       <div class="action-row" role="group" aria-label=${t("searchRail.actions", "Search actions")} data-digest-action-row>
         <button
           type="button"
+          data-digest-action="new-wave"
+          data-shortcut="Shift+Cmd+O"
+          aria-keyshortcuts="Shift+Meta+O Shift+Control+O"
+          aria-label=${t("searchRail.newWave", "New Wave")}
+          title=${t("searchRail.newWave", "New Wave")}
+          @click=${() => this._emit("wavy-new-wave-requested", { source: "button" })}
+        >
+          ${SEARCH_RAIL_ICON_NEW_WAVE}
+        </button>
+        <button
+          type="button"
+          data-digest-action="manage-saved"
+          aria-haspopup="dialog"
+          aria-label=${t("searchRail.manageSaved", "Manage saved searches")}
+          title=${t("searchRail.manageSaved", "Manage saved searches")}
+          @click=${this._openSavedSearches}
+        >
+          ${SEARCH_RAIL_ICON_MANAGE_SAVED}
+        </button>
+        ${WavySearchRail.FOLDERS.map((folder) => {
+          const selected = folder.id === this.activeFolder;
+          const badgeLabel =
+            folder.id === "mentions" && this.mentionsUnread > 0
+              ? `, ${this.mentionsUnread} ${t("searchRail.unreadMentions", "unread mentions")}`
+              : folder.id === "tasks" && this.tasksPending > 0
+                ? `, ${this.tasksPending} ${t("searchRail.pendingTasks", "pending tasks")}`
+                : "";
+          const buttonLabel = `${folder.label}${badgeLabel}`;
+          const icon = {
+            inbox: SEARCH_RAIL_ICON_INBOX,
+            mentions: SEARCH_RAIL_ICON_MENTIONS,
+            tasks: SEARCH_RAIL_ICON_TASKS,
+            public: SEARCH_RAIL_ICON_PUBLIC,
+            archive: SEARCH_RAIL_ICON_ARCHIVE,
+            pinned: SEARCH_RAIL_ICON_PINNED
+          }[folder.id];
+          return html`
+            <button
+              type="button"
+              data-digest-action=${folder.id}
+              data-folder-id=${folder.id}
+              data-query=${folder.query}
+              aria-current=${selected ? "page" : "false"}
+              aria-label=${buttonLabel}
+              title=${buttonLabel}
+              @click=${() => this._onFolderClick(folder)}
+            >
+              ${icon}
+              ${folder.id === "mentions"
+                ? html`<span
+                    class="dot mentions-dot"
+                    aria-hidden="true"
+                    ?hidden=${!this.mentionsUnread || this.mentionsUnread <= 0}
+                  ></span>`
+                : null}
+              ${folder.id === "tasks"
+                ? html`<span
+                    class="chip tasks-chip"
+                    aria-hidden="true"
+                    ?hidden=${!this.tasksPending || this.tasksPending <= 0}
+                  >${this.tasksPending || 0}</span>`
+                : null}
+            </button>
+          `;
+        })}
+        <button
+          type="button"
           data-digest-action="refresh"
           aria-label=${t("searchRail.refresh", "Refresh search results")}
           title=${t("searchRail.refresh", "Refresh search results")}
@@ -1155,123 +955,8 @@ export class WavySearchRail extends LitElement {
         >
           ${SEARCH_RAIL_ICON_REFRESH}
         </button>
-        <span class="sort-wrap">
-          <button
-            type="button"
-            data-digest-action="sort"
-            aria-label=${t("searchRail.sort", "Sort waves")}
-            title=${t("searchRail.sort", "Sort waves")}
-            aria-haspopup="menu"
-            aria-controls="wavy-search-sort-menu"
-            aria-expanded=${this.sortOpen ? "true" : "false"}
-            @click=${this._toggleSortMenu}
-          >
-            ${SEARCH_RAIL_ICON_SORT}
-          </button>
-          ${this.sortOpen
-            ? html`<div
-                class="sort-menu"
-                id="wavy-search-sort-menu"
-                role="menu"
-                aria-label=${t("searchRail.sort", "Sort waves")}
-                @keydown=${this._onSortMenuKeydown}
-                @focusout=${this._onSortMenuFocusout}
-              >
-                ${WavySearchRail.SORTS.map((sort) => html`
-                  <button
-                    type="button"
-                    class="sort-option"
-                    role="menuitemradio"
-                    aria-checked=${effectiveSort === sort.token.toLowerCase() ? "true" : "false"}
-                    data-sort-token=${sort.token}
-                    aria-label=${sort.label}
-                    title=${sort.label}
-                    @click=${() => this._applySort(sort)}
-                  >
-                    <span>${sort.label}</span>
-                    ${effectiveSort === sort.token.toLowerCase() ? html`<span aria-hidden="true">✓</span>` : null}
-                  </button>
-                `)}
-              </div>`
-            : null}
-        </span>
-        <button
-          type="button"
-          data-digest-action="filter"
-          aria-label=${t("searchRail.filter", "Filter waves")}
-          title=${t("searchRail.filter", "Filter waves")}
-          aria-pressed=${this.filtersOpen ? "true" : "false"}
-          aria-expanded=${this.filtersOpen ? "true" : "false"}
-          aria-controls="wavy-search-filter-strip"
-          @click=${this._toggleFilterPanel}
-        >
-          ${SEARCH_RAIL_ICON_FILTER}
-        </button>
+        <span class="toolbar-spacer" aria-hidden="true"></span>
       </div>
-
-      <div class="actions">
-        <button
-          type="button"
-          class="new-wave"
-          data-shortcut="Shift+Cmd+O"
-          aria-keyshortcuts="Shift+Meta+O Shift+Control+O"
-          aria-label=${t("searchRail.newWave", "New Wave")}
-          title=${t("searchRail.newWave", "New Wave")}
-          @click=${() => this._emit("wavy-new-wave-requested", { source: "button" })}
-        >
-          ${t("searchRail.newWave", "New Wave")}
-        </button>
-        <button
-          type="button"
-          class="manage-saved"
-          aria-haspopup="dialog"
-          aria-label=${t("searchRail.manageSaved", "Manage saved searches")}
-          title=${t("searchRail.manageSaved", "Manage saved searches")}
-          @click=${this._openSavedSearches}
-        >
-          ${t("searchRail.manageSaved", "Manage saved searches")}
-        </button>
-      </div>
-
-      <div class="folders-header">
-        <h2 id="folders-title">${t("searchRail.savedSearches", "Saved searches")}</h2>
-      </div>
-      <ul class="folders" aria-labelledby="folders-title">
-        ${WavySearchRail.FOLDERS.map((folder) => {
-          const selected = folder.id === this.activeFolder;
-          return html`
-            <li>
-              <button
-                type="button"
-                class="folder"
-                data-folder-id=${folder.id}
-                data-query=${folder.query}
-                aria-current=${selected ? "page" : "false"}
-                aria-label=${folder.label}
-                title=${folder.label}
-                @click=${() => this._onFolderClick(folder)}
-              >
-                <span class="label">${folder.label}</span>
-                ${folder.id === "mentions"
-                  ? html`<span
-                      class="dot mentions-dot"
-                      aria-label="${this.mentionsUnread || 0} ${t("searchRail.unreadMentions", "unread mentions")}"
-                      ?hidden=${!this.mentionsUnread || this.mentionsUnread <= 0}
-                    ></span>`
-                  : null}
-                ${folder.id === "tasks"
-                  ? html`<span
-                      class="chip tasks-chip"
-                      aria-label="${this.tasksPending || 0} ${t("searchRail.pendingTasks", "pending tasks")}"
-                      ?hidden=${!this.tasksPending || this.tasksPending <= 0}
-                      >${this.tasksPending || 0}</span
-                    >`
-                  : null}
-              </button>
-            </li>
-          `;
-        })}
-      </ul>
       ${pinnedSearches.length > 0
         ? html`
             <ul class="custom-searches" aria-label=${t("searchRail.pinnedSaved", "Pinned saved searches")}>

--- a/j2cl/lit/src/icons/search-rail-icons.js
+++ b/j2cl/lit/src/icons/search-rail-icons.js
@@ -2,25 +2,62 @@ import { svg } from "lit";
 
 /*
  * G-PORT-2 (#1111) icon set for the J2CL <wavy-search-rail> action
- * row. The glyphs mirror the GWT lucide-style icons used by
- * SearchPresenter (ICON_REFRESH, ICON_MODIFY) plus a sort icon for the
- * visible "sort" affordance the GWT inventory now exposes via the
- * orderby: search tokens. All glyphs are 16x16, currentColor stroked,
- * 1.6px line, rounded caps/joins so they read at the same weight as
- * the format-toolbar icons under V-3.
+ * row. The glyphs mirror the compact GWT SearchPresenter toolbar:
+ * New Wave, saved-search management, folder shortcuts, and refresh.
+ * All glyphs are 16x16, currentColor stroked, 1.6px line, rounded
+ * caps/joins so they read at the same weight as the format-toolbar
+ * icons under V-3.
  */
 export const SEARCH_RAIL_ICON_REFRESH = svg`<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
   <polyline points="14.5 3 14.5 6.5 11 6.5"></polyline>
   <path d="M13.1 9.5a5.5 5.5 0 1 1-1.3-5.7l2.7 2.7"></path>
 </svg>`;
 
-export const SEARCH_RAIL_ICON_SORT = svg`<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-  <line x1="4" y1="3" x2="4" y2="13"></line>
-  <polyline points="2 11 4 13 6 11"></polyline>
-  <line x1="11" y1="13" x2="11" y2="3"></line>
-  <polyline points="9 5 11 3 13 5"></polyline>
+export const SEARCH_RAIL_ICON_NEW_WAVE = svg`<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M7.3 2.8H3.2a1.4 1.4 0 0 0-1.4 1.4v8.6a1.4 1.4 0 0 0 1.4 1.4h8.6a1.4 1.4 0 0 0 1.4-1.4V8.7"></path>
+  <path d="M11.9 1.8a1.5 1.5 0 0 1 2.1 2.1L8 9.9l-2.6.7.7-2.6 5.8-6.2z"></path>
 </svg>`;
 
-export const SEARCH_RAIL_ICON_FILTER = svg`<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-  <polygon points="2 3 14 3 9.5 8.5 9.5 13 6.5 11.5 6.5 8.5"></polygon>
+export const SEARCH_RAIL_ICON_MANAGE_SAVED = svg`<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="3.5" y1="14" x2="3.5" y2="9.5"></line>
+  <line x1="3.5" y1="6.5" x2="3.5" y2="2"></line>
+  <line x1="8" y1="14" x2="8" y2="8"></line>
+  <line x1="8" y1="5" x2="8" y2="2"></line>
+  <line x1="12.5" y1="14" x2="12.5" y2="10.5"></line>
+  <line x1="12.5" y1="7.5" x2="12.5" y2="2"></line>
+  <line x1="2" y1="9.5" x2="5" y2="9.5"></line>
+  <line x1="6.5" y1="5" x2="9.5" y2="5"></line>
+  <line x1="11" y1="10.5" x2="14" y2="10.5"></line>
+</svg>`;
+
+export const SEARCH_RAIL_ICON_INBOX = svg`<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3.2 4.2h9.6l1.6 5.1v3.1a1.2 1.2 0 0 1-1.2 1.2H2.8a1.2 1.2 0 0 1-1.2-1.2V9.3l1.6-5.1z"></path>
+  <path d="M1.8 9.3h3.7l1 1.5h3l1-1.5h3.7"></path>
+</svg>`;
+
+export const SEARCH_RAIL_ICON_MENTIONS = svg`<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="8" cy="8" r="2.3"></circle>
+  <path d="M10.3 5.7v3.1a1.8 1.8 0 0 0 3.6 0V8a5.9 5.9 0 1 0-2.2 4.6"></path>
+</svg>`;
+
+export const SEARCH_RAIL_ICON_TASKS = svg`<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M13.5 7.5v4.8a1.3 1.3 0 0 1-1.3 1.3H3.7a1.3 1.3 0 0 1-1.3-1.3V3.7a1.3 1.3 0 0 1 1.3-1.3h6"></path>
+  <path d="M6 7.7l2 2 5.6-6"></path>
+</svg>`;
+
+export const SEARCH_RAIL_ICON_PUBLIC = svg`<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="8" cy="8" r="6.3"></circle>
+  <path d="M1.7 8h12.6"></path>
+  <path d="M8 1.7c1.7 1.7 2.5 3.8 2.5 6.3s-.8 4.6-2.5 6.3C6.3 12.6 5.5 10.5 5.5 8S6.3 3.4 8 1.7z"></path>
+</svg>`;
+
+export const SEARCH_RAIL_ICON_ARCHIVE = svg`<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M2.5 5.5v7.2a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1V5.5"></path>
+  <path d="M1.8 2.8h12.4v2.7H1.8z"></path>
+  <path d="M6.5 8.2h3"></path>
+</svg>`;
+
+export const SEARCH_RAIL_ICON_PINNED = svg`<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M8 11v3.2"></path>
+  <path d="M4.1 11h7.8V9.9a1.4 1.4 0 0 0-.8-1.2l-1-.5a1.4 1.4 0 0 1-.8-1.2V3.8h.6a1.1 1.1 0 0 0 0-2.2H6.1a1.1 1.1 0 0 0 0 2.2h.6V7a1.4 1.4 0 0 1-.8 1.2l-1 .5a1.4 1.4 0 0 0-.8 1.2V11z"></path>
 </svg>`;

--- a/j2cl/lit/test/wavy-search-rail.test.js
+++ b/j2cl/lit/test/wavy-search-rail.test.js
@@ -30,7 +30,7 @@ describe("<wavy-search-rail>", () => {
   it("renders all six saved-search folders with canonical query strings (B.5–B.10)", async () => {
     const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
     await el.updateComplete;
-    const folders = Array.from(el.renderRoot.querySelectorAll("button.folder"));
+    const folders = Array.from(el.renderRoot.querySelectorAll("button[data-folder-id]"));
     const map = new Map(folders.map((b) => [b.dataset.folderId, b.dataset.query]));
     expect(map.get("inbox")).to.equal("in:inbox");
     expect(map.get("mentions")).to.equal("mentions:me");
@@ -38,7 +38,7 @@ describe("<wavy-search-rail>", () => {
     expect(map.get("public")).to.equal("with:@");
     expect(map.get("archive")).to.equal("in:archive");
     expect(map.get("pinned")).to.equal("in:pinned");
-    const labels = folders.map((b) => b.querySelector(".label").textContent.trim());
+    const labels = folders.map((b) => b.getAttribute("aria-label"));
     expect(labels).to.deep.equal(["Inbox", "Mentions", "Tasks", "Public", "Archive", "Pinned"]);
   });
 
@@ -78,7 +78,7 @@ describe("<wavy-search-rail>", () => {
   it("New Wave button click emits wavy-new-wave-requested and carries aria-keyshortcuts (B.3)", async () => {
     const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
     await el.updateComplete;
-    const newWave = el.renderRoot.querySelector(".new-wave");
+    const newWave = el.renderRoot.querySelector('[data-digest-action="new-wave"]');
     expect(newWave).to.exist;
     expect(newWave.getAttribute("aria-keyshortcuts")).to.equal(
       "Shift+Meta+O Shift+Control+O"
@@ -99,7 +99,7 @@ describe("<wavy-search-rail>", () => {
     const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
     try {
       await el.updateComplete;
-      const manage = el.renderRoot.querySelector(".manage-saved");
+      const manage = el.renderRoot.querySelector('[data-digest-action="manage-saved"]');
       setTimeout(() => manage.click(), 0);
       const evt = await oneEvent(el, "wavy-manage-saved-searches-requested");
       expect(evt).to.exist;
@@ -120,7 +120,7 @@ describe("<wavy-search-rail>", () => {
     const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
     try {
       await el.updateComplete;
-      el.renderRoot.querySelector(".manage-saved").click();
+      el.renderRoot.querySelector('[data-digest-action="manage-saved"]').click();
       await waitForMicrotasks();
       await el.updateComplete;
       const dialog = el.renderRoot.querySelector('[role="dialog"]');
@@ -142,7 +142,7 @@ describe("<wavy-search-rail>", () => {
     const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
     try {
       await el.updateComplete;
-      el.renderRoot.querySelector(".manage-saved").click();
+      el.renderRoot.querySelector('[data-digest-action="manage-saved"]').click();
       await waitForMicrotasks();
       await el.updateComplete;
       const dialog = el.renderRoot.querySelector('[role="dialog"]');
@@ -163,7 +163,7 @@ describe("<wavy-search-rail>", () => {
       expect(el.renderRoot.querySelector(".custom-search")).to.be.null;
       el.renderRoot.querySelector('button[aria-label="Close saved searches"]').click();
       await el.updateComplete;
-      el.renderRoot.querySelector(".manage-saved").click();
+      el.renderRoot.querySelector('[data-digest-action="manage-saved"]').click();
       await el.updateComplete;
       const reopened = el.renderRoot.querySelector('[role="dialog"]');
       expect(reopened.querySelector(".saved-error").textContent).to.contain(
@@ -278,7 +278,7 @@ describe("<wavy-search-rail>", () => {
     const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
     try {
       await el.updateComplete;
-      el.renderRoot.querySelector(".manage-saved").click();
+      el.renderRoot.querySelector('[data-digest-action="manage-saved"]').click();
       await waitForMicrotasks();
       await el.updateComplete;
       const dialog = el.renderRoot.querySelector('[role="dialog"]');
@@ -345,7 +345,7 @@ describe("<wavy-search-rail>", () => {
     const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
     try {
       await el.updateComplete;
-      el.renderRoot.querySelector(".manage-saved").click();
+      el.renderRoot.querySelector('[data-digest-action="manage-saved"]').click();
       await waitForMicrotasks();
       await el.updateComplete;
       expect(el.renderRoot.querySelector(".saved-error").textContent).to.equal(
@@ -372,7 +372,7 @@ describe("<wavy-search-rail>", () => {
     const el = await fixture(html`<wavy-search-rail query="tag:work"></wavy-search-rail>`);
     try {
       await el.updateComplete;
-      const manage = el.renderRoot.querySelector(".manage-saved");
+      const manage = el.renderRoot.querySelector('[data-digest-action="manage-saved"]');
       manage.click();
       await waitForMicrotasks();
       await el.updateComplete;
@@ -412,7 +412,7 @@ describe("<wavy-search-rail>", () => {
     const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
     try {
       await el.updateComplete;
-      const manage = el.renderRoot.querySelector(".manage-saved");
+      const manage = el.renderRoot.querySelector('[data-digest-action="manage-saved"]');
       manage.click();
       await waitForMicrotasks();
       await el.updateComplete;
@@ -452,7 +452,7 @@ describe("<wavy-search-rail>", () => {
     const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
     try {
       await el.updateComplete;
-      el.renderRoot.querySelector(".manage-saved").click();
+      el.renderRoot.querySelector('[data-digest-action="manage-saved"]').click();
       await waitForMicrotasks();
       await el.updateComplete;
       const nameInput = el.renderRoot.querySelector('input[aria-label="Saved search name"]');
@@ -624,7 +624,7 @@ describe("<wavy-search-rail>", () => {
     const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
     try {
       await el.updateComplete;
-      el.renderRoot.querySelector(".manage-saved").click();
+      el.renderRoot.querySelector('[data-digest-action="manage-saved"]').click();
       await el.updateComplete;
       const add = el.renderRoot.querySelector(".saved-footer .saved-button");
       expect(add.disabled).to.equal(true);
@@ -661,7 +661,7 @@ describe("<wavy-search-rail>", () => {
     expect(el.savedSearchDrafts[0].name).to.equal("Dirty");
   });
 
-  it("opening saved-search management closes the sort menu", async () => {
+  it("opening saved-search management uses the compact GWT toolbar manage icon", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = async () => new Response("[]", {
       status: 200,
@@ -670,13 +670,9 @@ describe("<wavy-search-rail>", () => {
     const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
     try {
       await el.updateComplete;
-      el.renderRoot.querySelector('[data-digest-action="sort"]').click();
-      await el.updateComplete;
-      expect(el.renderRoot.querySelector(".sort-menu")).to.exist;
-      el.renderRoot.querySelector(".manage-saved").click();
+      el.renderRoot.querySelector('[data-digest-action="manage-saved"]').click();
       await waitForMicrotasks();
       await el.updateComplete;
-      expect(el.renderRoot.querySelector(".sort-menu")).to.be.null;
       expect(el.renderRoot.querySelector('[role="dialog"]')).to.exist;
     } finally {
       globalThis.fetch = originalFetch;
@@ -692,7 +688,7 @@ describe("<wavy-search-rail>", () => {
     const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
     try {
       await el.updateComplete;
-      const manage = el.renderRoot.querySelector(".manage-saved");
+      const manage = el.renderRoot.querySelector('[data-digest-action="manage-saved"]');
       manage.click();
       await waitForMicrotasks();
       await el.updateComplete;
@@ -760,7 +756,7 @@ describe("<wavy-search-rail>", () => {
     );
     await el.updateComplete;
     expect(el.activeFolder).to.equal("");
-    const folders = el.renderRoot.querySelectorAll("button.folder");
+    const folders = el.renderRoot.querySelectorAll("button[data-folder-id]");
     folders.forEach((b) => expect(b.getAttribute("aria-current")).to.equal("false"));
   });
 
@@ -775,6 +771,9 @@ describe("<wavy-search-rail>", () => {
     el.mentionsUnread = 3;
     await el.updateComplete;
     expect(dot.hasAttribute("hidden")).to.be.false;
+    const mentions = el.renderRoot.querySelector('[data-folder-id="mentions"]');
+    expect(mentions.getAttribute("aria-label")).to.equal("Mentions, 3 unread mentions");
+    expect(dot.getAttribute("aria-hidden")).to.equal("true");
   });
 
   it("Mentions dot uses the GWT unread red, not the task/toolbar palettes", async () => {
@@ -798,6 +797,9 @@ describe("<wavy-search-rail>", () => {
     await el.updateComplete;
     expect(chip.hasAttribute("hidden")).to.be.false;
     expect(chip.textContent.trim()).to.equal("7");
+    expect(chip.getAttribute("aria-hidden")).to.equal("true");
+    const tasks = el.renderRoot.querySelector('[data-folder-id="tasks"]');
+    expect(tasks.getAttribute("aria-label")).to.equal("Tasks, 7 pending tasks");
   });
 
   it("Tasks chip uses --wavy-signal-amber", async () => {
@@ -1061,225 +1063,35 @@ describe("<wavy-search-rail>", () => {
     });
   });
 
-  // G-PORT-2 (#1111): panel-level action row clones the GWT
-  // SearchPresenter toolbar — refresh + sort + filter buttons in a
-  // single visible row, each tagged with `data-digest-action="..."`
-  // so the parity test resolves them on both views via one selector.
-  describe("G-PORT-2 panel-level action row (#1111)", () => {
-    it("renders an action row with refresh + sort + filter buttons", async () => {
-      const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
-      await el.updateComplete;
-      const row = el.renderRoot.querySelector("[data-digest-action-row]");
-      expect(row, "action row must mount").to.exist;
-      const buttons = Array.from(row.querySelectorAll("button[data-digest-action]"));
-      expect(buttons.map((b) => b.dataset.digestAction)).to.deep.equal([
-        "refresh",
-        "sort",
-        "filter"
-      ]);
-    });
-
-    it("each action button carries an aria-label for screen readers", async () => {
-      const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
-      await el.updateComplete;
-      const refresh = el.renderRoot.querySelector('[data-digest-action="refresh"]');
-      const sort = el.renderRoot.querySelector('[data-digest-action="sort"]');
-      const filter = el.renderRoot.querySelector('[data-digest-action="filter"]');
-      expect(refresh.getAttribute("aria-label")).to.equal("Refresh search results");
-      expect(sort.getAttribute("aria-label")).to.equal("Sort waves");
-      expect(sort.getAttribute("aria-haspopup")).to.equal("menu");
-      expect(sort.getAttribute("aria-controls")).to.equal("wavy-search-sort-menu");
-      expect(filter.getAttribute("aria-label")).to.equal("Filter waves");
-    });
-
-    it("Sort button opens options and applying one submits an orderby query", async () => {
-      const el = await fixture(html`<wavy-search-rail query="in:inbox orderby:datedesc"></wavy-search-rail>`);
-      await el.updateComplete;
-      const sort = el.renderRoot.querySelector('[data-digest-action="sort"]');
-      sort.click();
-      await el.updateComplete;
-      const createdOldest = el.renderRoot.querySelector('[data-sort-token="orderby:createdasc"]');
-      expect(createdOldest, "created oldest sort option mounts").to.exist;
-      setTimeout(() => createdOldest.click(), 0);
-      const evt = await oneEvent(el, "wavy-search-submit");
-      expect(evt.detail.query).to.equal("in:inbox orderby:createdasc");
-      await el.updateComplete;
-      await waitForMicrotasks();
-      expect(el.renderRoot.querySelector(".sort-menu")).to.be.null;
-      expect(el.renderRoot.activeElement).to.equal(sort);
-    });
-
-    it("applying the default sort writes an explicit orderby token", async () => {
-      const el = await fixture(html`<wavy-search-rail query="in:inbox orderby:dateasc"></wavy-search-rail>`);
-      await el.updateComplete;
-      el.renderRoot.querySelector('[data-digest-action="sort"]').click();
-      await el.updateComplete;
-      const newestActivity = el.renderRoot.querySelector('[data-sort-token="orderby:datedesc"]');
-      expect(newestActivity.getAttribute("aria-checked")).to.equal("false");
-      expect(newestActivity.hasAttribute("aria-current")).to.equal(false);
-      setTimeout(() => newestActivity.click(), 0);
-      const evt = await oneEvent(el, "wavy-search-submit");
-      expect(evt.detail.query).to.equal("in:inbox orderby:datedesc");
-    });
-
-    it("default sort option shows aria-checked=true when query has no orderby token", async () => {
-      const el = await fixture(html`<wavy-search-rail query="in:inbox"></wavy-search-rail>`);
-      await el.updateComplete;
-      el.renderRoot.querySelector('[data-digest-action="sort"]').click();
-      await el.updateComplete;
-      const newestActivity = el.renderRoot.querySelector('[data-sort-token="orderby:datedesc"]');
-      const oldest = el.renderRoot.querySelector('[data-sort-token="orderby:createdasc"]');
-      expect(newestActivity.getAttribute("aria-checked")).to.equal("true");
-      expect(oldest.getAttribute("aria-checked")).to.equal("false");
-    });
-
-    it("choosing the implicit default sort with no orderby closes without re-submitting", async () => {
-      const el = await fixture(html`<wavy-search-rail query="in:inbox"></wavy-search-rail>`);
-      await el.updateComplete;
-      let submitCount = 0;
-      let sortRequestedCount = 0;
-      el.addEventListener("wavy-search-submit", () => {
-        submitCount += 1;
-      });
-      el.addEventListener("wavy-search-sort-requested", () => {
-        sortRequestedCount += 1;
-      });
-      const sort = el.renderRoot.querySelector('[data-digest-action="sort"]');
-      sort.click();
-      await el.updateComplete;
-      const newestActivity = el.renderRoot.querySelector('[data-sort-token="orderby:datedesc"]');
-      newestActivity.click();
-      await waitForMicrotasks();
-      await el.updateComplete;
-      expect(el.query).to.equal("in:inbox");
-      expect(submitCount).to.equal(0);
-      expect(sortRequestedCount).to.equal(0);
-      expect(el.renderRoot.querySelector(".sort-menu")).to.be.null;
-      expect(el.renderRoot.activeElement).to.equal(sort);
-    });
-
-    it("focuses the explicitly checked sort option when reopening the menu", async () => {
-      const el = await fixture(html`<wavy-search-rail query="in:inbox orderby:createdasc"></wavy-search-rail>`);
-      await el.updateComplete;
-      el.renderRoot.querySelector('[data-digest-action="sort"]').click();
-      await el.updateComplete;
-      await waitForMicrotasks();
-      const selected = el.renderRoot.querySelector('[data-sort-token="orderby:createdasc"]');
-      const unchecked = el.renderRoot.querySelector('[data-sort-token="orderby:datedesc"]');
-      expect(selected.getAttribute("aria-checked")).to.equal("true");
-      expect(unchecked.getAttribute("aria-checked")).to.equal("false");
-      expect(el.renderRoot.activeElement).to.equal(selected);
-    });
-
-    it("choosing the current sort closes the menu without re-submitting", async () => {
-      const el = await fixture(html`<wavy-search-rail query="in:inbox orderby:datedesc"></wavy-search-rail>`);
-      await el.updateComplete;
-      let submitCount = 0;
-      let sortRequestedCount = 0;
-      el.addEventListener("wavy-search-submit", () => {
-        submitCount += 1;
-      });
-      el.addEventListener("wavy-search-sort-requested", () => {
-        sortRequestedCount += 1;
-      });
-      const sort = el.renderRoot.querySelector('[data-digest-action="sort"]');
-      sort.click();
-      await el.updateComplete;
-      el.renderRoot.querySelector('[data-sort-token="orderby:datedesc"]').click();
-      await waitForMicrotasks();
-      await el.updateComplete;
-      expect(submitCount).to.equal(0);
-      expect(sortRequestedCount).to.equal(0);
-      expect(el.renderRoot.querySelector(".sort-menu")).to.be.null;
-      expect(el.renderRoot.activeElement).to.equal(sort);
-    });
-
-    it("Escape and outside click close the sort menu", async () => {
-      const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
-      await el.updateComplete;
-      const sort = el.renderRoot.querySelector('[data-digest-action="sort"]');
-      sort.click();
-      await el.updateComplete;
-      expect(el.renderRoot.querySelector(".sort-menu")).to.exist;
-      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
-      await el.updateComplete;
-      expect(el.renderRoot.querySelector(".sort-menu")).to.be.null;
-
-      sort.click();
-      await el.updateComplete;
-      expect(el.renderRoot.querySelector(".sort-menu")).to.exist;
-      document.body.click();
-      await el.updateComplete;
-      expect(el.renderRoot.querySelector(".sort-menu")).to.be.null;
-    });
-
-    it("focus leaving the sort menu closes it", async () => {
-      const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
-      await el.updateComplete;
-      const sort = el.renderRoot.querySelector('[data-digest-action="sort"]');
-      sort.click();
-      await el.updateComplete;
-      const menu = el.renderRoot.querySelector(".sort-menu");
-      const filter = el.renderRoot.querySelector('[data-digest-action="filter"]');
-      menu.dispatchEvent(new FocusEvent("focusout", {
-        bubbles: true,
-        composed: true,
-        relatedTarget: filter
-      }));
-      await el.updateComplete;
-      expect(el.renderRoot.querySelector(".sort-menu")).to.be.null;
-    });
-
-    it("Arrow keys move through sort options", async () => {
-      const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
-      await el.updateComplete;
-      el.renderRoot.querySelector('[data-digest-action="sort"]').click();
-      await el.updateComplete;
-      const menu = el.renderRoot.querySelector(".sort-menu");
-      const options = Array.from(menu.querySelectorAll(".sort-option"));
-      options[0].focus();
-      menu.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
-      expect(el.renderRoot.activeElement).to.equal(options[1]);
-      menu.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
-      expect(el.renderRoot.activeElement).to.equal(options[options.length - 1]);
-    });
-
-    it("Filter button click toggles the chip strip open and emits an event", async () => {
-      const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
-      await el.updateComplete;
-      const filterBtn = el.renderRoot.querySelector('[data-digest-action="filter"]');
-      const details = el.renderRoot.querySelector("details[data-j2cl-filter-strip]");
-      expect(details.hasAttribute("open"), "starts collapsed").to.equal(false);
-
-      // Use a click and capture the synchronous event without race risk:
-      // wavy-search-filter-toggle-requested is fired synchronously inside
-      // the handler, so attach the listener first and then click.
-      let toggleEvt = null;
-      el.addEventListener("wavy-search-filter-toggle-requested", (e) => {
-        toggleEvt = e;
-      });
-      filterBtn.click();
-      await el.updateComplete;
-      expect(toggleEvt, "filter-toggle-requested fires").to.exist;
-      expect(toggleEvt.detail.open).to.equal(true);
-      expect(details.hasAttribute("open"), "details opens").to.equal(true);
-      expect(filterBtn.getAttribute("aria-pressed")).to.equal("true");
-      expect(filterBtn.getAttribute("aria-expanded")).to.equal("true");
-
-      // Second click closes.
-      filterBtn.click();
-      await el.updateComplete;
-      expect(details.hasAttribute("open")).to.equal(false);
-      expect(filterBtn.getAttribute("aria-pressed")).to.equal("false");
-    });
-
-    it("filter button aria-controls points at the filter strip id", async () => {
-      const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
-      await el.updateComplete;
-      const filterBtn = el.renderRoot.querySelector('[data-digest-action="filter"]');
-      const details = el.renderRoot.querySelector("details[data-j2cl-filter-strip]");
-      expect(filterBtn.getAttribute("aria-controls")).to.equal(details.id);
-    });
+  it("renders the full GWT compact toolbar sequence without the J2CL pill/list controls", async () => {
+    const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
+    await el.updateComplete;
+    const row = el.renderRoot.querySelector("[data-digest-action-row]");
+    const buttons = Array.from(row.querySelectorAll("button[data-digest-action]"));
+    expect(buttons.map((b) => b.dataset.digestAction)).to.deep.equal([
+      "new-wave",
+      "manage-saved",
+      "inbox",
+      "mentions",
+      "tasks",
+      "public",
+      "archive",
+      "pinned",
+      "refresh"
+    ]);
+    expect(buttons.map((b) => b.getAttribute("aria-label"))).to.deep.equal([
+      "New Wave",
+      "Manage saved searches",
+      "Inbox",
+      "Mentions",
+      "Tasks",
+      "Public",
+      "Archive",
+      "Pinned",
+      "Refresh search results"
+    ]);
+    expect(el.renderRoot.querySelector(".actions")).to.be.null;
+    expect(el.renderRoot.querySelector("ul.folders")).to.be.null;
   });
 
   // J-UI-1 (#1079): the rail must expose a `cards` slot so the J2CL
@@ -1306,17 +1118,17 @@ describe("<wavy-search-rail>", () => {
       expect(assigned.map((n) => n.dataset.waveId)).to.deep.equal(["w+a", "w+b"]);
     });
 
-    it("preserves the saved-search list above the cards slot and filter strip below it", async () => {
+    it("preserves compact toolbar above the cards slot and filter strip below it", async () => {
       const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
       await el.updateComplete;
-      const folders = el.renderRoot.querySelector("ul.folders");
+      const toolbar = el.renderRoot.querySelector("[data-digest-action-row]");
       const slot = el.renderRoot.querySelector('slot[name="cards"]');
       const filters = el.renderRoot.querySelector("details.filters");
-      expect(folders, "saved-search list mounts").to.exist;
+      expect(toolbar, "toolbar mounts").to.exist;
       expect(slot, "cards slot mounts").to.exist;
       expect(filters, "filter strip mounts").to.exist;
-      // Document order: folders, then cards slot, then filter strip.
-      expect(folders.compareDocumentPosition(slot) & Node.DOCUMENT_POSITION_FOLLOWING).to.be.greaterThan(0);
+      // Document order: toolbar, then cards slot, then filter strip.
+      expect(toolbar.compareDocumentPosition(slot) & Node.DOCUMENT_POSITION_FOLLOWING).to.be.greaterThan(0);
       expect(slot.compareDocumentPosition(filters) & Node.DOCUMENT_POSITION_FOLLOWING).to.be.greaterThan(0);
     });
   });

--- a/wave/config/changelog.d/2026-05-18-j2cl-search-toolbar-gwt-parity.json
+++ b/wave/config/changelog.d/2026-05-18-j2cl-search-toolbar-gwt-parity.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-18-j2cl-search-toolbar-gwt-parity",
+  "version": "J2CL parity",
+  "date": "2026-05-18",
+  "title": "J2CL search rail now uses the compact GWT search toolbar actions.",
+  "summary": "The J2CL root search rail now presents the same compact icon action row as GWT for New Wave, saved-search management, folder shortcuts, and refresh, instead of the separate large New Wave/manage buttons and folder list.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Moved J2CL New Wave, Manage saved searches, Inbox, Mentions, Tasks, Public, Archive, Pinned, and Refresh into one GWT-style toolbar row.",
+        "Kept the existing J2CL events and canonical search queries behind the toolbar icons so functionality matches the previous controls while matching the GWT layout."
+      ]
+    }
+  ]
+}

--- a/wave/src/e2e/j2cl-gwt-parity/tests/keyboard-shortcuts-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/keyboard-shortcuts-parity.spec.ts
@@ -268,7 +268,7 @@ test.describe("G-PORT-7 keyboard shortcuts parity", () => {
     const railNewWaveAriaKey = await page.evaluate(() => {
       const railHost = document.querySelector("wavy-search-rail") as any;
       if (!railHost || !railHost.shadowRoot) return null;
-      const btn = railHost.shadowRoot.querySelector("button.new-wave");
+      const btn = railHost.shadowRoot.querySelector('[data-digest-action="new-wave"]');
       return btn ? btn.getAttribute("aria-keyshortcuts") : null;
     });
     expect(

--- a/wave/src/e2e/j2cl-gwt-parity/tests/search-panel-parity.spec.ts
+++ b/wave/src/e2e/j2cl-gwt-parity/tests/search-panel-parity.spec.ts
@@ -2,8 +2,8 @@
 // ?view=gwt.
 //
 // Asserts:
-//   - both views render the search rail surface (action row + folder
-//     list);
+//   - both views render the search rail surface and J2CL exposes the
+//     GWT-style compact action row;
 //   - both views expose a refresh affordance reachable via a single
 //     selector (`title="Refresh search results"`) that exists on the
 //     GWT toolbar (setTooltip ⇒ HTML `title="..."`) and the J2CL
@@ -104,7 +104,8 @@ test.describe("G-PORT-2 search panel parity", () => {
       "J2CL: <wavy-search-rail> must mount"
     ).toHaveCount(1, { timeout: 15_000 });
 
-    // The new action row must mount with refresh + sort + filter buttons.
+    // The compact GWT-style action row must mount with the same toolbar
+    // sequence as the J2CL Lit rail.
     // The rail emits the action row twice in DOM: once pre-upgrade (in
     // light DOM, where it's intentionally hidden post-upgrade because the
     // rail does not expose a default slot per #1060) and once in the
@@ -115,18 +116,22 @@ test.describe("G-PORT-2 search panel parity", () => {
       page.locator("[data-digest-action-row]:visible").first(),
       "J2CL: at least one action-row must be visible"
     ).toBeVisible({ timeout: 10_000 });
-    await expect(
-      page.locator('[data-digest-action="refresh"]:visible').first(),
-      "J2CL: refresh action button"
-    ).toBeVisible();
-    await expect(
-      page.locator('[data-digest-action="sort"]:visible').first(),
-      "J2CL: sort action button"
-    ).toBeVisible();
-    await expect(
-      page.locator('[data-digest-action="filter"]:visible').first(),
-      "J2CL: filter action button"
-    ).toBeVisible();
+    for (const action of [
+      "new-wave",
+      "manage-saved",
+      "inbox",
+      "mentions",
+      "tasks",
+      "public",
+      "archive",
+      "pinned",
+      "refresh"
+    ]) {
+      await expect(
+        page.locator(`[data-digest-action="${action}"]:visible`).first(),
+        `J2CL: ${action} action button`
+      ).toBeVisible();
+    }
 
     // Refresh affordance is reachable via the cross-view selector.
     await expect(
@@ -194,10 +199,10 @@ test.describe("G-PORT-2 search panel parity", () => {
       refreshButton(page),
       "GWT: refresh affordance reachable via title='Refresh search results'"
     ).toBeVisible({ timeout: 30_000 });
-    // data-digest-action-row/sort/filter are only emitted by the J2CL SSR
+    // data-digest-action-row is only emitted by the J2CL SSR
     // path (appendWavySearchRail in HtmlRenderer). The GWT search panel
     // creates its toolbar via SearchPanelWidget at runtime without those
-    // attributes, so sort/filter are not asserted here.
+    // attributes, so the compact J2CL row is not asserted here.
 
     // GWT search is also async (XHR /search). Wait until either at
     // least one digest card appears, or the wave-count info bar

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -4412,30 +4412,21 @@ public final class HtmlRenderer {
     sb.append("        <input type=\"search\" class=\"query\" name=\"q\" aria-label=\"Search waves\" value=\"").append(safeInitialQuery).append("\">\n");
     sb.append("        <button type=\"button\" class=\"help-trigger\" aria-label=\"Search help\" aria-haspopup=\"dialog\" aria-controls=\"wavy-search-help\">?</button>\n");
     sb.append("      </div>\n");
-    // G-PORT-2 (#1111): pre-upgrade light-DOM action row mirroring the
-    // shadow-DOM render so the buttons exist before the J2CL bundle
-    // upgrades the rail. Each button carries `data-digest-action="..."`
-    // so the parity test resolves it on both views with one selector.
+    // Pre-upgrade light-DOM action row mirroring the compact GWT toolbar.
+    // Each button carries `data-digest-action="..."` so the parity tests
+    // resolve the same affordances before and after the Lit upgrade.
     sb.append("      <div class=\"action-row\" role=\"group\" aria-label=\"Search actions\" data-digest-action-row>\n");
-    sb.append("        <button type=\"button\" data-digest-action=\"refresh\" aria-label=\"Refresh search results\" title=\"Refresh search results\">↻</button>\n");
-    sb.append("        <button type=\"button\" data-digest-action=\"sort\" aria-label=\"Sort waves\" title=\"Sort waves\" aria-haspopup=\"menu\">⇅</button>\n");
-    sb.append("        <button type=\"button\" data-digest-action=\"filter\" aria-label=\"Filter waves\" title=\"Filter waves\" aria-pressed=\"false\" aria-expanded=\"false\" aria-controls=\"wavy-search-filter-strip\">▽</button>\n");
+    sb.append("        <button type=\"button\" data-digest-action=\"new-wave\" data-shortcut=\"Shift+Cmd+O\" aria-keyshortcuts=\"Shift+Meta+O Shift+Control+O\" aria-label=\"New Wave\" title=\"New Wave\">N</button>\n");
+    sb.append("        <button type=\"button\" data-digest-action=\"manage-saved\" aria-haspopup=\"dialog\" aria-label=\"Manage saved searches\" title=\"Manage saved searches\">S</button>\n");
+    sb.append("        <button type=\"button\" data-digest-action=\"inbox\" data-folder-id=\"inbox\" data-query=\"in:inbox\" aria-current=\"").append("inbox".equals(activeFolder) ? "page" : "false").append("\" aria-label=\"Inbox\" title=\"Inbox\">I</button>\n");
+    sb.append("        <button type=\"button\" data-digest-action=\"mentions\" data-folder-id=\"mentions\" data-query=\"mentions:me\" aria-current=\"").append("mentions".equals(activeFolder) ? "page" : "false").append("\" aria-label=\"Mentions\" title=\"Mentions\">@<span class=\"dot mentions-dot\" aria-hidden=\"true\" hidden></span></button>\n");
+    sb.append("        <button type=\"button\" data-digest-action=\"tasks\" data-folder-id=\"tasks\" data-query=\"tasks:me\" aria-current=\"").append("tasks".equals(activeFolder) ? "page" : "false").append("\" aria-label=\"Tasks\" title=\"Tasks\">T<span class=\"chip tasks-chip\" aria-hidden=\"true\" hidden>0</span></button>\n");
+    sb.append("        <button type=\"button\" data-digest-action=\"public\" data-folder-id=\"public\" data-query=\"with:@\" aria-current=\"").append("public".equals(activeFolder) ? "page" : "false").append("\" aria-label=\"Public\" title=\"Public\">P</button>\n");
+    sb.append("        <button type=\"button\" data-digest-action=\"archive\" data-folder-id=\"archive\" data-query=\"in:archive\" aria-current=\"").append("archive".equals(activeFolder) ? "page" : "false").append("\" aria-label=\"Archive\" title=\"Archive\">A</button>\n");
+    sb.append("        <button type=\"button\" data-digest-action=\"pinned\" data-folder-id=\"pinned\" data-query=\"in:pinned\" aria-current=\"").append("pinned".equals(activeFolder) ? "page" : "false").append("\" aria-label=\"Pinned\" title=\"Pinned\">Pin</button>\n");
+    sb.append("        <button type=\"button\" data-digest-action=\"refresh\" aria-label=\"Refresh search results\" title=\"Refresh search results\">R</button>\n");
+    sb.append("        <span class=\"toolbar-spacer\" aria-hidden=\"true\"></span>\n");
     sb.append("      </div>\n");
-    sb.append("      <div class=\"actions\">\n");
-    sb.append("        <button type=\"button\" class=\"new-wave\" data-shortcut=\"Shift+Cmd+O\" aria-keyshortcuts=\"Shift+Meta+O Shift+Control+O\">New Wave</button>\n");
-    sb.append("        <button type=\"button\" class=\"manage-saved\" aria-haspopup=\"dialog\">Manage saved searches</button>\n");
-    sb.append("      </div>\n");
-    sb.append("      <div class=\"folders-header\">\n");
-    sb.append("        <h2 id=\"folders-title\">Saved searches</h2>\n");
-    sb.append("      </div>\n");
-    sb.append("      <ul class=\"folders\" aria-labelledby=\"folders-title\">\n");
-    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"inbox\" data-query=\"in:inbox\" aria-current=\"").append("inbox".equals(activeFolder) ? "page" : "false").append("\"><span class=\"label\">Inbox</span></button></li>\n");
-    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"mentions\" data-query=\"mentions:me\" aria-current=\"").append("mentions".equals(activeFolder) ? "page" : "false").append("\"><span class=\"label\">Mentions</span><span class=\"dot mentions-dot\" hidden></span></button></li>\n");
-    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"tasks\" data-query=\"tasks:me\" aria-current=\"").append("tasks".equals(activeFolder) ? "page" : "false").append("\"><span class=\"label\">Tasks</span><span class=\"chip tasks-chip\" hidden>0</span></button></li>\n");
-    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"public\" data-query=\"with:@\" aria-current=\"").append("public".equals(activeFolder) ? "page" : "false").append("\"><span class=\"label\">Public</span></button></li>\n");
-    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"archive\" data-query=\"in:archive\" aria-current=\"").append("archive".equals(activeFolder) ? "page" : "false").append("\"><span class=\"label\">Archive</span></button></li>\n");
-    sb.append("        <li><button type=\"button\" class=\"folder\" data-folder-id=\"pinned\" data-query=\"in:pinned\" aria-current=\"").append("pinned".equals(activeFolder) ? "page" : "false").append("\"><span class=\"label\">Pinned</span></button></li>\n");
-    sb.append("      </ul>\n");
     // F-4 (#1039 / R-4.7): SSR filter chip strip. Mirrors
     // WavySearchRail.FILTERS so the strip exists pre-upgrade and the
     // J2CL upgrade is content-preserving. aria-pressed is derived from

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clSearchRailParityTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clSearchRailParityTest.java
@@ -336,7 +336,11 @@ public final class J2clSearchRailParityTest {
       assertTrue(
           "Folder " + id + " carries data-query=\"" + query + "\"",
           html.contains("data-query=\"" + query + "\""));
-      assertTrue("Folder " + id + " label \"" + label + "\"", html.contains(">" + label + "<"));
+      // #1253: compact toolbar uses icon buttons; the accessible name is
+      // in aria-label/title, not as visible inner text.
+      assertTrue(
+          "Folder " + id + " accessible label \"" + label + "\" in aria-label",
+          html.contains("aria-label=\"" + label + "\""));
     }
     // Inbox is selected by default; the others are aria-current="false".
     assertTrue(
@@ -356,26 +360,35 @@ public final class J2clSearchRailParityTest {
     assertTrue(
         "B.2 help-trigger references the modal id",
         html.contains("aria-controls=\"wavy-search-help\""));
-    assertTrue("B.3 New Wave button class", html.contains("class=\"new-wave\""));
+    // B.3 New Wave button — #1253 compact toolbar uses data-digest-action
+    // instead of class="new-wave" so the parity selector is consistent
+    // with the other toolbar actions.
+    assertTrue(
+        "B.3 New Wave button is tagged data-digest-action=\"new-wave\"",
+        html.contains("data-digest-action=\"new-wave\""));
     assertTrue(
         "B.3 New Wave button carries the keyboard-shortcut metadata "
             + "(global listener intentionally deferred to S6)",
         html.contains("aria-keyshortcuts=\"Shift+Meta+O Shift+Control+O\""));
-    assertTrue("B.4 Manage saved searches class", html.contains("class=\"manage-saved\""));
-    // G-PORT-2 (#1111): Refresh moved into the panel-level action row
-    // alongside Sort and Filter — tagged with `data-digest-action`
-    // for the cross-view parity selector.
+    // B.4 Manage saved searches — same pattern: data-digest-action replaces
+    // the old class="manage-saved" contract (#1253 compact toolbar).
+    assertTrue(
+        "B.4 Manage saved searches is tagged data-digest-action=\"manage-saved\"",
+        html.contains("data-digest-action=\"manage-saved\""));
+    // G-PORT-2 (#1111, updated #1253): Refresh is in the compact action row;
+    // Sort and Filter were removed from the toolbar (sort now happens via
+    // orderby: query tokens; filtering via the inline filter-chip strip below).
     assertTrue(
         "B.11 Refresh button is tagged data-digest-action=\"refresh\"",
         html.contains("data-digest-action=\"refresh\""));
     assertTrue(
         "B.11 Refresh button has descriptive aria-label",
         html.contains("aria-label=\"Refresh search results\""));
-    assertTrue(
-        "G-PORT-2 (#1111) Sort button is tagged data-digest-action=\"sort\"",
+    assertFalse(
+        "#1253: Sort button was removed from compact toolbar",
         html.contains("data-digest-action=\"sort\""));
-    assertTrue(
-        "G-PORT-2 (#1111) Filter button is tagged data-digest-action=\"filter\"",
+    assertFalse(
+        "#1253: Filter button was removed from compact toolbar",
         html.contains("data-digest-action=\"filter\""));
     assertTrue(
         "G-PORT-2 (#1111) action row mounts with data-digest-action-row",
@@ -383,12 +396,14 @@ public final class J2clSearchRailParityTest {
     assertTrue(
         "B.12 result-count <p> with aria-live=\"polite\"",
         html.contains("class=\"result-count\" aria-live=\"polite\""));
-    assertTrue(
-        "Saved-searches list announces its name to screen readers via "
-            + "aria-labelledby pointing to the folders header h2",
+    // #1253: separate folder list (ul.folders + h2 header) replaced by
+    // compact icon buttons inside the action row. Folder navigation is
+    // now part of the data-digest-action-row.
+    assertFalse(
+        "#1253: old folders-title h2 removed",
         html.contains("<h2 id=\"folders-title\">Saved searches</h2>"));
-    assertTrue(
-        "Saved-searches list aria-labelledby relationship intact",
+    assertFalse(
+        "#1253: old ul.folders removed",
         html.contains("<ul class=\"folders\" aria-labelledby=\"folders-title\""));
   }
 
@@ -483,10 +498,10 @@ public final class J2clSearchRailParityTest {
             + "does not flash before the J2CL bundle upgrades the element "
             + "(connectedCallback drops `hidden` on upgrade so the open/close "
             + "flow takes over).",
-        html.contains("<wavy-search-help id=\"wavy-search-help\" hidden"));
+        html.contains("<wavy-search-help slot=\"modal\" id=\"wavy-search-help\" hidden"));
     assertFalse(
         "Modal renders closed by default (no open attribute on initial mount)",
-        html.contains("<wavy-search-help id=\"wavy-search-help\" open"));
+        html.contains("<wavy-search-help slot=\"modal\" id=\"wavy-search-help\" open"));
     String[] filterTokens = {
         // C.1–C.4
         ">in:inbox<", ">in:archive<", ">in:all<", ">in:pinned<",

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
@@ -103,6 +103,9 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
             && html.contains("data-digest-action=\"public\"")
             && html.contains("data-digest-action=\"archive\"")
             && html.contains("data-digest-action=\"pinned\""));
+    assertTrue(
+        "signed-in J2CL search rail must SSR the GWT-style refresh toolbar icon",
+        html.contains("data-digest-action=\"refresh\""));
     assertFalse(
         "signed-in J2CL search rail must not SSR the old J2CL sort button",
         html.contains("data-digest-action=\"sort\""));

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
@@ -89,6 +89,29 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
     assertTrue(
         "signed-in J2CL search rail must SSR the blue panel-title strip",
         html.contains("<h2 class=\"panel-title\" id=\"wavy-search-rail-title\""));
+    assertTrue(
+        "signed-in J2CL search rail must SSR the GWT-style New Wave toolbar icon",
+        html.contains("data-digest-action=\"new-wave\""));
+    assertTrue(
+        "signed-in J2CL search rail must SSR the GWT-style saved-search management icon",
+        html.contains("data-digest-action=\"manage-saved\""));
+    assertTrue(
+        "signed-in J2CL search rail must SSR folder toolbar icons",
+        html.contains("data-digest-action=\"inbox\"")
+            && html.contains("data-digest-action=\"mentions\"")
+            && html.contains("data-digest-action=\"tasks\"")
+            && html.contains("data-digest-action=\"public\"")
+            && html.contains("data-digest-action=\"archive\"")
+            && html.contains("data-digest-action=\"pinned\""));
+    assertFalse(
+        "signed-in J2CL search rail must not SSR the old J2CL sort button",
+        html.contains("data-digest-action=\"sort\""));
+    assertFalse(
+        "signed-in J2CL search rail must not SSR the old J2CL filter button",
+        html.contains("data-digest-action=\"filter\""));
+    assertFalse(
+        "signed-in J2CL search rail must not SSR the old separate folder list",
+        html.contains("<ul class=\"folders\""));
     assertFalse(html.contains("j2cl-brand-eyebrow"));
     assertFalse(html.contains("J2CL ·"));
   }


### PR DESCRIPTION
Closes #1252\n\n## Summary\n- Replace the J2CL-only search rail pill controls and folder list with the compact GWT-style toolbar icon sequence.\n- Preserve the existing New Wave, saved-search management, folder shortcut, pinned saved-search, refresh, and filter-chip event behavior.\n- Add a changelog fragment and update Lit coverage for the GWT toolbar contract.\n\n## Verification\n- npm test -- --files test/wavy-search-rail.test.js (j2cl/lit) -> 61 passed, 0 failed\n- npm test (j2cl/lit) -> 868 passed, 0 failed\n- npm run build (j2cl/lit) -> audit-buttons OK and esbuild completed\n- python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py -> assembled 371 entries; validation passed\n- git diff --check -> passed\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search toolbar redesigned to a compact icon-based action row: New Wave, Manage Saved Searches, per-folder shortcuts (Inbox, Mentions, Tasks, Public, Archive, Pinned) with unread/pending indicators, plus Refresh; filter strip remains. Sort and legacy filter/sort controls removed.
* **Tests**
  * UI and parity tests updated to assert the compact toolbar, new button selectors, folder shortcuts, and accessibility attributes.
* **Changelog**
  * Release note entry added documenting the toolbar parity change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1253?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->