### PR TITLE
Fix J2CL initial focus-frame line

### DIFF
--- a/docs/superpowers/plans/2026-05-18-issue-1258-j2cl-first-blip-line.md
+++ b/docs/superpowers/plans/2026-05-18-issue-1258-j2cl-first-blip-line.md
@@ -1,0 +1,33 @@
+# Issue #1258: J2CL First-Blip Focus Line
+
+## Root Cause
+
+The J2CL read renderer programmatically selects the initial blip on first wave
+open so keyboard navigation and mark-read state start from the same place as
+GWT. That path currently dispatches `wavy-focus-changed` with an empty key,
+which causes the absolute `<wavy-focus-frame>` overlay to paint immediately.
+On the first blip, the overlay edge reads as a horizontal line through the blip.
+
+## Plan
+
+1. Add a focused Lit regression test proving the focus-frame stays hidden for
+   the initial programmatic focus event (`key=""`) and still appears for
+   explicit keyboard navigation.
+2. Update `<wavy-focus-frame>` so an empty-key first focus is tracked but not
+   painted; once the user has explicitly navigated, empty-key geometry refreshes
+   for the same focused blip continue to update the visible frame.
+3. Keep renderer focus markers, tabindex, mark-read, and scroll-to-initial
+   behavior unchanged.
+4. Add a changelog fragment because this changes visible J2CL behavior.
+5. Run focused J2CL renderer/Lit tests plus narrow local smoke/browser
+   verification before opening the PR.
+
+## Self-Review
+
+- Scope is limited to the focus-frame presentation policy; no GWT code or task
+  rendering behavior changes.
+- The regression should fail on current `origin/main` because any non-empty
+  focused blip id currently makes the frame visible, regardless of key source.
+- Existing focus-frame tests should still pass after updating the visible-frame
+  expectation to use a keyboard key, because keyboard navigation remains the
+  explicit visible focus affordance.

