### PR TITLE
Fix J2CL inline blip placement and open-wave viewport

### DIFF
--- a/docs/superpowers/plans/2026-05-18-issue-1254-j2cl-inline-blip-scroll.md
+++ b/docs/superpowers/plans/2026-05-18-issue-1254-j2cl-inline-blip-scroll.md
@@ -1,0 +1,23 @@
+# Issue 1254: J2CL Inline Blip Insertion And Open-Wave Scroll Parity
+
+## Root Cause
+
+- GWT toolbar Reply calls `ReplyLocationResolver.resolve(...)`; when no caret/selection is found it falls back to `blip.getContent().size() - 1`, then calls `WaveletBasedConversationBlip.addReplyThread(location).appendBlip()`.
+- J2CL already has a rich-content path that can emit the same parent-body `<reply id="...">` anchor, but `J2clComposeSurfaceController.onInlineReplyAnchorRequested(...)` stores `-1` when `wave-blip` reports no captured caret. The next submit therefore creates only the manifest `<thread>` and no body anchor.
+- A manifest-only child thread is not equivalent to GWT's anchored inline reply. It renders like a continuation/flat child and can disappear from the expected inline location after reload because rehydration follows document anchors.
+- Open-wave scrolling already has client-side `FocusBlipSelector.selectInitialBlip` parity on `main`; however the initial server viewport can still exclude the root blip when it anchors around the last unread/last blip. PR #1251 has the narrow server-side fix that keeps the root visible in the initial J2CL viewport.
+
+## Implementation Plan
+
+- In `J2clComposeSurfaceController`, normalize a missing inline anchor to `parentBodyItemCount - 1` when the parent body has a valid end position, matching GWT's fallback.
+- Keep explicit captured caret offsets unchanged.
+- Keep continuation replies unchanged; they do not call the inline-anchor request path and `submitReply(..., continuation=true)` still suppresses anchors.
+- Bring the small root-visible initial viewport fix from PR #1251 into this branch if it is not on `main`, so open-wave scroll behavior has both client focus and server window parity.
+- Add a changelog fragment for the user-facing J2CL behavior fix.
+
+## Verification
+
+- Red/green: `./mvnw -f pom.xml -Psearch-sidecar -Dtest=org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceControllerTest test` from `j2cl/`.
+- Focused server viewport test if root-visible fix is included.
+- Changelog assemble/validate.
+- PR gate subset from the J2CL runbook as time permits: `sbt -batch "j2clSearchBuild; j2clSearchTest"`.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -1229,9 +1229,19 @@ public final class J2clComposeSurfaceController {
     int normalizedBodyItemCount = Math.max(0, parentBodyItemCount);
     pendingInlineAnchorBlipId = blipId == null ? "" : blipId;
     pendingInlineAnchorItemOffset =
-        (anchorItemOffset >= 1 && anchorItemOffset < normalizedBodyItemCount)
-            ? anchorItemOffset : -1;
+        normalizedInlineReplyAnchorOffset(anchorItemOffset, normalizedBodyItemCount);
     pendingInlineAnchorParentBodyItemCount = normalizedBodyItemCount;
+  }
+
+  private static int normalizedInlineReplyAnchorOffset(
+      int anchorItemOffset, int parentBodyItemCount) {
+    if (anchorItemOffset >= 1 && anchorItemOffset < parentBodyItemCount) {
+      return anchorItemOffset;
+    }
+    if (parentBodyItemCount > 1) {
+      return parentBodyItemCount - 1;
+    }
+    return -1;
   }
 
   private void clearPendingInlineAnchor() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -1235,10 +1235,10 @@ public final class J2clComposeSurfaceController {
 
   private static int normalizedInlineReplyAnchorOffset(
       int anchorItemOffset, int parentBodyItemCount) {
-    if (anchorItemOffset >= 1 && anchorItemOffset < parentBodyItemCount) {
+    if (anchorItemOffset >= 0 && anchorItemOffset < parentBodyItemCount) {
       return anchorItemOffset;
     }
-    if (parentBodyItemCount > 1) {
+    if (anchorItemOffset < 0 && parentBodyItemCount > 1) {
       return parentBodyItemCount - 1;
     }
     return -1;
@@ -2462,7 +2462,7 @@ public final class J2clComposeSurfaceController {
     // body-anchor element.
     final boolean useAnchor =
         !continuation
-            && pendingInlineAnchorItemOffset >= 1
+            && pendingInlineAnchorItemOffset >= 0
             && pendingInlineAnchorParentBodyItemCount > 0
             && replyTargetBlipId != null
             && replyTargetBlipId.equals(pendingInlineAnchorBlipId);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -1235,9 +1235,11 @@ public final class J2clComposeSurfaceController {
 
   private static int normalizedInlineReplyAnchorOffset(
       int anchorItemOffset, int parentBodyItemCount) {
-    if (anchorItemOffset >= 0 && anchorItemOffset < parentBodyItemCount) {
+    // Downstream anchor-op builders require offset >= 1; only pass through in-range values.
+    if (anchorItemOffset >= 1 && anchorItemOffset < parentBodyItemCount) {
       return anchorItemOffset;
     }
+    // Sentinel -1 (or any negative): no caret was captured; fall back to last body item.
     if (anchorItemOffset < 0 && parentBodyItemCount > 1) {
       return parentBodyItemCount - 1;
     }
@@ -2462,7 +2464,7 @@ public final class J2clComposeSurfaceController {
     // body-anchor element.
     final boolean useAnchor =
         !continuation
-            && pendingInlineAnchorItemOffset >= 0
+            && pendingInlineAnchorItemOffset >= 1
             && pendingInlineAnchorParentBodyItemCount > 0
             && replyTargetBlipId != null
             && replyTargetBlipId.equals(pendingInlineAnchorBlipId);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -139,8 +139,9 @@ public class J2clComposeSurfaceControllerTest {
   }
 
   @Test
-  public void inlineReplyWithCaretAtBodyStartPreservesOffset() {
-    // offset 0 is a valid start-of-body caret, not a "no caret" signal
+  public void inlineReplyWithOffsetZeroProducesNoAnchor() {
+    // offset 0 is below the minimum accepted by downstream anchor-op builders (>= 1),
+    // so it is treated as an invalid anchor and results in no inline anchor (-1).
     FakeGateway gateway = new FakeGateway();
     FakeView view = new FakeView();
     CapturingDeltaFactory factory = new CapturingDeltaFactory();
@@ -161,7 +162,7 @@ public class J2clComposeSurfaceControllerTest {
     controller.onReplySubmitted("reply at body start", "b+child");
 
     Assert.assertNotNull(factory.lastReplySession);
-    Assert.assertEquals(0, factory.lastInlineAnchorItemOffset);
+    Assert.assertEquals(-1, factory.lastInlineAnchorItemOffset);
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -139,6 +139,32 @@ public class J2clComposeSurfaceControllerTest {
   }
 
   @Test
+  public void inlineReplyWithCaretAtBodyStartPreservesOffset() {
+    // offset 0 is a valid start-of-body caret, not a "no caret" signal
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    CapturingDeltaFactory factory = new CapturingDeltaFactory();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            factory,
+            waveId -> { },
+            waveId -> { });
+
+    controller.start();
+    controller.onWriteSessionChanged(writeSessionWithReplyTargets());
+    controller.onInlineReplyAnchorRequested(
+        "b+child",
+        /* anchorItemOffset= */ 0,
+        /* parentBodyItemCount= */ TEST_BODY_ITEM_COUNT);
+    controller.onReplySubmitted("reply at body start", "b+child");
+
+    Assert.assertNotNull(factory.lastReplySession);
+    Assert.assertEquals(0, factory.lastInlineAnchorItemOffset);
+  }
+
+  @Test
   public void continuationReplyIgnoresPendingInlineAnchor() {
     FakeGateway gateway = new FakeGateway();
     FakeView view = new FakeView();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -109,6 +109,64 @@ public class J2clComposeSurfaceControllerTest {
   }
 
   @Test
+  public void inlineReplyWithoutCapturedCaretFallsBackToParentBodyEndLikeGwt() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    CapturingDeltaFactory factory = new CapturingDeltaFactory();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            factory,
+            waveId -> { },
+            waveId -> { });
+
+    controller.start();
+    controller.onWriteSessionChanged(writeSessionWithReplyTargets());
+    controller.onInlineReplyAnchorRequested(
+        "b+child",
+        /* anchorItemOffset= */ -1,
+        /* parentBodyItemCount= */ TEST_BODY_ITEM_COUNT);
+    controller.onReplySubmitted("reply without live selection", "b+child");
+
+    Assert.assertNotNull(factory.lastReplySession);
+    Assert.assertEquals("b+child", factory.lastReplySession.getReplyTargetBlipId());
+    Assert.assertEquals(
+        "GWT ReplyLocationResolver falls back to blip.getContent().size() - 1",
+        TEST_BODY_ITEM_COUNT - 1,
+        factory.lastInlineAnchorItemOffset);
+    Assert.assertEquals(TEST_BODY_ITEM_COUNT, factory.lastInlineAnchorParentBodyItemCount);
+  }
+
+  @Test
+  public void continuationReplyIgnoresPendingInlineAnchor() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    CapturingDeltaFactory factory = new CapturingDeltaFactory();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            factory,
+            waveId -> { },
+            waveId -> { });
+
+    controller.start();
+    controller.onWriteSessionChanged(writeSessionWithReplyTargets());
+    controller.onInlineReplyAnchorRequested(
+        "b+child",
+        /* anchorItemOffset= */ TEST_BODY_ITEM_COUNT - 1,
+        /* parentBodyItemCount= */ TEST_BODY_ITEM_COUNT);
+    controller.onContinuationSubmitted("same-level reply", "b+child");
+
+    Assert.assertNotNull(factory.lastReplySession);
+    Assert.assertTrue(factory.lastReplySession.isContinuationReply());
+    Assert.assertEquals("b+child", factory.lastReplySession.getReplyTargetBlipId());
+    Assert.assertEquals(-1, factory.lastInlineAnchorItemOffset);
+    Assert.assertEquals(0, factory.lastInlineAnchorParentBodyItemCount);
+  }
+
+  @Test
   public void selectedWaveParticipantsRenderBeforeWriteSessionReady() {
     FakeGateway gateway = new FakeGateway();
     FakeView view = new FakeView();
@@ -4865,6 +4923,8 @@ public class J2clComposeSurfaceControllerTest {
     private String lastDraftText = null;
     private int lastDocumentComponentCount = -1;
     private J2clSidecarWriteSession lastReplySession = null;
+    private int lastInlineAnchorItemOffset = Integer.MIN_VALUE;
+    private int lastInlineAnchorParentBodyItemCount = Integer.MIN_VALUE;
 
     @Override
     public J2clComposeSurfaceController.CreateWaveRequest createWaveRequest(
@@ -4898,6 +4958,19 @@ public class J2clComposeSurfaceControllerTest {
       lastDocumentComponentCount = componentCount(document);
       return new SidecarSubmitRequest(
           session.getSelectedWaveId() + "/~/conv+root", "{\"reply\":true}", session.getChannelId());
+    }
+
+    @Override
+    public SidecarSubmitRequest createReplyRequest(
+        String address,
+        J2clSidecarWriteSession session,
+        String draftText,
+        org.waveprotocol.box.j2cl.richtext.J2clComposerDocument document,
+        int inlineAnchorItemOffset,
+        int parentBodyItemCount) {
+      lastInlineAnchorItemOffset = inlineAnchorItemOffset;
+      lastInlineAnchorParentBodyItemCount = parentBodyItemCount;
+      return createReplyRequest(address, session, draftText, document);
     }
 
     private static int componentCount(org.waveprotocol.box.j2cl.richtext.J2clComposerDocument document) {

--- a/wave/config/changelog.d/2026-05-18-j2cl-inline-blip-scroll-parity.json
+++ b/wave/config/changelog.d/2026-05-18-j2cl-inline-blip-scroll-parity.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-18-j2cl-inline-blip-scroll-parity",
+  "version": "J2CL parity",
+  "date": "2026-05-18",
+  "title": "J2CL now matches GWT inline reply placement and wave-open positioning.",
+  "summary": "J2CL replies now use the same inline-blip fallback position as GWT when no caret is captured, and initial wave-open viewport ordering keeps the root title blip visible.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Inline replies created from J2CL now fall back to the end of the parent blip body instead of creating a manifest-only child thread.",
+        "Initial J2CL viewport windows now keep the root blip ordered before generated numeric blips so wave-open scrolling has the same starting content as GWT."
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
@@ -38,7 +38,13 @@ import org.waveprotocol.box.server.rpc.ServerRpcController;
 import org.waveprotocol.box.server.waveserver.search.SearchWaveletManager;
 import org.waveprotocol.box.server.waveserver.WaveletProvider.SubmitRequestListener;
 import org.waveprotocol.wave.concurrencycontrol.channel.dto.FragmentsPayload;
+import org.waveprotocol.wave.model.document.DocumentConstants;
+import org.waveprotocol.wave.model.document.operation.AnnotationBoundaryMap;
+import org.waveprotocol.wave.model.document.operation.Attributes;
+import org.waveprotocol.wave.model.document.operation.DocInitialization;
+import org.waveprotocol.wave.model.document.operation.DocInitializationCursor;
 import org.waveprotocol.wave.model.id.SegmentId;
+import org.waveprotocol.wave.model.wave.data.ReadableBlipData;
 import org.waveprotocol.wave.model.wave.data.ReadableWaveletData;
 import org.waveprotocol.wave.model.id.IdFilter;
 import org.waveprotocol.wave.model.id.InvalidIdException;
@@ -73,7 +79,6 @@ import javax.annotation.Nullable;
 public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
 
   private static final Log LOG = Log.get(WaveClientRpcImpl.class);
-  private static final String ROOT_BLIP_ID = "b+root";
   private static final String J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK =
       "J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK";
   /** Config hook to adjust viewport limits at runtime (eager-read at startup). */
@@ -559,16 +564,54 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
       }
     }
     if (naturalOrder) {
-      blips.sort(WaveClientRpcImpl::compareBlipIdsNaturally);
+      String rootBlipId = getRootBlipId(snapshot.snapshot);
+      blips.sort((left, right) -> compareBlipIdsNaturally(left, right, rootBlipId));
     }
     return blips;
   }
 
-  private static int compareBlipIdsNaturally(String left, String right) {
-    if (ROOT_BLIP_ID.equals(left) && !ROOT_BLIP_ID.equals(right)) {
+  /**
+   * Reads the root blip ID from the manifest document of a wavelet snapshot.
+   * The manifest ({@code "conversation"} document) has the form
+   * {@code <conversation><blip id="b+xyz">...</blip>...</conversation>}.
+   * The first {@code <blip>} element's {@code id} attribute is the root blip.
+   *
+   * @return the root blip ID, or {@code null} if the manifest is absent or has no blip element.
+   */
+  @Nullable
+  private static String getRootBlipId(ReadableWaveletData waveletData) {
+    ReadableBlipData manifestDoc =
+        waveletData.getDocument(DocumentConstants.MANIFEST_DOCUMENT_ID);
+    if (manifestDoc == null) {
+      return null;
+    }
+    DocInitialization docOp = manifestDoc.getContent().asOperation();
+    final String[] rootBlipId = {null};
+    docOp.apply(new DocInitializationCursor() {
+      @Override
+      public void elementStart(String type, Attributes attrs) {
+        if (rootBlipId[0] == null
+            && DocumentConstants.BLIP.equals(type)
+            && attrs != null) {
+          String id = attrs.get(DocumentConstants.BLIP_ID);
+          if (id != null) {
+            rootBlipId[0] = id;
+          }
+        }
+      }
+      @Override public void elementEnd() {}
+      @Override public void characters(String chars) {}
+      @Override public void annotationBoundary(AnnotationBoundaryMap map) {}
+    });
+    return rootBlipId[0];
+  }
+
+  private static int compareBlipIdsNaturally(String left, String right,
+      @Nullable String rootBlipId) {
+    if (rootBlipId != null && rootBlipId.equals(left) && !rootBlipId.equals(right)) {
       return -1;
     }
-    if (ROOT_BLIP_ID.equals(right) && !ROOT_BLIP_ID.equals(left)) {
+    if (rootBlipId != null && rootBlipId.equals(right) && !rootBlipId.equals(left)) {
       return 1;
     }
     String leftPrefix = trailingNumberPrefix(left);

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
@@ -585,24 +585,29 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
     if (manifestDoc == null) {
       return null;
     }
-    DocInitialization docOp = manifestDoc.getContent().asOperation();
     final String[] rootBlipId = {null};
-    docOp.apply(new DocInitializationCursor() {
-      @Override
-      public void elementStart(String type, Attributes attrs) {
-        if (rootBlipId[0] == null
-            && DocumentConstants.BLIP.equals(type)
-            && attrs != null) {
-          String id = attrs.get(DocumentConstants.BLIP_ID);
-          if (id != null) {
-            rootBlipId[0] = id;
+    try {
+      DocInitialization docOp = manifestDoc.getContent().asOperation();
+      docOp.apply(new DocInitializationCursor() {
+        @Override
+        public void elementStart(String type, Attributes attrs) {
+          if (rootBlipId[0] == null
+              && DocumentConstants.BLIP.equals(type)
+              && attrs != null) {
+            String id = attrs.get(DocumentConstants.BLIP_ID);
+            if (id != null) {
+              rootBlipId[0] = id;
+            }
           }
         }
-      }
-      @Override public void elementEnd() {}
-      @Override public void characters(String chars) {}
-      @Override public void annotationBoundary(AnnotationBoundaryMap map) {}
-    });
+        @Override public void elementEnd() {}
+        @Override public void characters(String chars) {}
+        @Override public void annotationBoundary(AnnotationBoundaryMap map) {}
+      });
+    } catch (Exception e) {
+      LOG.warning("Failed to parse manifest for root blip ID, falling back to natural order: " + e);
+      return null;
+    }
     return rootBlipId[0];
   }
 

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveClientRpcImpl.java
@@ -73,6 +73,7 @@ import javax.annotation.Nullable;
 public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
 
   private static final Log LOG = Log.get(WaveClientRpcImpl.class);
+  private static final String ROOT_BLIP_ID = "b+root";
   private static final String J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK =
       "J2CL_VIEWPORT_FULL_SNAPSHOT_FALLBACK";
   /** Config hook to adjust viewport limits at runtime (eager-read at startup). */
@@ -564,10 +565,10 @@ public class WaveClientRpcImpl implements ProtocolWaveClientRpc.Interface {
   }
 
   private static int compareBlipIdsNaturally(String left, String right) {
-    if ("b+root".equals(left) && !"b+root".equals(right)) {
+    if (ROOT_BLIP_ID.equals(left) && !ROOT_BLIP_ID.equals(right)) {
       return -1;
     }
-    if ("b+root".equals(right) && !"b+root".equals(left)) {
+    if (ROOT_BLIP_ID.equals(right) && !ROOT_BLIP_ID.equals(left)) {
       return 1;
     }
     String leftPrefix = trailingNumberPrefix(left);

--- a/wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcViewportHintsTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/frontend/WaveClientRpcViewportHintsTest.java
@@ -38,6 +38,15 @@ import org.waveprotocol.wave.model.version.HashedVersion;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.model.wave.data.ReadableWaveletData;
 import org.waveprotocol.wave.concurrencycontrol.channel.FragmentsMetrics;
+import org.waveprotocol.wave.model.document.DocumentConstants;
+import org.waveprotocol.wave.model.document.operation.DocInitialization;
+import org.waveprotocol.wave.model.document.operation.DocOp;
+import org.waveprotocol.wave.model.document.operation.impl.AttributesImpl;
+import org.waveprotocol.wave.model.document.operation.impl.DocInitializationBuffer;
+import org.waveprotocol.wave.model.wave.data.DocumentOperationSink;
+import org.waveprotocol.wave.model.operation.OperationException;
+import org.waveprotocol.wave.model.operation.SilentOperationSink;
+import org.waveprotocol.wave.model.document.Document;
 
 import java.util.Arrays;
 import java.util.List;
@@ -154,9 +163,10 @@ public final class WaveClientRpcViewportHintsTest {
 
   @Test
   public void viewportHintsKeepRootBlipInInitialSnapshotWindow() {
+    // "b+root" is the actual root blip identified in the manifest — it must sort first.
     ProtocolWaveletUpdate update =
         openWithRpc(
-            makeWaveClientRpcWithBlipIds("b+2", "b+root", "b+1", "b+3"),
+            makeWaveClientRpcWithRootBlipId("b+root", "b+2", "b+root", "b+1", "b+3"),
             viewportHintRequest(null, "forward", 2));
 
     assertTrue(update.hasFragments());
@@ -513,6 +523,69 @@ public final class WaveClientRpcViewportHintsTest {
       }
     };
     return WaveClientRpcImpl.create(frontend, false);
+  }
+
+  /**
+   * Like {@link #makeWaveClientRpcWithBlipIds} but also adds a manifest document so that the
+   * root blip can be resolved from the snapshot (rather than relying on a hardcoded string).
+   */
+  private static WaveClientRpcImpl makeWaveClientRpcWithRootBlipId(
+      String rootBlipId, String... blipIds) {
+    ClientFrontend frontend = new ClientFrontend() {
+      @Override public void submitRequest(ParticipantId u, WaveletName wn, org.waveprotocol.wave.federation.Proto.ProtocolWaveletDelta d, String c, WaveletProvider.SubmitRequestListener l) {}
+      @Override public void openRequest(ParticipantId u, WaveId waveId, org.waveprotocol.wave.model.id.IdFilter f, java.util.Collection<WaveClientRpc.WaveletVersion> k, String searchQuery, OpenListener listener) {
+        WaveletId wid = WaveletId.of(waveId.getDomain(), "conv+root");
+        WaveletName wn = WaveletName.of(waveId, wid);
+        ReadableWaveletData data = providerDataWithRootBlipId(waveId, wid, rootBlipId, blipIds);
+        CommittedWaveletSnapshot snap = new CommittedWaveletSnapshot(data, HashedVersion.unsigned(100));
+        listener.onUpdate(wn, snap, java.util.Collections.emptyList(), HashedVersion.unsigned(100), null, "ch-vh");
+      }
+    };
+    return WaveClientRpcImpl.create(frontend, false);
+  }
+
+  private static ReadableWaveletData providerDataWithRootBlipId(
+      WaveId waveId, WaveletId wid, String rootBlipId, String... blipIds) {
+    ReadableWaveletDataStub stub = dataStub(waveId, wid);
+    for (int i = 0; i < blipIds.length; i++) {
+      stub.addDoc(
+          blipIds[i],
+          new ReadableBlipDataStub(ParticipantId.ofUnsafe("user@example.com"), (i + 1) * 100L));
+    }
+    // Add a manifest document so the root blip can be resolved from the snapshot.
+    stub.addDoc(DocumentConstants.MANIFEST_DOCUMENT_ID, manifestBlipDoc(rootBlipId));
+    return stub;
+  }
+
+  /**
+   * Creates a ReadableBlipData whose DocInitialization encodes a minimal manifest document:
+   * {@code <conversation><blip id="rootBlipId"/></conversation>}.
+   */
+  private static org.waveprotocol.wave.model.wave.data.ReadableBlipData manifestBlipDoc(
+      String rootBlipId) {
+    DocInitializationBuffer buf = new DocInitializationBuffer();
+    buf.elementStart("conversation", new AttributesImpl());
+    buf.elementStart(DocumentConstants.BLIP,
+        new AttributesImpl(DocumentConstants.BLIP_ID, rootBlipId));
+    buf.elementEnd();
+    buf.elementEnd();
+    DocInitialization docInit = buf.finish();
+    return new org.waveprotocol.wave.model.wave.data.ReadableBlipData() {
+      @Override public String getId() { return DocumentConstants.MANIFEST_DOCUMENT_ID; }
+      @Override public org.waveprotocol.wave.model.wave.data.ReadableWaveletData getWavelet() { return null; }
+      @Override public ParticipantId getAuthor() { return ParticipantId.ofUnsafe("stub@example.com"); }
+      @Override public java.util.Set<ParticipantId> getContributors() { return java.util.Collections.emptySet(); }
+      @Override public long getLastModifiedTime() { return 0; }
+      @Override public long getLastModifiedVersion() { return 0; }
+      @Override public DocumentOperationSink getContent() {
+        return new DocumentOperationSink() {
+          @Override public DocInitialization asOperation() { return docInit; }
+          @Override public void consume(DocOp op) throws OperationException {}
+          @Override public Document getMutableDocument() { return null; }
+          @Override public void init(SilentOperationSink<? super DocOp> outputSink) {}
+        };
+      }
+    };
   }
 
   private static ReadableWaveletData providerDataWithBlips(WaveId waveId, WaveletId wid, int count) {


### PR DESCRIPTION
Fixes #1254

## Summary
- Match GWT inline-reply fallback behavior in J2CL by anchoring missing-caret inline replies at the end of the parent blip body.
- Keep continuation replies from receiving inline body anchors.
- Keep the root/title blip first in J2CL initial viewport natural ordering so open-wave positioning starts from the same content as GWT.
- Add a changelog fragment and issue-level plan/evidence file.

## Verification
- `./mvnw -f pom.xml -Psearch-sidecar -Dtest=org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceControllerTest test` from `j2cl/` -> 173 tests, 0 failures.
- `sbt -batch "testOnly org.waveprotocol.box.server.frontend.WaveClientRpcViewportHintsTest"` -> 20 tests, 0 failures.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json` -> passed.
- `sbt -batch "j2clSearchBuild; j2clSearchTest"` -> passed.
- `git diff --check` -> passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * J2CL inline replies now properly fall back to the parent blip's end position when a caret is unavailable, preventing empty manifest-only threads
  * Root blip is now consistently positioned first in the initial viewport, matching GWT behavior for improved scroll consistency

* **Tests**
  * Added test coverage for inline reply fallback behavior and viewport ordering with root blip positioning

* **Documentation**
  * Added documentation describing J2CL inline reply and scroll parity fixes with verification steps

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->