### PR TITLE
Stabilize J2CL wave load rendering

### DIFF
--- a/docs/superpowers/plans/2026-05-18-issue-1255-j2cl-stable-wave-load.md
+++ b/docs/superpowers/plans/2026-05-18-issue-1255-j2cl-stable-wave-load.md
@@ -1,0 +1,30 @@
+# Issue 1255: J2CL Stable Wave Load
+
+## Root Cause
+
+- `J2clSelectedWaveController` renders the viewport immediately, then fetches attachment metadata asynchronously and calls `view.render()` again when metadata returns.
+- `J2clReadSurfaceDomRenderer.renderWindow()` treats changed attachment render models as a full window mismatch, clears `host.innerHTML`, and recreates every `<wave-blip>`. That makes the read surface visibly flash and reflow for metadata-only updates.
+- The renderer creates defined `<wave-blip>` elements with light-DOM body children. The existing `wave-blip:not(:defined)` skeleton only protects server-first/custom-element-not-yet-defined markup; it does not protect client-created, already-defined hosts during Lit's first render.
+- Pending attachment tiles reserve only `72px`, then medium/large image attachments expand after metadata and image preview details arrive.
+
+## Plan
+
+- Add regression coverage for attachment metadata refresh preserving the existing blip host.
+- Add Lit coverage for clearing a renderer-set pending-upgrade marker after `wave-blip` first renders.
+- Add Lit coverage for medium/large pending attachment metadata reserving display-size-specific space.
+- Update `J2clReadSurfaceDomRenderer` to stamp a pending-upgrade marker on new `<wave-blip>` hosts and add an attachment-only fast path that updates attachment tile subtrees without clearing the whole read surface.
+- Update `wave-blip` to remove the pending-upgrade marker after first render.
+- Update read-surface CSS so pending medium/large attachment placeholders reserve closer-to-final space.
+
+## Acceptance Criteria
+
+- Opening a wave in J2CL does not rebuild the full blip stream when only attachment metadata resolves.
+- Client-created `<wave-blip>` hosts do not expose raw light-DOM content between host insertion and Lit's first render.
+- Pending attachment placeholders reduce layout shift for medium and large attachments.
+- Focused Maven and Lit tests pass, plus a narrow local J2CL browser sanity check is recorded.
+
+## Non-Goals
+
+- Do not redesign the J2CL read surface.
+- Do not replace the sidecar attachment metadata protocol.
+- Do not implement full rich-text annotation parity in this slice.

--- a/j2cl/lit/src/design/wavy-thread-collapse.css
+++ b/j2cl/lit/src/design/wavy-thread-collapse.css
@@ -33,6 +33,26 @@ wave-blip:not(:defined) > * {
   visibility: hidden;
 }
 