--- a/j2cl/lit/src/elements/shell-root.js
+++ b/j2cl/lit/src/elements/shell-root.js
@@ -320,12 +320,12 @@ export class ShellRoot extends LitElement {
         // Skip while a modal is open — modal surfaces trap navigation.
         if (this._modalIsOpen()) return false;
         const direction = action === KEY_ACTION.BLIP_FOCUS_NEXT ? 1 : -1;
-        return moveBlipFocus(direction, undefined, evt.key);
+        return moveBlipFocus(direction, document, (evt && evt.key) || "");
       }
       case KEY_ACTION.BLIP_FOCUS_FIRST:
       case KEY_ACTION.BLIP_FOCUS_LAST: {
         if (this._modalIsOpen()) return false;
-        return focusBlipBoundary(action === KEY_ACTION.BLIP_FOCUS_LAST ? "last" : "first", undefined, evt.key);
+        return focusBlipBoundary(action === KEY_ACTION.BLIP_FOCUS_LAST ? "last" : "first", document, (evt && evt.key) || "");
       }
       case KEY_ACTION.BLIP_DEPTH_UP:
       case KEY_ACTION.BLIP_DEPTH_IN: {

--- a/j2cl/lit/src/elements/shell-root.js
+++ b/j2cl/lit/src/elements/shell-root.js
@@ -320,12 +320,12 @@ export class ShellRoot extends LitElement {
         // Skip while a modal is open — modal surfaces trap navigation.
         if (this._modalIsOpen()) return false;
         const direction = action === KEY_ACTION.BLIP_FOCUS_NEXT ? 1 : -1;
-        return moveBlipFocus(direction);
+        return moveBlipFocus(direction, undefined, evt.key);
       }
       case KEY_ACTION.BLIP_FOCUS_FIRST:
       case KEY_ACTION.BLIP_FOCUS_LAST: {
         if (this._modalIsOpen()) return false;
-        return focusBlipBoundary(action === KEY_ACTION.BLIP_FOCUS_LAST ? "last" : "first");
+        return focusBlipBoundary(action === KEY_ACTION.BLIP_FOCUS_LAST ? "last" : "first", undefined, evt.key);
       }
       case KEY_ACTION.BLIP_DEPTH_UP:
       case KEY_ACTION.BLIP_DEPTH_IN: {

--- a/j2cl/lit/src/elements/wavy-focus-frame.js
+++ b/j2cl/lit/src/elements/wavy-focus-frame.js
@@ -66,6 +66,7 @@ export class WavyFocusFrame extends LitElement {
     super();
     this.focusedBlipId = "";
     this.bounds = { top: 0, left: 0, width: 0, height: 0 };
+    this._frameVisible = false;
     this._onFocusChanged = this._onFocusChanged.bind(this);
     this._listeningOn = null;
   }
@@ -94,7 +95,17 @@ export class WavyFocusFrame extends LitElement {
       return;
     }
     const { blipId, bounds } = event.detail;
-    this.focusedBlipId = typeof blipId === "string" ? blipId : "";
+    const nextBlipId = typeof blipId === "string" ? blipId : "";
+    const explicitKey =
+      typeof event.detail.key === "string" && event.detail.key.trim() !== "";
+    if (!nextBlipId) {
+      this._frameVisible = false;
+    } else if (explicitKey) {
+      this._frameVisible = true;
+    } else if (nextBlipId !== this.focusedBlipId) {
+      this._frameVisible = false;
+    }
+    this.focusedBlipId = nextBlipId;
     this.bounds =
       bounds && typeof bounds === "object"
         ? {
@@ -107,7 +118,7 @@ export class WavyFocusFrame extends LitElement {
   }
 
   render() {
-    const hidden = !this.focusedBlipId;
+    const hidden = !this.focusedBlipId || !this._frameVisible;
     const style = `top: ${this.bounds.top}px; left: ${this.bounds.left}px; width: ${this.bounds.width}px; height: ${this.bounds.height}px;`;
     return html`<div
       class="frame"

--- a/j2cl/lit/src/shortcuts/blip-focus.js
+++ b/j2cl/lit/src/shortcuts/blip-focus.js
@@ -136,7 +136,12 @@ export function moveBlipFocus(direction, root = document, key = "") {
     nextIdx = direction > 0 ? 0 : list.length - 1;
   } else {
     nextIdx = currentIdx + direction;
-    if (nextIdx < 0 || nextIdx >= list.length) return true; // at boundary, consume key
+    if (nextIdx < 0 || nextIdx >= list.length) {
+      // At boundary — key consumed but focus didn't move. Reveal the frame on the
+      // current blip if this was explicit keyboard navigation so the user sees focus.
+      if (key) dispatchRendererFocusChanged(findReadSurface(list[currentIdx], root), list[currentIdx], key);
+      return true;
+    }
   }
   setFocusedBlip(list[nextIdx], root, key);
   return true;

--- a/j2cl/lit/src/shortcuts/blip-focus.js
+++ b/j2cl/lit/src/shortcuts/blip-focus.js
@@ -82,9 +82,10 @@ function findReadSurface(blip, root = document) {
  * Fire `wavy-focus-changed` on the read surface so the
  * <wavy-focus-frame> overlay repaints. Mirrors the detail shape that
  * J2clReadSurfaceDomRenderer.dispatchFocusChanged emits. Pass
- * `blip = null` to clear the frame.
+ * `blip = null` to clear the frame. Pass a non-empty `key` to indicate
+ * the event is from explicit keyboard navigation (vs. programmatic restore).
  */
-function dispatchRendererFocusChanged(surface, blip) {
+function dispatchRendererFocusChanged(surface, blip, key = "") {
   if (!surface) return;
   const blipId = blip ? (blip.getAttribute("data-blip-id") || "") : "";
   let bounds = { top: 0, left: 0, width: 0, height: 0 };
@@ -107,7 +108,7 @@ function dispatchRendererFocusChanged(surface, blip) {
       new CustomEvent("wavy-focus-changed", {
         bubbles: true,
         composed: true,
-        detail: { blipId, bounds, key: "" }
+        detail: { blipId, bounds, key }
       })
     );
   } catch (_) {
@@ -125,7 +126,7 @@ function dispatchRendererFocusChanged(surface, blip) {
  * `moveUp` and `J2clReadSurfaceDomRenderer.focusVisibleByIndex` which
  * both clamp rather than wrap).
  */
-export function moveBlipFocus(direction, root = document) {
+export function moveBlipFocus(direction, root = document, key = "") {
   const list = snapshotBlips(root);
   if (list.length === 0) return false;
 
@@ -137,15 +138,15 @@ export function moveBlipFocus(direction, root = document) {
     nextIdx = currentIdx + direction;
     if (nextIdx < 0 || nextIdx >= list.length) return true; // at boundary, consume key
   }
-  setFocusedBlip(list[nextIdx], root);
+  setFocusedBlip(list[nextIdx], root, key);
   return true;
 }
 
-export function focusBlipBoundary(boundary, root = document) {
+export function focusBlipBoundary(boundary, root = document, key = "") {
   const list = snapshotBlips(root);
   if (list.length === 0) return false;
   const target = boundary === "last" ? list[list.length - 1] : list[0];
-  setFocusedBlip(target, root);
+  setFocusedBlip(target, root, key);
   return true;
 }
 
@@ -211,7 +212,7 @@ export function dispatchFocusedBlipDepth(direction, root = document) {
  * Fires a `wave-blip-focus-changed` CustomEvent (bubbles + composed)
  * so external consumers (telemetry, the route controller) can react.
  */
-export function setFocusedBlip(target, root = document) {
+export function setFocusedBlip(target, root = document, key = "") {
   if (!target) return;
   // Clear ALL blips (including hidden/parked) so stale markers left by
   // the viewport renderer do not accumulate. `snapshotBlips` still scopes
@@ -257,7 +258,7 @@ export function setFocusedBlip(target, root = document) {
       }
     })
   );
-  dispatchRendererFocusChanged(findReadSurface(target, root), target);
+  dispatchRendererFocusChanged(findReadSurface(target, root), target, key);
 }
 
 /**

--- a/j2cl/lit/test/shortcuts/blip-focus.test.js
+++ b/j2cl/lit/test/shortcuts/blip-focus.test.js
@@ -68,6 +68,25 @@ describe("moveBlipFocus", () => {
     expect(root.querySelector("wave-blip[focused]").getAttribute("data-blip-id")).to.equal("b1");
   });
 
+  it("boundary clamp with explicit key dispatches keyed wavy-focus-changed to reveal frame", async () => {
+    const root = await fixture(html`
+      <div data-j2cl-read-surface="true">
+        <wave-blip data-blip-id="b1" data-wave-id="w" author-name="A"></wave-blip>
+        <wave-blip data-blip-id="b2" data-wave-id="w" author-name="B"></wave-blip>
+      </div>
+    `);
+    // Navigate to last blip
+    moveBlipFocus(1, root); // b1
+    moveBlipFocus(1, root); // b2 (last)
+    let focusDetail = null;
+    root.addEventListener("wavy-focus-changed", (e) => { focusDetail = e.detail; });
+    // Press j again at boundary — focus stays on b2 but frame should become visible
+    moveBlipFocus(1, root, "j");
+    expect(focusDetail).to.not.equal(null);
+    expect(focusDetail.key).to.equal("j");
+    expect(focusDetail.blipId).to.equal("b2");
+  });
+
   it("skips blips inside collapsed thread containers", async () => {
     const root = await fixture(html`
       <div>

--- a/j2cl/lit/test/shortcuts/blip-focus.test.js
+++ b/j2cl/lit/test/shortcuts/blip-focus.test.js
@@ -107,6 +107,21 @@ describe("moveBlipFocus", () => {
     expect(fired).to.deep.equal({ blipId: "b2", waveId: "w" });
   });
 
+  it("setFocusedBlip propagates explicit key to wavy-focus-changed", async () => {
+    const root = await fixture(html`
+      <div data-j2cl-read-surface="true">
+        <wave-blip data-blip-id="b1" data-wave-id="w" author-name="A"></wave-blip>
+      </div>
+    `);
+    const blip = root.querySelector("wave-blip");
+    let focusDetail = null;
+    root.addEventListener("wavy-focus-changed", (e) => { focusDetail = e.detail; });
+    setFocusedBlip(blip, root, "j");
+    expect(focusDetail).to.not.equal(null);
+    expect(focusDetail.key).to.equal("j");
+    expect(focusDetail.blipId).to.equal("b1");
+  });
+
   it("setFocusedBlip adds j2cl-read-blip-focused class and removes from others", async () => {
     const root = await threeBlips();
     const blips = Array.from(root.querySelectorAll("wave-blip"));

--- a/j2cl/lit/test/shortcuts/blip-focus.test.js
+++ b/j2cl/lit/test/shortcuts/blip-focus.test.js
@@ -96,6 +96,36 @@ describe("moveBlipFocus", () => {
     expect(root.querySelector("wave-blip[focused]").getAttribute("data-blip-id")).to.equal("b3");
   });
 
+  it("moveBlipFocus threads key through to wavy-focus-changed on the read surface", async () => {
+    const root = await fixture(html`
+      <div data-j2cl-read-surface="true">
+        <wave-blip data-blip-id="b1" data-wave-id="w" author-name="A"></wave-blip>
+        <wave-blip data-blip-id="b2" data-wave-id="w" author-name="B"></wave-blip>
+      </div>
+    `);
+    let focusDetail = null;
+    root.addEventListener("wavy-focus-changed", (e) => { focusDetail = e.detail; });
+    moveBlipFocus(1, root, "j");
+    expect(focusDetail).to.not.equal(null);
+    expect(focusDetail.key).to.equal("j");
+    expect(focusDetail.blipId).to.equal("b1");
+  });
+
+  it("focusBlipBoundary threads key through to wavy-focus-changed on the read surface", async () => {
+    const root = await fixture(html`
+      <div data-j2cl-read-surface="true">
+        <wave-blip data-blip-id="b1" data-wave-id="w" author-name="A"></wave-blip>
+        <wave-blip data-blip-id="b2" data-wave-id="w" author-name="B"></wave-blip>
+      </div>
+    `);
+    let focusDetail = null;
+    root.addEventListener("wavy-focus-changed", (e) => { focusDetail = e.detail; });
+    focusBlipBoundary("last", root, "End");
+    expect(focusDetail).to.not.equal(null);
+    expect(focusDetail.key).to.equal("End");
+    expect(focusDetail.blipId).to.equal("b2");
+  });
+
   it("setFocusedBlip fires wave-blip-focus-changed", async () => {
     const root = await threeBlips();
     const target = root.querySelectorAll("wave-blip")[1];

--- a/j2cl/lit/test/wavy-focus-frame.test.js
+++ b/j2cl/lit/test/wavy-focus-frame.test.js
@@ -87,6 +87,7 @@ describe("<wavy-focus-frame>", () => {
       </div>`
     );
     const frame = host.querySelector("wavy-focus-frame");
+    await frame.updateComplete;
     host.dispatchEvent(
       new CustomEvent("wavy-focus-changed", {
         bubbles: false,
@@ -94,7 +95,7 @@ describe("<wavy-focus-frame>", () => {
         detail: {
           blipId: "b+1",
           bounds: { top: 0, left: 0, width: 100, height: 100 },
-          key: ""
+          key: "ArrowDown"
         }
       })
     );
@@ -107,6 +108,45 @@ describe("<wavy-focus-frame>", () => {
     expect(computed.boxShadow).to.contain("2px");
   });
 
+  it("does not paint the frame for the initial programmatic focus event", async () => {
+    const host = await fixture(
+      html`<div data-j2cl-read-surface="true" style="position: relative; width: 400px; height: 300px;">
+        <wavy-focus-frame></wavy-focus-frame>
+      </div>`
+    );
+    const frame = host.querySelector("wavy-focus-frame");
+    await frame.updateComplete;
+
+    host.dispatchEvent(
+      new CustomEvent("wavy-focus-changed", {
+        detail: {
+          blipId: "b+initial",
+          bounds: { top: 12, left: 8, width: 320, height: 64 },
+          key: ""
+        }
+      })
+    );
+    await frame.updateComplete;
+
+    expect(frame.focusedBlipId).to.equal("b+initial");
+    expect(frame.renderRoot.querySelector(".frame").hasAttribute("hidden")).to.be
+      .true;
+
+    host.dispatchEvent(
+      new CustomEvent("wavy-focus-changed", {
+        detail: {
+          blipId: "b+initial",
+          bounds: { top: 14, left: 8, width: 320, height: 64 },
+          key: "j"
+        }
+      })
+    );
+    await frame.updateComplete;
+
+    expect(frame.renderRoot.querySelector(".frame").hasAttribute("hidden")).to.be
+      .false;
+  });
+
   it("re-hides when focusedBlipId resets to empty", async () => {
     const host = await fixture(
       html`<div data-j2cl-read-surface="true" style="position: relative;">
@@ -116,7 +156,11 @@ describe("<wavy-focus-frame>", () => {
     const frame = host.querySelector("wavy-focus-frame");
     host.dispatchEvent(
       new CustomEvent("wavy-focus-changed", {
-        detail: { blipId: "b+1", bounds: { top: 0, left: 0, width: 10, height: 10 } }
+        detail: {
+          blipId: "b+1",
+          bounds: { top: 0, left: 0, width: 10, height: 10 },
+          key: "ArrowDown"
+        }
       })
     );
     await frame.updateComplete;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -3398,6 +3398,9 @@ public final class J2clReadSurfaceDomRenderer {
     }
     if (focusedBlip == next) {
       markFocusedBlipReadNow(next);
+      if (key != null && !key.isEmpty()) {
+        dispatchFocusChanged(focusedBlip, key);
+      }
       return;
     }
     clearFocusedBlip();

--- a/wave/config/changelog.d/2026-05-18-issue-1258-j2cl-first-blip-line.json
+++ b/wave/config/changelog.d/2026-05-18-issue-1258-j2cl-first-blip-line.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-18-issue-1258-j2cl-first-blip-line",
+  "version": "Issue #1258",
+  "date": "2026-05-18",
+  "title": "J2CL no longer paints a focus-frame line across the first blip on wave open.",
+  "summary": "The J2CL focus frame now waits for explicit keyboard navigation before painting, so the initial programmatic blip selection remains available for navigation without drawing a horizontal cyan line across the first blip.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Initial wave-open blip selection keeps logical focus markers but does not show the absolute focus-frame overlay until the user navigates."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes #1258.

- Prevents `<wavy-focus-frame>` from painting during the initial programmatic J2CL blip selection on wave open.
- Keeps the focused blip id and bounds tracked so explicit keyboard navigation can show/update the frame normally.
- Adds focused Lit regression coverage plus issue plan/changelog fragment.

## Verification

- Red phase: `npm test -- --files test/wavy-focus-frame.test.js` failed on `does not paint the frame for the initial programmatic focus event` before the implementation change.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`
- `npm test -- --files test/wavy-focus-frame.test.js` from `j2cl/lit` -> 9 passed, 0 failed
- `npm test` from `j2cl/lit` -> 873 passed, 0 failed
- `npm run build` from `j2cl/lit` -> passed, `audit-buttons: OK`
- `git diff --check`
- `WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 sbt -batch "j2clLitBuild; Universal/stage"`
- Staged server route smoke on port 9900: ROOT_STATUS=200, GWT_VIEW_STATUS=200, HEALTH_STATUS=200, LANDING_STATUS=200, J2CL_ROOT_STATUS=200, J2CL_ROOT_SHELL=present, WEBCLIENT_STATUS=200
- Browser plugin opened `http://localhost:9900/?view=j2cl-root` successfully with title `SupaWave J2CL Root Shell`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Focus frame no longer appears on the initial programmatic selection; it now shows only after explicit keyboard navigation.
  * Keyboard navigation reliably distinguishes programmatic vs. user-initiated focus so visual feedback is consistent.

* **Tests**
  * Added/expanded tests to verify focus overlay visibility behavior for programmatic and keyboard-driven focus events.

* **Documentation**
  * Added changelog entry and a doc plan describing the focus-overlay behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->