+/* Client-created <wave-blip> hosts can already be defined when Java appends
+ * their light-DOM body. Keep that body hidden until Lit's first render has
+ * installed the formatted shadow wrapper, then wave-blip removes this marker. */
+wave-blip[data-j2cl-pending-upgrade] {
+  display: block;
+  min-height: 96px;
+  margin: var(--wavy-spacing-2, 8px) 0;
+  border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
+  border-radius: var(--wavy-radius-sm, 4px);
+  background:
+    linear-gradient(90deg, rgba(34, 211, 238, 0.08), rgba(255, 255, 255, 0.72), rgba(34, 211, 238, 0.08)),
+    var(--wavy-bg-surface, #f8fafc);
+  color: transparent;
+  overflow: hidden;
+}
+
+wave-blip[data-j2cl-pending-upgrade] > * {
+  visibility: hidden;
+}
+
 .j2cl-read-attachments {
   display: grid;
   gap: var(--wavy-spacing-2, 8px);
@@ -74,6 +94,14 @@ wave-blip:not(:defined) > * {
 .j2cl-read-attachment[data-attachment-state="metadata-failure"],
 .j2cl-read-attachment[data-attachment-state="blocked"] {
   min-height: 72px;
+}
+
+.j2cl-read-attachment[data-attachment-state="pending"][data-display-size="medium"] {
+  min-height: 180px;
+}
+
+.j2cl-read-attachment[data-attachment-state="pending"][data-display-size="large"] {
+  min-height: 260px;
 }
 
 /* Inline reply threads animate height + opacity per F-0 token. Default

--- a/j2cl/lit/src/design/wavy-thread-collapse.css
+++ b/j2cl/lit/src/design/wavy-thread-collapse.css
@@ -38,7 +38,7 @@ wave-blip:not(:defined) > * {
  * installed the formatted shadow wrapper, then wave-blip removes this marker. */
 wave-blip[data-j2cl-pending-upgrade] {
   display: block;
-  min-height: 96px;
+  min-height: 40px;
   margin: var(--wavy-spacing-2, 8px) 0;
   border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.18));
   border-radius: var(--wavy-radius-sm, 4px);
@@ -94,14 +94,6 @@ wave-blip[data-j2cl-pending-upgrade] > * {
 .j2cl-read-attachment[data-attachment-state="metadata-failure"],
 .j2cl-read-attachment[data-attachment-state="blocked"] {
   min-height: 72px;
-}
-
-.j2cl-read-attachment[data-attachment-state="pending"][data-display-size="medium"] {
-  min-height: 180px;
-}
-
-.j2cl-read-attachment[data-attachment-state="pending"][data-display-size="large"] {
-  min-height: 260px;
 }
 
 /* Inline reply threads animate height + opacity per F-0 token. Default

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -128,6 +128,9 @@ export class WaveBlip extends LitElement {
        * host is a transparent wrapper so the F-0 recipe styling owns
        * focus / unread / pulse visuals. */
     }
+    :host([data-j2cl-pending-upgrade]) .body {
+      visibility: hidden;
+    }
     /* Per-blip action toolbar. G-PORT-9 keeps the primary action glyphs
      * visible in the metadata strip because GWT paints them in the blip
      * header; task-specific controls still reveal on hover/focus below. */
@@ -414,6 +417,10 @@ export class WaveBlip extends LitElement {
     this.authorAvatarUrl = "";
     this._capturedReplyAnchorOffset = undefined;
     this._capturedReplyAnchorCapturedAt = undefined;
+  }
+
+  firstUpdated() {
+    this.removeAttribute("data-j2cl-pending-upgrade");
   }
 
   /**

--- a/j2cl/lit/test/read-surface-layout.test.js
+++ b/j2cl/lit/test/read-surface-layout.test.js
@@ -32,7 +32,7 @@ before(async () => {
 });
 
 describe("J2CL read-surface loading layout", () => {
-  it("reserves display-size-specific space for pending attachment metadata", async () => {
+  it("uses the compact pending attachment placeholder for all display sizes", async () => {
     const medium = await fixture(html`
       <div
         class="j2cl-read-attachment"
@@ -48,7 +48,17 @@ describe("J2CL read-surface loading layout", () => {
       ></div>
     `);
 
-    expect(getComputedStyle(medium).minHeight).to.equal("180px");
-    expect(getComputedStyle(large).minHeight).to.equal("260px");
+    expect(getComputedStyle(medium).minHeight).to.equal("72px");
+    expect(getComputedStyle(large).minHeight).to.equal("72px");
+  });
+
+  it("keeps client-created pending-upgrade blips close to a one-line card height", async () => {
+    const blip = await fixture(html`
+      <wave-blip data-j2cl-pending-upgrade>
+        <span>Pending formatted card</span>
+      </wave-blip>
+    `);
+
+    expect(getComputedStyle(blip).minHeight).to.equal("40px");
   });
 });

--- a/j2cl/lit/test/read-surface-layout.test.js
+++ b/j2cl/lit/test/read-surface-layout.test.js
@@ -1,0 +1,54 @@
+import { fixture, expect, html } from "@open-wc/testing";
+
+function ensureReadSurfaceStylesLoaded() {
+  if (document.querySelector("link[data-read-surface-layout-test]")) return;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "/src/design/wavy-thread-collapse.css";
+  link.dataset.readSurfaceLayoutTest = "true";
+  document.head.appendChild(link);
+}
+
+async function waitForReadSurfaceStyles() {
+  for (let i = 0; i < 50; i++) {
+    const probe = await fixture(html`
+      <div
+        class="j2cl-read-attachment"
+        data-attachment-state="pending"
+        data-display-size="medium"
+      ></div>
+    `);
+    const minHeight = getComputedStyle(probe).minHeight;
+    probe.remove();
+    if (minHeight && minHeight !== "0px") return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error("wavy-thread-collapse.css did not apply within 1000ms");
+}
+
+before(async () => {
+  ensureReadSurfaceStylesLoaded();
+  await waitForReadSurfaceStyles();
+});
+
+describe("J2CL read-surface loading layout", () => {
+  it("reserves display-size-specific space for pending attachment metadata", async () => {
+    const medium = await fixture(html`
+      <div
+        class="j2cl-read-attachment"
+        data-attachment-state="pending"
+        data-display-size="medium"
+      ></div>
+    `);
+    const large = await fixture(html`
+      <div
+        class="j2cl-read-attachment"
+        data-attachment-state="pending"
+        data-display-size="large"
+      ></div>
+    `);
+
+    expect(getComputedStyle(medium).minHeight).to.equal("180px");
+    expect(getComputedStyle(large).minHeight).to.equal("260px");
+  });
+});

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -81,6 +81,39 @@ describe("<wave-blip>", () => {
     expect(card.hasAttribute("unread")).to.be.true;
   });
 
+  it("clears the renderer pending-upgrade marker after the first Lit render", async () => {
+    const el = await fixture(html`
+      <wave-blip data-j2cl-pending-upgrade data-blip-id="b2p" data-wave-id="w2">
+        pending body
+      </wave-blip>
+    `);
+    await el.updateComplete;
+    expect(el.hasAttribute("data-j2cl-pending-upgrade")).to.be.false;
+  });
+
+  it("keeps the slotted body hidden while the pending-upgrade marker is present", async () => {
+    const el = document.createElement("wave-blip");
+    el.setAttribute("data-j2cl-pending-upgrade", "");
+    el.setAttribute("data-blip-id", "b2pending");
+    el.setAttribute("data-wave-id", "w2");
+    el.textContent = "pending body";
+    const removeAttribute = el.removeAttribute.bind(el);
+    el.removeAttribute = (name) => {
+      if (name !== "data-j2cl-pending-upgrade") {
+        removeAttribute(name);
+      }
+    };
+    document.body.appendChild(el);
+    try {
+      await el.updateComplete;
+      const body = el.renderRoot.querySelector(".body");
+      expect(getComputedStyle(body).visibility).to.equal("hidden");
+    } finally {
+      el.removeAttribute = removeAttribute;
+      el.remove();
+    }
+  });
+
   it("highlights unread blip bodies beyond the small card unread dot", async () => {
     const el = await fixture(html`
       <wave-blip data-blip-id="b2u" data-wave-id="w2" author-name="Bob" unread>

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -3826,6 +3826,57 @@ public final class J2clReadSurfaceDomRenderer {
     return true;
   }
 
+  /**
+   * Returns true when the {@code wavy-task-affordance} children currently in {@code actual} match
+   * what {@code taskBinder} would produce for {@code blipId}. Falls through to false (triggering a
+   * full rebuild) when a task item is added, removed, checked, reassigned, due-dated, or its text
+   * range shifts — the same cases that {@link #applyTaskOnlyDiffIfPossible} handles via aggregate
+   * fields, but covering per-item granularity that the window-entry aggregate fields miss.
+   */
+  private boolean renderedTaskItemsMatch(String blipId, HTMLElement actual) {
+    if (actual == null) {
+      return false;
+    }
+    List<J2clTaskItemModel> expected = taskBinder == null
+        ? Collections.<J2clTaskItemModel>emptyList()
+        : taskBinder.tasksFor(blipId);
+    if (expected == null) {
+      expected = Collections.emptyList();
+    }
+    List<J2clTaskItemModel> namedExpected = new ArrayList<>();
+    for (J2clTaskItemModel t : expected) {
+      if (t != null && !t.getTaskId().isEmpty()) {
+        namedExpected.add(t);
+      }
+    }
+    NodeList<Element> rendered = actual.querySelectorAll("wavy-task-affordance[data-task-id]");
+    if (rendered.length != namedExpected.size()) {
+      return false;
+    }
+    for (int i = 0; i < namedExpected.size(); i++) {
+      J2clTaskItemModel exp = namedExpected.get(i);
+      Element ren = rendered.getAt(i);
+      if (!exp.getTaskId().equals(ren.getAttribute("data-task-id"))) {
+        return false;
+      }
+      if (exp.isChecked() != ren.hasAttribute("data-task-completed")) {
+        return false;
+      }
+      if (!String.valueOf(exp.getTextOffset()).equals(safeString(ren.getAttribute("data-task-start")))) {
+        return false;
+      }
+      if (!String.valueOf(exp.getEndOffset()).equals(safeString(ren.getAttribute("data-task-end")))) {
+        return false;
+      }
+      String expectedAssignee = safeString(exp.getAssigneeAddress()).trim();
+      String renderedAssignee = safeString(ren.getAttribute("data-task-assignee"));
+      if (!expectedAssignee.equals(renderedAssignee)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   private static String safeString(String value) {
     return value == null ? "" : value;
   }
@@ -4010,13 +4061,18 @@ public final class J2clReadSurfaceDomRenderer {
     }
     // Guard: if any mention binder ranges differ from the rendered state, fall through to the full
     // rebuild so mention spans are refreshed (same guard as matchesRenderedWindowEntries).
+    // Also guard against task-item binder changes: if per-task affordance state is stale, fall
+    // through so renderBlip() can rebuild the wavy-task-affordance subtree from the new binder.
     for (int i = 0; i < entries.size(); i++) {
       J2clReadWindowEntry entry = entries.get(i);
       if (!entry.isLoaded()) {
         continue;
       }
-      if (!renderedMentionRangesMatch(
-          entry.getBlipId(), entry.getText(), renderedBlipById(entry.getBlipId()))) {
+      HTMLElement blipElement = renderedBlipById(entry.getBlipId());
+      if (!renderedMentionRangesMatch(entry.getBlipId(), entry.getText(), blipElement)) {
+        return false;
+      }
+      if (!renderedTaskItemsMatch(entry.getBlipId(), blipElement)) {
         return false;
       }
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -3873,6 +3873,11 @@ public final class J2clReadSurfaceDomRenderer {
       if (!expectedAssignee.equals(renderedAssignee)) {
         return false;
       }
+      String expectedDue = formatDueDate(exp.getDueTimestamp());
+      String renderedDue = safeString(ren.getAttribute("data-task-due-date"));
+      if (!expectedDue.equals(renderedDue)) {
+        return false;
+      }
     }
     return true;
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -34,6 +34,7 @@ public final class J2clReadSurfaceDomRenderer {
   // Roughly one compact blip of lead time before a viewport edge reaches the exact scroll boundary.
   private static final double EDGE_SCROLL_THRESHOLD_PX = 64;
   private static final String ATTACHMENT_TELEMETRY_BOUND = "data-attachment-telemetry-bound";
+  private static final String BLIP_PENDING_UPGRADE = "data-j2cl-pending-upgrade";
 
   static final class InlineAnchorTextSegment {
     private final String text;
@@ -761,6 +762,11 @@ public final class J2clReadSurfaceDomRenderer {
     // entire blip stream flash and reflow even though only one
     // attribute changed. The surgical path is silent.
     if (applyTaskOnlyDiffIfPossible(effectiveEntries)) {
+      restoreFocusedBlipById(focusedBlipId);
+      evaluateDwellTimers();
+      return true;
+    }
+    if (applyAttachmentOnlyDiffIfPossible(effectiveEntries)) {
       restoreFocusedBlipById(focusedBlipId);
       evaluateDwellTimers();
       return true;
@@ -1525,6 +1531,7 @@ public final class J2clReadSurfaceDomRenderer {
         (HTMLElement) DomGlobal.document.createElement("wave-blip");
     element.className = "blip j2cl-read-blip";
     element.setAttribute("data-j2cl-read-blip", "true");
+    element.setAttribute(BLIP_PENDING_UPGRADE, "");
     element.setAttribute("data-blip-id", blip.getBlipId());
     element.setAttribute("role", "listitem");
     element.setAttribute("tabindex", index == 0 ? "0" : "-1");
@@ -3873,6 +3880,34 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   /**
+   * GWT-parity (#1255): identity comparison for the attachment metadata refresh fast path.
+   * Attachment metadata resolution changes only the attachment render models. Text, focus,
+   * parent/thread placement, task state, and read metadata must stay identical or we fall through
+   * to the normal rebuild path.
+   */
+  private static boolean sameWindowEntryExceptAttachments(
+      J2clReadWindowEntry left, J2clReadWindowEntry right) {
+    return left.isLoaded() == right.isLoaded()
+        && left.getFromVersion() == right.getFromVersion()
+        && left.getToVersion() == right.getToVersion()
+        && left.getSegment().equals(right.getSegment())
+        && left.getBlipId().equals(right.getBlipId())
+        && left.getText().equals(right.getText())
+        && left.getAuthorId().equals(right.getAuthorId())
+        && left.getLastModifiedTimeMillis() == right.getLastModifiedTimeMillis()
+        && left.getParentBlipId().equals(right.getParentBlipId())
+        && left.getThreadId().equals(right.getThreadId())
+        && left.isUnread() == right.isUnread()
+        && left.hasMention() == right.hasMention()
+        && left.isTaskDone() == right.isTaskDone()
+        && left.getTaskAssignee().equals(right.getTaskAssignee())
+        && left.getTaskDueTimestamp() == right.getTaskDueTimestamp()
+        && left.getBodyItemCount() == right.getBodyItemCount()
+        && left.isTask() == right.isTask()
+        && left.getInlineReplyAnchors().equals(right.getInlineReplyAnchors());
+  }
+
+  /**
    * GWT-parity (round 5, #1237): when the only differences between the
    * incoming entries and the rendered entries are task-related
    * (taskDone / assignee / due-date / body-item-count), surgically
@@ -3940,6 +3975,87 @@ public final class J2clReadSurfaceDomRenderer {
     renderedWindowEntries =
         Collections.unmodifiableList(new ArrayList<J2clReadWindowEntry>(entries));
     return true;
+  }
+
+  /**
+   * GWT-parity (#1255): when attachment metadata resolves, keep the existing wave-blip hosts and
+   * replace only their attachment tile subtree. Clearing {@code host.innerHTML} here makes every
+   * blip detach and Lit-upgrade again, which is the visible "formatting disappears, then returns"
+   * churn users reported while attachments finish loading.
+   */
+  private boolean applyAttachmentOnlyDiffIfPossible(List<J2clReadWindowEntry> entries) {
+    if (renderedSurface == null || renderedSurface.parentElement != host) {
+      return false;
+    }
+    if (renderedWindowEntries.size() != entries.size()) {
+      return false;
+    }
+    if (conversationManifest != renderedConversationManifest) {
+      return false;
+    }
+    boolean anyAttachmentDiff = false;
+    for (int i = 0; i < entries.size(); i++) {
+      J2clReadWindowEntry next = entries.get(i);
+      J2clReadWindowEntry prev = renderedWindowEntries.get(i);
+      if (!sameWindowEntryExceptAttachments(prev, next)) {
+        return false;
+      }
+      if (!prev.getAttachments().equals(next.getAttachments())) {
+        anyAttachmentDiff = true;
+      }
+    }
+    if (!anyAttachmentDiff) {
+      return false;
+    }
+    for (J2clReadWindowEntry entry : entries) {
+      if (!entry.isLoaded()) {
+        continue;
+      }
+      HTMLElement element = renderedBlipById(entry.getBlipId());
+      if (element == null) {
+        return false;
+      }
+      replaceAttachmentSubtree(element, entry.getAttachments());
+    }
+    renderedWindowEntries =
+        Collections.unmodifiableList(new ArrayList<J2clReadWindowEntry>(entries));
+    return true;
+  }
+
+  private void replaceAttachmentSubtree(
+      HTMLElement blipElement, List<J2clAttachmentRenderModel> attachments) {
+    HTMLElement existing = directChildWithClass(blipElement, "j2cl-read-attachments");
+    if (existing != null && existing.parentElement == blipElement) {
+      blipElement.removeChild(existing);
+    }
+    if (attachments == null || attachments.isEmpty()) {
+      return;
+    }
+    HTMLElement next = (HTMLElement) DomGlobal.document.createElement("div");
+    next.className = "j2cl-read-attachments";
+    for (J2clAttachmentRenderModel attachment : attachments) {
+      next.appendChild(renderAttachment(attachment));
+    }
+    Element reactionRow = blipElement.querySelector("reaction-row[slot='reactions']");
+    if (reactionRow != null && reactionRow.parentElement == blipElement) {
+      blipElement.insertBefore(next, reactionRow);
+    } else {
+      blipElement.appendChild(next);
+    }
+  }
+
+  private static HTMLElement directChildWithClass(HTMLElement parent, String className) {
+    if (parent == null || className == null || className.isEmpty()) {
+      return null;
+    }
+    Element child = parent.firstElementChild;
+    while (child != null) {
+      if (child instanceof HTMLElement && child.classList.contains(className)) {
+        return (HTMLElement) child;
+      }
+      child = child.nextElementSibling;
+    }
+    return null;
   }
 
   private HTMLElement renderedBlipById(String blipId) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -4008,6 +4008,8 @@ public final class J2clReadSurfaceDomRenderer {
     if (!anyAttachmentDiff) {
       return false;
     }
+    List<J2clReadWindowEntry> changedEntries = new ArrayList<J2clReadWindowEntry>();
+    List<HTMLElement> changedElements = new ArrayList<HTMLElement>();
     for (int i = 0; i < entries.size(); i++) {
       J2clReadWindowEntry entry = entries.get(i);
       if (!entry.isLoaded()) {
@@ -4021,7 +4023,11 @@ public final class J2clReadSurfaceDomRenderer {
       if (element == null) {
         return false;
       }
-      replaceAttachmentSubtree(element, entry.getAttachments());
+      changedEntries.add(entry);
+      changedElements.add(element);
+    }
+    for (int i = 0; i < changedEntries.size(); i++) {
+      replaceAttachmentSubtree(changedElements.get(i), changedEntries.get(i).getAttachments());
     }
     renderedWindowEntries =
         Collections.unmodifiableList(new ArrayList<J2clReadWindowEntry>(entries));

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -3894,6 +3894,7 @@ public final class J2clReadSurfaceDomRenderer {
         && left.getBlipId().equals(right.getBlipId())
         && left.getText().equals(right.getText())
         && left.getAuthorId().equals(right.getAuthorId())
+        && left.getAuthorDisplayName().equals(right.getAuthorDisplayName())
         && left.getLastModifiedTimeMillis() == right.getLastModifiedTimeMillis()
         && left.getParentBlipId().equals(right.getParentBlipId())
         && left.getThreadId().equals(right.getThreadId())
@@ -4007,8 +4008,13 @@ public final class J2clReadSurfaceDomRenderer {
     if (!anyAttachmentDiff) {
       return false;
     }
-    for (J2clReadWindowEntry entry : entries) {
+    for (int i = 0; i < entries.size(); i++) {
+      J2clReadWindowEntry entry = entries.get(i);
       if (!entry.isLoaded()) {
+        continue;
+      }
+      J2clReadWindowEntry previous = renderedWindowEntries.get(i);
+      if (previous.getAttachments().equals(entry.getAttachments())) {
         continue;
       }
       HTMLElement element = renderedBlipById(entry.getBlipId());

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -4020,43 +4020,41 @@ public final class J2clReadSurfaceDomRenderer {
         return false;
       }
     }
-    List<J2clReadWindowEntry> changedEntries = new ArrayList<J2clReadWindowEntry>();
-    List<HTMLElement> changedElements = new ArrayList<HTMLElement>();
+    List<J2clReadWindowEntry> loadedEntries = new ArrayList<J2clReadWindowEntry>();
+    List<HTMLElement> loadedElements = new ArrayList<HTMLElement>();
+    List<Boolean> attachmentChanged = new ArrayList<Boolean>();
     for (int i = 0; i < entries.size(); i++) {
       J2clReadWindowEntry entry = entries.get(i);
       if (!entry.isLoaded()) {
         continue;
       }
       J2clReadWindowEntry previous = renderedWindowEntries.get(i);
-      if (previous.getAttachments().equals(entry.getAttachments())) {
-        continue;
-      }
       HTMLElement element = renderedBlipById(entry.getBlipId());
       if (element == null) {
         return false;
       }
-      changedEntries.add(entry);
-      changedElements.add(element);
+      loadedEntries.add(entry);
+      loadedElements.add(element);
+      attachmentChanged.add(!previous.getAttachments().equals(entry.getAttachments()));
     }
-    for (int i = 0; i < changedEntries.size(); i++) {
-      replaceAttachmentSubtree(changedElements.get(i), changedEntries.get(i).getAttachments());
-    }
-    // reactionBinder may have been updated in the same render pass (e.g. a reaction
-    // and attachment metadata arriving together). Refresh every reaction-row so chips
-    // don't stay stale when the full rebuild path was bypassed.
-    for (HTMLElement blip : renderedBlips) {
-      String blipId = blip.getAttribute("data-blip-id");
-      if (blipId == null || blipId.isEmpty()) {
-        continue;
-      }
-      Element reactionRow = blip.querySelector("reaction-row[slot='reactions']");
-      if (reactionRow != null) {
-        setProperty((HTMLElement) reactionRow, "reactions", buildReactionsArray(blipId));
+    for (int i = 0; i < loadedEntries.size(); i++) {
+      J2clReadWindowEntry entry = loadedEntries.get(i);
+      HTMLElement element = loadedElements.get(i);
+      refreshReactionRow(element, entry.getBlipId());
+      if (Boolean.TRUE.equals(attachmentChanged.get(i))) {
+        replaceAttachmentSubtree(element, entry.getAttachments());
       }
     }
     renderedWindowEntries =
         Collections.unmodifiableList(new ArrayList<J2clReadWindowEntry>(entries));
     return true;
+  }
+
+  private void refreshReactionRow(HTMLElement blipElement, String blipId) {
+    Element reactionRow = blipElement.querySelector("reaction-row[slot='reactions']");
+    if (reactionRow instanceof HTMLElement && reactionRow.parentElement == blipElement) {
+      setProperty((HTMLElement) reactionRow, "reactions", buildReactionsArray(blipId));
+    }
   }
 
   private void replaceAttachmentSubtree(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -4029,6 +4029,19 @@ public final class J2clReadSurfaceDomRenderer {
     for (int i = 0; i < changedEntries.size(); i++) {
       replaceAttachmentSubtree(changedElements.get(i), changedEntries.get(i).getAttachments());
     }
+    // reactionBinder may have been updated in the same render pass (e.g. a reaction
+    // and attachment metadata arriving together). Refresh every reaction-row so chips
+    // don't stay stale when the full rebuild path was bypassed.
+    for (HTMLElement blip : renderedBlips) {
+      String blipId = blip.getAttribute("data-blip-id");
+      if (blipId == null || blipId.isEmpty()) {
+        continue;
+      }
+      Element reactionRow = blip.querySelector("reaction-row[slot='reactions']");
+      if (reactionRow != null) {
+        setProperty((HTMLElement) reactionRow, "reactions", buildReactionsArray(blipId));
+      }
+    }
     renderedWindowEntries =
         Collections.unmodifiableList(new ArrayList<J2clReadWindowEntry>(entries));
     return true;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -4008,6 +4008,18 @@ public final class J2clReadSurfaceDomRenderer {
     if (!anyAttachmentDiff) {
       return false;
     }
+    // Guard: if any mention binder ranges differ from the rendered state, fall through to the full
+    // rebuild so mention spans are refreshed (same guard as matchesRenderedWindowEntries).
+    for (int i = 0; i < entries.size(); i++) {
+      J2clReadWindowEntry entry = entries.get(i);
+      if (!entry.isLoaded()) {
+        continue;
+      }
+      if (!renderedMentionRangesMatch(
+          entry.getBlipId(), entry.getText(), renderedBlipById(entry.getBlipId()))) {
+        return false;
+      }
+    }
     List<J2clReadWindowEntry> changedEntries = new ArrayList<J2clReadWindowEntry>();
     List<HTMLElement> changedElements = new ArrayList<HTMLElement>();
     for (int i = 0; i < entries.size(); i++) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -4031,6 +4031,7 @@ public class J2clReadSurfaceDomRendererTest {
     return false;
   }
 
+  /** Returns the number of entries in the {@code reactions} JsArray property of a reaction-row. */
   private static int reactionCount(HTMLElement reactionRow) {
     Object reactions = Js.asPropertyMap(reactionRow).get("reactions");
     if (reactions == null) {
@@ -4039,13 +4040,21 @@ public class J2clReadSurfaceDomRendererTest {
     return Js.<JsArray<Object>>uncheckedCast(reactions).length;
   }
 
+  /**
+   * Returns the {@code count} field of the first entry in the {@code reactions} JsArray property
+   * of a reaction-row element (each entry is a plain JS object with a numeric {@code count} field).
+   */
   private static int firstReactionCount(HTMLElement reactionRow) {
     Object reactions = Js.asPropertyMap(reactionRow).get("reactions");
     JsArray<Object> array = Js.uncheckedCast(reactions);
     if (array == null || array.length == 0) {
       return 0;
     }
-    Object count = Js.asPropertyMap(array.getAt(0)).get("count");
+    Object firstReaction = array.getAt(0);
+    if (firstReaction == null) {
+      return 0;
+    }
+    Object count = Js.asPropertyMap(firstReaction).get("count");
     return count instanceof Number ? ((Number) count).intValue() : 0;
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -1392,6 +1392,19 @@ public class J2clReadSurfaceDomRendererTest {
     J2clAttachmentRenderModel pending =
         J2clAttachmentRenderModel.metadataPending(
             "example.com/att+hero", "Hero diagram", "medium");
+    J2clAttachmentRenderModel unchanged =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+stable",
+            "Stable diagram",
+            "medium",
+            attachmentMetadata(
+                "example.com/att+stable",
+                "stable.png",
+                "image/png",
+                "/attachment/example.com/att+stable",
+                "/thumbnail/example.com/att+stable",
+                new J2clAttachmentMetadata.ImageMetadata(640, 480),
+                false));
 
     Assert.assertTrue(
         renderer.renderWindow(
@@ -1402,13 +1415,25 @@ public class J2clReadSurfaceDomRendererTest {
                     9L,
                     "b+root",
                     "Root text",
-                    Arrays.asList(pending)))));
+                    Arrays.asList(pending)),
+                J2clReadWindowEntry.loaded(
+                    "blip:b+stable",
+                    0L,
+                    9L,
+                    "b+stable",
+                    "Stable text",
+                    Arrays.asList(unchanged)))));
     HTMLElement originalBlip = blip(host, "b+root");
+    HTMLElement unchangedBlip = blip(host, "b+stable");
     Assert.assertNotNull(originalBlip);
+    Assert.assertNotNull(unchangedBlip);
     HTMLElement pendingTile =
         (HTMLElement) host.querySelector("[data-attachment-id='example.com/att+hero']");
     Assert.assertNotNull("attachment tile should be present before resolve", pendingTile);
     Assert.assertEquals("pending", pendingTile.getAttribute("data-attachment-state"));
+    HTMLElement unchangedTile =
+        (HTMLElement) host.querySelector("[data-attachment-id='example.com/att+stable']");
+    Assert.assertNotNull("unchanged attachment tile should be present", unchangedTile);
 
     J2clAttachmentRenderModel resolved =
         J2clAttachmentRenderModel.fromMetadata(
@@ -1433,9 +1458,19 @@ public class J2clReadSurfaceDomRendererTest {
                     9L,
                     "b+root",
                     "Root text",
-                    Arrays.asList(resolved)))));
+                    Arrays.asList(resolved)),
+                J2clReadWindowEntry.loaded(
+                    "blip:b+stable",
+                    0L,
+                    9L,
+                    "b+stable",
+                    "Stable text",
+                    Arrays.asList(unchanged)))));
 
     Assert.assertSame(originalBlip, blip(host, "b+root"));
+    Assert.assertSame(unchangedBlip, blip(host, "b+stable"));
+    Assert.assertSame(
+        unchangedTile, host.querySelector("[data-attachment-id='example.com/att+stable']"));
     HTMLElement tile =
         (HTMLElement) host.querySelector("[data-attachment-id='example.com/att+hero']");
     Assert.assertNotNull("attachment tile should be present after resolve", tile);

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -1385,6 +1385,65 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void attachmentMetadataRefreshUpdatesTilesWithoutRebuildingBlips() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    J2clAttachmentRenderModel pending =
+        J2clAttachmentRenderModel.metadataPending(
+            "example.com/att+hero", "Hero diagram", "medium");
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded(
+                    "blip:b+root",
+                    0L,
+                    9L,
+                    "b+root",
+                    "Root text",
+                    Arrays.asList(pending)))));
+    HTMLElement originalBlip = blip(host, "b+root");
+    Assert.assertNotNull(originalBlip);
+    Assert.assertEquals(
+        "pending",
+        ((HTMLElement) host.querySelector("[data-attachment-id='example.com/att+hero']"))
+            .getAttribute("data-attachment-state"));
+
+    J2clAttachmentRenderModel resolved =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+hero",
+            "Hero diagram",
+            "medium",
+            attachmentMetadata(
+                "example.com/att+hero",
+                "hero.png",
+                "image/png",
+                "/attachment/example.com/att+hero",
+                "/thumbnail/example.com/att+hero",
+                new J2clAttachmentMetadata.ImageMetadata(1200, 800),
+                false));
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loaded(
+                    "blip:b+root",
+                    0L,
+                    9L,
+                    "b+root",
+                    "Root text",
+                    Arrays.asList(resolved)))));
+
+    Assert.assertSame(originalBlip, blip(host, "b+root"));
+    HTMLElement tile =
+        (HTMLElement) host.querySelector("[data-attachment-id='example.com/att+hero']");
+    Assert.assertEquals("ready", tile.getAttribute("data-attachment-state"));
+    Assert.assertNotNull(tile.querySelector("[data-j2cl-attachment-open='true']"));
+    Assert.assertNotNull(tile.querySelector(".j2cl-read-attachment-preview"));
+  }
+
+  @Test
   public void largeInlineImageUsesAttachmentUrlAndDataDisplaySize() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -1405,10 +1405,10 @@ public class J2clReadSurfaceDomRendererTest {
                     Arrays.asList(pending)))));
     HTMLElement originalBlip = blip(host, "b+root");
     Assert.assertNotNull(originalBlip);
-    Assert.assertEquals(
-        "pending",
-        ((HTMLElement) host.querySelector("[data-attachment-id='example.com/att+hero']"))
-            .getAttribute("data-attachment-state"));
+    HTMLElement pendingTile =
+        (HTMLElement) host.querySelector("[data-attachment-id='example.com/att+hero']");
+    Assert.assertNotNull("attachment tile should be present before resolve", pendingTile);
+    Assert.assertEquals("pending", pendingTile.getAttribute("data-attachment-state"));
 
     J2clAttachmentRenderModel resolved =
         J2clAttachmentRenderModel.fromMetadata(
@@ -1438,6 +1438,7 @@ public class J2clReadSurfaceDomRendererTest {
     Assert.assertSame(originalBlip, blip(host, "b+root"));
     HTMLElement tile =
         (HTMLElement) host.querySelector("[data-attachment-id='example.com/att+hero']");
+    Assert.assertNotNull("attachment tile should be present after resolve", tile);
     Assert.assertEquals("ready", tile.getAttribute("data-attachment-state"));
     Assert.assertNotNull(tile.querySelector("[data-j2cl-attachment-open='true']"));
     Assert.assertNotNull(tile.querySelector(".j2cl-read-attachment-preview"));

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -1,6 +1,7 @@
 package org.waveprotocol.box.j2cl.read;
 
 import com.google.j2cl.junit.apt.J2clTestInput;
+import elemental2.core.JsArray;
 import elemental2.dom.DomGlobal;
 import elemental2.dom.Element;
 import elemental2.dom.Event;
@@ -15,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import jsinterop.base.Js;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -22,6 +24,7 @@ import org.junit.Test;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadata;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
 import org.waveprotocol.box.j2cl.overlay.J2clMentionRange;
+import org.waveprotocol.box.j2cl.overlay.J2clReactionSummary;
 import org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel;
 import org.waveprotocol.box.j2cl.telemetry.J2clClientTelemetry;
 import org.waveprotocol.box.j2cl.telemetry.RecordingTelemetrySink;
@@ -1389,6 +1392,11 @@ public class J2clReadSurfaceDomRendererTest {
     assumeBrowserDom();
     HTMLDivElement host = createHost();
     J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    ArrayList<J2clReactionSummary> rootReactions = new ArrayList<J2clReactionSummary>();
+    rootReactions.add(
+        new J2clReactionSummary("👍", Arrays.asList("alice@example.com"), true, ""));
+    renderer.setReactionBinder(
+        blipId -> "b+root".equals(blipId) ? rootReactions : Collections.emptyList());
     J2clAttachmentRenderModel pending =
         J2clAttachmentRenderModel.metadataPending(
             "example.com/att+hero", "Hero diagram", "medium");
@@ -1431,6 +1439,10 @@ public class J2clReadSurfaceDomRendererTest {
         (HTMLElement) host.querySelector("[data-attachment-id='example.com/att+hero']");
     Assert.assertNotNull("attachment tile should be present before resolve", pendingTile);
     Assert.assertEquals("pending", pendingTile.getAttribute("data-attachment-state"));
+    HTMLElement originalReactionRow =
+        (HTMLElement) originalBlip.querySelector("reaction-row[slot='reactions']");
+    Assert.assertNotNull("reaction row should be present before resolve", originalReactionRow);
+    Assert.assertEquals(1, reactionCount(originalReactionRow));
     HTMLElement unchangedTile =
         (HTMLElement) host.querySelector("[data-attachment-id='example.com/att+stable']");
     Assert.assertNotNull("unchanged attachment tile should be present", unchangedTile);
@@ -1448,6 +1460,10 @@ public class J2clReadSurfaceDomRendererTest {
                 "/thumbnail/example.com/att+hero",
                 new J2clAttachmentMetadata.ImageMetadata(1200, 800),
                 false));
+    rootReactions.clear();
+    rootReactions.add(
+        new J2clReactionSummary(
+            "👍", Arrays.asList("alice@example.com", "bob@example.com"), true, ""));
 
     Assert.assertTrue(
         renderer.renderWindow(
@@ -1468,6 +1484,10 @@ public class J2clReadSurfaceDomRendererTest {
                     Arrays.asList(unchanged)))));
 
     Assert.assertSame(originalBlip, blip(host, "b+root"));
+    Assert.assertSame(
+        originalReactionRow, originalBlip.querySelector("reaction-row[slot='reactions']"));
+    Assert.assertEquals(1, reactionCount(originalReactionRow));
+    Assert.assertEquals(2, firstReactionCount(originalReactionRow));
     Assert.assertSame(unchangedBlip, blip(host, "b+stable"));
     Assert.assertSame(
         unchangedTile, host.querySelector("[data-attachment-id='example.com/att+stable']"));
@@ -3891,6 +3911,24 @@ public class J2clReadSurfaceDomRendererTest {
       }
     }
     return false;
+  }
+
+  private static int reactionCount(HTMLElement reactionRow) {
+    Object reactions = Js.asPropertyMap(reactionRow).get("reactions");
+    if (reactions == null) {
+      return 0;
+    }
+    return Js.<JsArray<Object>>uncheckedCast(reactions).length;
+  }
+
+  private static int firstReactionCount(HTMLElement reactionRow) {
+    Object reactions = Js.asPropertyMap(reactionRow).get("reactions");
+    JsArray<Object> array = Js.uncheckedCast(reactions);
+    if (array == null || array.length == 0) {
+      return 0;
+    }
+    Object count = Js.asPropertyMap(array.getAt(0)).get("count");
+    return count instanceof Number ? ((Number) count).intValue() : 0;
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRendererTest.java
@@ -1500,6 +1500,124 @@ public class J2clReadSurfaceDomRendererTest {
   }
 
   @Test
+  public void attachmentMetadataRefreshFallsBackWhenTaskDueDateChanges() {
+    assumeBrowserDom();
+    HTMLDivElement host = createHost();
+    J2clReadSurfaceDomRenderer renderer = new J2clReadSurfaceDomRenderer(host);
+    ArrayList<J2clTaskItemModel> taskItems = new ArrayList<>();
+    taskItems.add(
+        new J2clTaskItemModel(
+            "task-1",
+            0,
+            4,
+            "task-b-task-task-1",
+            "",
+            1714560000000L,
+            false,
+            true));
+    renderer.setTaskBinder(
+        blipId ->
+            "b+task".equals(blipId)
+                ? taskItems
+                : Collections.<J2clTaskItemModel>emptyList());
+    J2clAttachmentRenderModel pending =
+        J2clAttachmentRenderModel.metadataPending(
+            "example.com/att+hero", "Hero diagram", "medium");
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loadedWithTaskMetadata(
+                    "blip:b+task",
+                    0L,
+                    9L,
+                    "b+task",
+                    "Task body",
+                    Arrays.asList(pending),
+                    "alice@example.com",
+                    "alice@example.com",
+                    1714240000000L,
+                    "",
+                    "",
+                    /* unread= */ false,
+                    /* hasMention= */ false,
+                    /* taskDone= */ false,
+                    /* taskAssignee= */ "",
+                    /* taskDueTimestamp= */ J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP,
+                    /* bodyItemCount= */ 9,
+                    /* isTask= */ true))));
+    HTMLElement originalBlip = blip(host, "b+task");
+    Assert.assertNotNull(originalBlip);
+    HTMLElement originalAffordance =
+        (HTMLElement) originalBlip.querySelector("wavy-task-affordance[data-task-id='task-1']");
+    Assert.assertNotNull(originalAffordance);
+    Assert.assertEquals("2024-05-01", originalAffordance.getAttribute("data-task-due-date"));
+
+    taskItems.clear();
+    taskItems.add(
+        new J2clTaskItemModel(
+            "task-1",
+            0,
+            4,
+            "task-b-task-task-1",
+            "",
+            1714646400000L,
+            false,
+            true));
+    J2clAttachmentRenderModel resolved =
+        J2clAttachmentRenderModel.fromMetadata(
+            "example.com/att+hero",
+            "Hero diagram",
+            "medium",
+            attachmentMetadata(
+                "example.com/att+hero",
+                "hero.png",
+                "image/png",
+                "/attachment/example.com/att+hero",
+                "/thumbnail/example.com/att+hero",
+                new J2clAttachmentMetadata.ImageMetadata(1200, 800),
+                false));
+
+    Assert.assertTrue(
+        renderer.renderWindow(
+            Arrays.asList(
+                J2clReadWindowEntry.loadedWithTaskMetadata(
+                    "blip:b+task",
+                    0L,
+                    9L,
+                    "b+task",
+                    "Task body",
+                    Arrays.asList(resolved),
+                    "alice@example.com",
+                    "alice@example.com",
+                    1714240000000L,
+                    "",
+                    "",
+                    /* unread= */ false,
+                    /* hasMention= */ false,
+                    /* taskDone= */ false,
+                    /* taskAssignee= */ "",
+                    /* taskDueTimestamp= */ J2clTaskItemModel.UNKNOWN_DUE_TIMESTAMP,
+                    /* bodyItemCount= */ 9,
+                    /* isTask= */ true))));
+
+    HTMLElement updatedBlip = blip(host, "b+task");
+    Assert.assertNotNull(updatedBlip);
+    Assert.assertNotSame(
+        "due-date-only task changes must not take the attachment-only DOM path",
+        originalBlip,
+        updatedBlip);
+    HTMLElement updatedAffordance =
+        (HTMLElement) updatedBlip.querySelector("wavy-task-affordance[data-task-id='task-1']");
+    Assert.assertNotNull(updatedAffordance);
+    Assert.assertEquals("2024-05-02", updatedAffordance.getAttribute("data-task-due-date"));
+    HTMLElement tile =
+        (HTMLElement) host.querySelector("[data-attachment-id='example.com/att+hero']");
+    Assert.assertNotNull(tile);
+    Assert.assertEquals("ready", tile.getAttribute("data-attachment-state"));
+  }
+
+  @Test
   public void largeInlineImageUsesAttachmentUrlAndDataDisplaySize() {
     assumeBrowserDom();
     HTMLDivElement host = createHost();

--- a/wave/config/changelog.d/2026-05-18-issue-1255-j2cl-stable-wave-load.json
+++ b/wave/config/changelog.d/2026-05-18-issue-1255-j2cl-stable-wave-load.json
@@ -3,14 +3,14 @@
   "version": "Issue #1255",
   "date": "2026-05-18",
   "title": "J2CL wave loading now keeps blip layout stable while formatting and attachments settle.",
-  "summary": "J2CL selected-wave rendering now avoids full blip-stream rebuilds when attachment metadata resolves, hides client-created blips until their Lit wrapper has rendered, and reserves display-size-aware attachment placeholder space to reduce initial load reflow.",
+  "summary": "J2CL selected-wave rendering now avoids full blip-stream rebuilds when attachment metadata resolves, hides client-created blips until their Lit wrapper has rendered, and keeps pending placeholders compact so initial load no longer flashes raw content.",
   "sections": [
     {
       "type": "fix",
       "items": [
         "Attachment metadata refreshes update only the affected attachment tile subtree instead of clearing and rebuilding the whole read surface.",
         "Client-created wave-blip hosts hide their light-DOM body until the formatted Lit card has completed its first render.",
-        "Pending medium and large attachment placeholders reserve closer-to-final space so image metadata arrival causes less wave-size churn."
+        "Pending placeholders stay compact while attachment metadata is loading, avoiding a shrink-shift for attachments that resolve without a large preview."
       ]
     }
   ]

--- a/wave/config/changelog.d/2026-05-18-issue-1255-j2cl-stable-wave-load.json
+++ b/wave/config/changelog.d/2026-05-18-issue-1255-j2cl-stable-wave-load.json
@@ -1,0 +1,17 @@
+{
+  "releaseId": "2026-05-18-issue-1255-j2cl-stable-wave-load",
+  "version": "Issue #1255",
+  "date": "2026-05-18",
+  "title": "J2CL wave loading now keeps blip layout stable while formatting and attachments settle.",
+  "summary": "J2CL selected-wave rendering now avoids full blip-stream rebuilds when attachment metadata resolves, hides client-created blips until their Lit wrapper has rendered, and reserves display-size-aware attachment placeholder space to reduce initial load reflow.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Attachment metadata refreshes update only the affected attachment tile subtree instead of clearing and rebuilding the whole read surface.",
+        "Client-created wave-blip hosts hide their light-DOM body until the formatted Lit card has completed its first render.",
+        "Pending medium and large attachment placeholders reserve closer-to-final space so image metadata arrival causes less wave-size churn."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- keep existing J2CL `<wave-blip>` hosts when attachment metadata resolves, replacing only attachment tile subtrees
- hide client-created blip light DOM until the first Lit render installs the formatted card
- reserve medium/large pending attachment space to avoid preview-driven size jumps

Fixes #1255

## Verification
- `npm test -- --files test/wave-blip.test.js test/read-surface-layout.test.js` from `j2cl/lit`
- `./mvnw -q -Dtest=J2clReadSurfaceDomRendererTest test` from `j2cl`
- `npm run build` from `j2cl/lit`
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`
- `./mvnw -q -DskipTests compile` from `j2cl`
- `WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 bash scripts/worktree-boot.sh --port 9925`
- Playwright sanity against `/?view=j2cl-root` for signed-in root shell, pending-upgrade hide/auto-clear, and pending attachment placeholder heights
- `git diff --check`

Note: the local SBT stage still lacks `/j2cl-search/sidecar/j2cl-sidecar.js`, so the browser sanity ignored that pre-existing asset noise and scoped itself to this selected-wave layout fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduce flashing and layout shift by refreshing attachment tiles in place during metadata updates while preserving blip layout, focus, and timers.

* **Style**
  * Hide interim client-created light-DOM content until first render and reserve compact placeholder space for pending medium/large attachments.

* **Tests**
  * Added layout and component tests validating pending-state sizing and upgrade-clearing behavior.

* **Documentation**
  * Added implementation plan and acceptance criteria for stability improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->