### PR TITLE
Fix J2CL topbar user menu parity

### DIFF
--- a/docs/superpowers/plans/2026-05-18-issue-1259-j2cl-topbar-user-menu.md
+++ b/docs/superpowers/plans/2026-05-18-issue-1259-j2cl-topbar-user-menu.md
@@ -1,0 +1,22 @@
+Plan for issue #1259
+
+Root cause:
+- The J2CL root shell renders the right-side compact controls through <wavy-header> inside shell-header.
+- The <wavy-header> user button only emits wavy-user-menu-requested; no root-shell listener consumes it, so clicking the avatar has no visible effect.
+- Compact mode styles the user control as a square icon tile, while GWT uses the shared topbar user-menu-toggle/avatar/dropdown contract.
+
+Implementation plan:
+1. Add failing Lit tests for compact <wavy-header>: clicking the user control opens a dropdown menu, toggles aria-expanded, closes on Escape/outside click, and exposes GWT-style account/sign-out menu links.
+2. Update j2cl/lit/src/elements/wavy-header.js narrowly:
+   - Add open/close state and document/Escape handling.
+   - Render a GWT-style compact user menu dropdown with account/product/legal/sign-out links.
+   - Restyle compact user control to match the GWT topbar pill/avatar rather than the square icon tile.
+3. Update the Jakarta HtmlRenderer SSR light DOM for <wavy-header> so the fallback markup includes the same menu and attributes before Lit upgrades.
+4. Mirror necessary pre-upgrade CSS in shell-tokens.css.
+5. Add a changelog fragment and run focused Lit/server renderer tests plus local smoke if feasible.
+
+Self-review checkpoints:
+- Keep the fix in the J2CL topbar seam only; do not change unrelated wave panel chrome.
+- Preserve existing Admin and Sign out top-level links.
+- Keep hrefs local/context-aware and escaped.
+- Verify with tests before PR.

--- a/j2cl/lit/src/elements/wavy-header.js
+++ b/j2cl/lit/src/elements/wavy-header.js
@@ -30,7 +30,7 @@ import { t } from "../i18n/t.js";
  *
  * Events:
  * - wavy-locale-changed     — `{detail: {locale}}` on <select> change
- * - wavy-user-menu-requested — `{detail: {address}}` on user-menu click
+ * - wavy-user-menu-requested — `{detail: {address, open}}` on user-menu click
  */
 export class WavyHeader extends LitElement {
   static properties = {

--- a/j2cl/lit/src/elements/wavy-header.js
+++ b/j2cl/lit/src/elements/wavy-header.js
@@ -38,8 +38,10 @@ export class WavyHeader extends LitElement {
     locale: { type: String, reflect: true },
     address: { type: String, attribute: "data-address", reflect: true },
     userName: { type: String, attribute: "user-name" },
+    userRole: { type: String, attribute: "user-role" },
     unreadCount: { type: Number, attribute: "unread-count" },
     basePath: { type: String, attribute: "base-path" },
+    returnTarget: { type: String, attribute: "return-target" },
     compactGwtTopbar: { type: Boolean, attribute: "compact-gwt-topbar", reflect: true },
     connectionState: { type: String, attribute: "data-connection-state", reflect: true },
     saveState: { type: String, attribute: "data-save-state", reflect: true },
@@ -141,8 +143,7 @@ export class WavyHeader extends LitElement {
       text-decoration: none;
     }
     :host([compact-gwt-topbar]) .bell,
-    :host([compact-gwt-topbar]) .mail,
-    :host([compact-gwt-topbar]) .user-menu {
+    :host([compact-gwt-topbar]) .mail {
       width: 32px;
       height: 32px;
       min-width: 32px;
@@ -151,6 +152,17 @@ export class WavyHeader extends LitElement {
       color: #fff;
       background: rgba(255, 255, 255, 0.10);
       border-radius: 6px;
+    }
+    :host([compact-gwt-topbar]) .user-menu {
+      width: auto;
+      height: 32px;
+      min-width: 0;
+      padding: 3px 8px 3px 4px;
+      justify-content: center;
+      color: #fff;
+      background: rgba(255, 255, 255, 0.10);
+      border-radius: 20px;
+      gap: 6px;
     }
     .savestatus,
     .netstatus {
@@ -273,6 +285,25 @@ export class WavyHeader extends LitElement {
       font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
       font-weight: 600;
     }
+    :host([compact-gwt-topbar]) .avatar {
+      width: 28px;
+      height: 28px;
+      border: 0;
+      background: rgba(255, 255, 255, 0.25);
+      color: #fff;
+      font-size: 13px;
+      font-weight: 700;
+      line-height: 1;
+    }
+    .caret {
+      display: none;
+      font-size: 10px;
+      line-height: 1;
+      opacity: 0.8;
+    }
+    :host([compact-gwt-topbar]) .caret {
+      display: inline;
+    }
     .user-email {
       font: var(--wavy-type-meta, 0.6875rem / 1.4 sans-serif);
       color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
@@ -286,6 +317,90 @@ export class WavyHeader extends LitElement {
         display: none;
       }
     }
+    .user-menu-wrap {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+    }
+    .user-menu-dropdown {
+      display: none;
+      position: absolute;
+      right: 0;
+      top: 100%;
+      z-index: 1000;
+      min-width: 224px;
+      margin-top: 6px;
+      padding: 6px;
+      border: 1px solid #dbe7f1;
+      border-radius: 10px;
+      background: #fff;
+      box-shadow: 0 14px 30px rgba(2, 62, 107, 0.18);
+      color: #1f2933;
+    }
+    .user-menu-dropdown.open {
+      display: block;
+    }
+    .user-info {
+      padding: 6px 10px 9px;
+      border-bottom: 1px solid #e2e8f0;
+      color: #4a5568;
+      margin-bottom: 2px;
+    }
+    .user-info-label,
+    .section-label {
+      display: block;
+      font-size: 10px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #718096;
+    }
+    .user-info-label {
+      margin-bottom: 4px;
+    }
+    .section-label {
+      padding: 0 10px 4px;
+    }
+    .user-info-address {
+      display: block;
+      color: #1f2933;
+      font-size: 13px;
+      font-weight: 600;
+      line-height: 1.3;
+      overflow-wrap: anywhere;
+    }
+    .menu-section {
+      padding: 4px 0 0;
+    }
+    .menu-section + .menu-section {
+      border-top: 1px solid #e2e8f0;
+      margin-top: 4px;
+      padding-top: 6px;
+    }
+    .user-menu-dropdown a {
+      display: block;
+      padding: 7px 10px;
+      border-radius: 8px;
+      color: #1f2933;
+      text-decoration: none;
+      font-size: 13px;
+      line-height: 1.25;
+      transition: background 0.12s, color 0.12s;
+    }
+    .user-menu-dropdown a:hover,
+    .user-menu-dropdown a:focus-visible {
+      background: #f0f7fb;
+      color: #0077b6;
+      outline: none;
+    }
+    .section-link-strong {
+      font-weight: 700;
+      color: #0077b6;
+    }
+    .menu-signout {
+      font-weight: 600;
+      margin-top: 2px;
+    }
     svg {
       width: 16px;
       height: 16px;
@@ -298,13 +413,18 @@ export class WavyHeader extends LitElement {
     this.locale = getLocale();
     this.address = "";
     this.userName = "";
+    this.userRole = "user";
     this.unreadCount = 0;
     this.basePath = "/";
+    this.returnTarget = "/";
     this.compactGwtTopbar = false;
     this.noBrand = false;
     this.connectionState = "online";
     this.saveState = "saved";
     this._unsubscribeLocale = null;
+    this._menuOpen = false;
+    this._onDocumentClick = this._onDocumentClick.bind(this);
+    this._onWindowKeyDown = this._onWindowKeyDown.bind(this);
   }
 
   connectedCallback() {
@@ -315,6 +435,12 @@ export class WavyHeader extends LitElement {
       }
       this.requestUpdate();
     });
+    if (typeof document !== "undefined") {
+      document.addEventListener("click", this._onDocumentClick);
+    }
+    if (typeof window !== "undefined") {
+      window.addEventListener("keydown", this._onWindowKeyDown);
+    }
   }
 
   disconnectedCallback() {
@@ -323,6 +449,12 @@ export class WavyHeader extends LitElement {
       this._unsubscribeLocale();
       this._unsubscribeLocale = null;
     }
+    if (typeof document !== "undefined") {
+      document.removeEventListener("click", this._onDocumentClick);
+    }
+    if (typeof window !== "undefined") {
+      window.removeEventListener("keydown", this._onWindowKeyDown);
+    }
   }
 
   _normalizedBasePath() {
@@ -330,6 +462,20 @@ export class WavyHeader extends LitElement {
     if (!raw || raw === "/") return "/";
     const withLeading = raw.startsWith("/") ? raw : `/${raw}`;
     return withLeading.endsWith("/") ? withLeading.slice(0, -1) : withLeading;
+  }
+
+  _href(path) {
+    const base = this._normalizedBasePath();
+    if (base === "/") return path;
+    return `${base}${path}`;
+  }
+
+  _signOutHref() {
+    const target = this.returnTarget || this._normalizedBasePath();
+    const encoded = target.startsWith("/")
+      ? `/${encodeURIComponent(target.slice(1))}`
+      : encodeURIComponent(target);
+    return `${this._href("/auth/signout")}?r=${encoded}`;
   }
 
   _initials() {
@@ -362,13 +508,33 @@ export class WavyHeader extends LitElement {
   }
 
   _onUserMenuClick() {
+    this._menuOpen = !this._menuOpen;
+    this.requestUpdate();
     this.dispatchEvent(
       new CustomEvent("wavy-user-menu-requested", {
         bubbles: true,
         composed: true,
-        detail: { address: this.address }
+        detail: { address: this.address, open: this._menuOpen }
       })
     );
+  }
+
+  _onDocumentClick(evt) {
+    if (!this._menuOpen) return;
+    const path = evt.composedPath ? evt.composedPath() : [];
+    if (path.includes(this)) return;
+    this._menuOpen = false;
+    this.requestUpdate();
+  }
+
+  _onWindowKeyDown(evt) {
+    if (evt.key !== "Escape" || !this._menuOpen) return;
+    evt.preventDefault();
+    this._menuOpen = false;
+    this.requestUpdate();
+    this.updateComplete.then(() => {
+      this.renderRoot.querySelector("#wavyHeaderUserMenuToggle")?.focus();
+    });
   }
 
   _saveLabel() {
@@ -388,6 +554,7 @@ export class WavyHeader extends LitElement {
     const hasUnread = (this.unreadCount || 0) > 0;
     const base = this._normalizedBasePath();
     const compact = this.compactGwtTopbar;
+    const isAdminOrOwner = this.userRole === "admin" || this.userRole === "owner";
     return html`
       ${this.noBrand
         ? null
@@ -480,17 +647,57 @@ export class WavyHeader extends LitElement {
               </svg>
             </a>
 
-            <button
-              type="button"
-              class="user-menu"
-              aria-haspopup="menu"
-              aria-label=${t("header.userMenu", "Open user menu")}
-              title=${t("header.userMenu", "Open user menu")}
-              @click=${this._onUserMenuClick}
-            >
-              <span class="avatar" aria-hidden="true">${initials}</span>
-              <span class="user-email">${this.address || ""}</span>
-            </button>
+            <span class="user-menu-wrap">
+              <button
+                id="wavyHeaderUserMenuToggle"
+                type="button"
+                class="user-menu"
+                aria-haspopup="true"
+                aria-expanded=${this._menuOpen ? "true" : "false"}
+                aria-controls="wavyHeaderUserMenu"
+                aria-label=${t("header.userMenu", "Open user menu")}
+                title=${this.address || t("header.userMenu", "Open user menu")}
+                @click=${this._onUserMenuClick}
+              >
+                <span class="avatar" aria-hidden="true">${initials}</span>
+                <span class="user-email">${this.address || ""}</span>
+                <span class="caret" aria-hidden="true">▾</span>
+              </button>
+              <div
+                id="wavyHeaderUserMenu"
+                class=${`user-menu-dropdown ${this._menuOpen ? "open" : ""}`}
+                aria-labelledby="wavyHeaderUserMenuToggle"
+              >
+                <div class="user-info">
+                  <div class="user-info-label">Signed in as</div>
+                  <div class="user-info-address">${this.address || ""}</div>
+                </div>
+                <div class="menu-section">
+                  <div class="section-label">Account</div>
+                  <a href=${this._href("/userprofile/edit")}>Edit Profile</a>
+                  <a href=${this._href("/account/settings")}>Account Settings</a>
+                </div>
+                <div class="menu-section">
+                  <div class="section-label">Plugins / Integrations</div>
+                  <a class="section-link-strong" href=${this._href("/account/robots")}>Robot &amp; Data API</a>
+                  <a href=${this._href("/api-docs")} target="_blank" rel="noopener noreferrer">API Docs</a>
+                </div>
+                <div class="menu-section">
+                  <div class="section-label">Product / Support</div>
+                  <a href=${this._href("/changelog")} target="_blank" rel="noopener noreferrer">What's New</a>
+                  <a href=${this._href("/contact")}>Contact Us</a>
+                  ${isAdminOrOwner ? html`<a href=${this._href("/admin")}>Admin</a>` : null}
+                </div>
+                <div class="menu-section">
+                  <div class="section-label">Legal</div>
+                  <a href=${this._href("/terms")} target="_blank" rel="noopener noreferrer">Terms of Service</a>
+                  <a href=${this._href("/privacy")} target="_blank" rel="noopener noreferrer">Privacy Policy</a>
+                </div>
+                <div class="menu-section">
+                  <a class="menu-signout" href=${this._signOutHref()}>Sign Out</a>
+                </div>
+              </div>
+            </span>
           `
         : null}
     `;

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -323,8 +323,7 @@ shell-header[compact-gwt-topbar] wavy-header .locale {
 }
 
 shell-header[compact-gwt-topbar] wavy-header .bell,
-shell-header[compact-gwt-topbar] wavy-header .mail,
-shell-header[compact-gwt-topbar] wavy-header .user-menu {
+shell-header[compact-gwt-topbar] wavy-header .mail {
   box-sizing: border-box;
   display: inline-flex;
   align-items: center;
@@ -341,11 +340,151 @@ shell-header[compact-gwt-topbar] wavy-header .user-menu {
   text-decoration: none;
 }
 
+shell-header[compact-gwt-topbar] wavy-header .user-menu-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .user-menu {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: auto;
+  height: 32px;
+  min-width: 0;
+  padding: 3px 8px 3px 4px;
+  border: 0;
+  border-radius: 20px;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.10);
+  cursor: pointer;
+  text-decoration: none;
+}
+
 shell-header[compact-gwt-topbar] wavy-header .bell svg,
 shell-header[compact-gwt-topbar] wavy-header .mail svg {
   width: 16px;
   height: 16px;
   flex: 0 0 auto;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .avatar {
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 0;
+  background: rgba(255, 255, 255, 0.25);
+  color: #fff;
+  font: 700 13px / 1 Arial, Helvetica, sans-serif;
+  text-transform: uppercase;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .caret {
+  display: inline;
+  font-size: 10px;
+  line-height: 1;
+  opacity: 0.8;
+}
+
+wavy-header .user-menu-dropdown {
+  display: none;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .user-menu-dropdown {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  z-index: 1000;
+  min-width: 224px;
+  margin-top: 6px;
+  padding: 6px;
+  border: 1px solid #dbe7f1;
+  border-radius: 10px;
+  background: #fff;
+  box-shadow: 0 14px 30px rgba(2, 62, 107, 0.18);
+  color: #1f2933;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .user-menu-dropdown.open {
+  display: block;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .user-info {
+  padding: 6px 10px 9px;
+  border-bottom: 1px solid #e2e8f0;
+  color: #4a5568;
+  margin-bottom: 2px;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .user-info-label,
+shell-header[compact-gwt-topbar] wavy-header .section-label {
+  display: block;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #718096;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .user-info-label {
+  margin-bottom: 4px;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .section-label {
+  padding: 0 10px 4px;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .user-info-address {
+  display: block;
+  color: #1f2933;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .menu-section {
+  padding: 4px 0 0;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .menu-section + .menu-section {
+  border-top: 1px solid #e2e8f0;
+  margin-top: 4px;
+  padding-top: 6px;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .user-menu-dropdown a {
+  display: block;
+  padding: 7px 10px;
+  border-radius: 8px;
+  color: #1f2933;
+  text-decoration: none;
+  font-size: 13px;
+  line-height: 1.25;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .user-menu-dropdown a:hover,
+shell-header[compact-gwt-topbar] wavy-header .user-menu-dropdown a:focus-visible {
+  background: #f0f7fb;
+  color: #0077b6;
+  outline: none;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .section-link-strong {
+  font-weight: 700;
+  color: #0077b6;
+}
+
+shell-header[compact-gwt-topbar] wavy-header .menu-signout {
+  font-weight: 600;
+  margin-top: 2px;
 }
 
 /* GWT topbar parity (#1232): savestatus + netstatus chips inside the

--- a/j2cl/lit/test/wavy-header.test.js
+++ b/j2cl/lit/test/wavy-header.test.js
@@ -235,6 +235,10 @@ describe("<wavy-header>", () => {
     const owner = await fixture(html`<wavy-header signed-in user-role="owner"></wavy-header>`);
     await owner.updateComplete;
     expect(owner.renderRoot.querySelector('a[href="/admin"]')).to.exist;
+
+    const admin = await fixture(html`<wavy-header signed-in user-role="admin"></wavy-header>`);
+    await admin.updateComplete;
+    expect(admin.renderRoot.querySelector('a[href="/admin"]')).to.exist;
   });
 
   it("user menu signout follows return-target attribute updates", async () => {

--- a/j2cl/lit/test/wavy-header.test.js
+++ b/j2cl/lit/test/wavy-header.test.js
@@ -68,6 +68,18 @@ describe("<wavy-header>", () => {
     expect(getComputedStyle(bell).height).to.equal("32px");
   });
 
+  it("compact GWT topbar mode uses the GWT user-menu pill geometry", async () => {
+    const el = await fixture(html`<wavy-header compact-gwt-topbar signed-in></wavy-header>`);
+    await el.updateComplete;
+    const userMenu = el.renderRoot.querySelector("button.user-menu");
+    const avatar = userMenu.querySelector(".avatar");
+
+    expect(getComputedStyle(userMenu).width).to.not.equal("32px");
+    expect(getComputedStyle(userMenu).borderRadius).to.equal("20px");
+    expect(getComputedStyle(avatar).width).to.equal("28px");
+    expect(getComputedStyle(avatar).height).to.equal("28px");
+  });
+
   it("change on locale picker emits wavy-locale-changed (A.2)", async () => {
     const el = await fixture(html`<wavy-header></wavy-header>`);
     await el.updateComplete;
@@ -131,7 +143,7 @@ describe("<wavy-header>", () => {
     await el.updateComplete;
     const userMenu = el.renderRoot.querySelector("button.user-menu");
     expect(userMenu).to.exist;
-    expect(userMenu.getAttribute("aria-haspopup")).to.equal("menu");
+    expect(userMenu.getAttribute("aria-haspopup")).to.equal("true");
     const avatar = userMenu.querySelector(".avatar");
     expect(avatar).to.exist;
     expect(avatar.textContent.trim()).to.equal("AS"); // alice.smith → A + S
@@ -162,6 +174,84 @@ describe("<wavy-header>", () => {
     setTimeout(() => userMenu.click(), 0);
     const evt = await oneEvent(el, "wavy-user-menu-requested");
     expect(evt.detail.address).to.equal("alice@example.com");
+    expect(evt.detail.open).to.equal(true);
+  });
+
+  it("user-menu click opens the GWT-style account menu and outside/Escape closes it", async () => {
+    const el = await fixture(
+      html`<wavy-header
+        compact-gwt-topbar
+        signed-in
+        data-address="alice@example.com"
+        return-target="/?view=j2cl-root"
+      ></wavy-header>`
+    );
+    await el.updateComplete;
+    const userMenu = el.renderRoot.querySelector("button.user-menu");
+    const dropdown = el.renderRoot.querySelector(".user-menu-dropdown");
+    const outside = document.createElement("button");
+    outside.textContent = "outside";
+    document.body.appendChild(outside);
+
+    expect(dropdown).to.exist;
+    expect(dropdown.classList.contains("open")).to.be.false;
+    expect(userMenu.getAttribute("aria-expanded")).to.equal("false");
+
+    userMenu.click();
+    await el.updateComplete;
+
+    expect(dropdown.classList.contains("open")).to.be.true;
+    expect(userMenu.getAttribute("aria-expanded")).to.equal("true");
+    expect(dropdown.querySelector(".user-info-address").textContent.trim()).to.equal(
+      "alice@example.com"
+    );
+    expect(dropdown.querySelector('a[href="/userprofile/edit"]')).to.exist;
+    expect(dropdown.querySelector('a[href="/auth/signout?r=/%3Fview%3Dj2cl-root"]')).to.exist;
+
+    outside.click();
+    await el.updateComplete;
+
+    expect(dropdown.classList.contains("open")).to.be.false;
+    expect(userMenu.getAttribute("aria-expanded")).to.equal("false");
+
+    userMenu.click();
+    await el.updateComplete;
+    expect(dropdown.classList.contains("open")).to.be.true;
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await el.updateComplete;
+
+    expect(dropdown.classList.contains("open")).to.be.false;
+    expect(userMenu.getAttribute("aria-expanded")).to.equal("false");
+    expect(el.renderRoot.activeElement).to.equal(userMenu);
+    outside.remove();
+  });
+
+  it("user menu shows Admin only for admin and owner roles", async () => {
+    const user = await fixture(html`<wavy-header signed-in user-role="user"></wavy-header>`);
+    await user.updateComplete;
+    expect(user.renderRoot.querySelector('a[href="/admin"]')).to.not.exist;
+
+    const owner = await fixture(html`<wavy-header signed-in user-role="owner"></wavy-header>`);
+    await owner.updateComplete;
+    expect(owner.renderRoot.querySelector('a[href="/admin"]')).to.exist;
+  });
+
+  it("user menu signout follows return-target attribute updates", async () => {
+    const el = await fixture(
+      html`<wavy-header signed-in return-target="/?view=j2cl-root"></wavy-header>`
+    );
+    await el.updateComplete;
+
+    expect(el.renderRoot.querySelector('a[href="/auth/signout?r=/%3Fview%3Dj2cl-root"]')).to
+      .exist;
+
+    el.setAttribute("return-target", "/?view=j2cl-root&q=in:inbox");
+    await el.updateComplete;
+
+    expect(
+      el.renderRoot.querySelector('a[href="/auth/signout?r=/%3Fview%3Dj2cl-root%26q%3Din%3Ainbox"]')
+    ).to.exist;
   });
 
   it("avatar initials handle single-name emails", async () => {

--- a/wave/config/changelog.d/2026-05-18-j2cl-topbar-user-menu.json
+++ b/wave/config/changelog.d/2026-05-18-j2cl-topbar-user-menu.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-18-j2cl-topbar-user-menu",
+  "version": "J2CL parity",
+  "date": "2026-05-18",
+  "title": "J2CL topbar user menu now matches the compact GWT behavior.",
+  "summary": "The J2CL root topbar now opens a GWT-style account dropdown from the user/avatar control and uses the same compact pill/avatar geometry as the GWT topbar.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Restored the user menu dropdown on the J2CL compact topbar avatar.",
+        "Aligned the compact J2CL user control styling with the GWT topbar pill and avatar pattern."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -4377,7 +4377,7 @@ public final class HtmlRenderer {
     sb.append("            <a href=\"").append(base).append("privacy\" target=\"_blank\" rel=\"noopener noreferrer\">Privacy Policy</a>\n");
     sb.append("          </div>\n");
     sb.append("          <div class=\"menu-section\">\n");
-    sb.append("            <a class=\"menu-signout\" href=\"").append(safeSignOutHref).append("\">Sign Out</a>\n");
+    sb.append("            <a class=\"menu-signout\" data-j2cl-root-signout=\"true\" href=\"").append(safeSignOutHref).append("\">Sign Out</a>\n");
     sb.append("          </div>\n");
     sb.append("        </div>\n");
   }

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -4341,6 +4341,9 @@ public final class HtmlRenderer {
       String resolvedReturnTarget,
       String userRole) {
     String base = safeBasePath == null || safeBasePath.isEmpty() ? "/" : safeBasePath;
+    if (!base.endsWith("/")) {
+      base = base + "/";
+    }
     String safeSignOutHref =
         base + "auth/signout?r=" + escapeHtml(encodeLocalReturnTarget(resolvedReturnTarget));
     boolean isAdminOrOwner =

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3592,8 +3592,8 @@ public final class HtmlRenderer {
       // passed through alongside the safe (HTML-escaped) form so
       // computeUserInitials can run on the unescaped local part.
       appendWavyHeaderActionsSlot(
-          sb, address, safeAddress, safeResolvedReturnTarget, safeResolvedBasePath, safeHtmlLang,
-          true);
+          sb, address, safeAddress, resolvedReturnTarget, safeResolvedReturnTarget,
+          safeResolvedBasePath, safeHtmlLang, role, true);
       // The legacy inline Admin and Sign out links are PRESERVED until
       // the F-0 user-menu sheet ships (A.7 only mounts the trigger;
       // A.8–A.18 are F-0). Removing them now would orphan affordances
@@ -3875,7 +3875,15 @@ public final class HtmlRenderer {
     sb.append("      <span aria-hidden=\"true\">J2</span><span>SupaWave Read Surface Preview</span>\n");
     sb.append("    </a>\n");
     appendWavyHeaderActionsSlot(
-        sb, resolvedAddress, safeAddress, safeResolvedReturnTarget, safeResolvedBasePath, "en", false);
+        sb,
+        resolvedAddress,
+        safeAddress,
+        resolvedReturnTarget,
+        safeResolvedReturnTarget,
+        safeResolvedBasePath,
+        "en",
+        HumanAccountData.ROLE_USER,
+        false);
     sb.append("  </shell-header>\n");
     sb.append("  <shell-nav-rail slot=\"nav\" label=\"Primary\">\n");
     appendWavySearchRail(sb, safeInitialQuery, false, false);
@@ -4232,8 +4240,8 @@ public final class HtmlRenderer {
    */
   private static void appendWavyHeaderActionsSlot(
       StringBuilder sb, String rawAddress, String safeAddress,
-      String safeResolvedReturnTarget, String safeBasePath, String safeHtmlLang,
-      boolean compactGwtTopbar) {
+      String resolvedReturnTarget, String safeResolvedReturnTarget, String safeBasePath, String safeHtmlLang,
+      String userRole, boolean compactGwtTopbar) {
     String escapedAddress = safeAddress == null ? "" : safeAddress;
     // computeUserInitials runs on the RAW address so the local-part
     // splitting matches the JS Lit element exactly (the Lit element
@@ -4258,6 +4266,10 @@ public final class HtmlRenderer {
         .append(escapedAddress)
         .append("\" user-name=\"")
         .append(escapedAddress)
+        .append("\" user-role=\"")
+        .append(escapeHtml(userRole == null ? HumanAccountData.ROLE_USER : userRole))
+        .append("\" return-target=\"")
+        .append(safeResolvedReturnTarget)
         .append("\" unread-count=\"0\" data-connection-state=\"online\""
             + " data-save-state=\"saved\" base-path=\"")
         .append(safeBasePath)
@@ -4306,14 +4318,65 @@ public final class HtmlRenderer {
         .append("<svg viewBox=\"0 0 16 16\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.4\" aria-hidden=\"true\">")
         .append("<rect x=\"2\" y=\"3.5\" width=\"12\" height=\"9\" rx=\"1.4\"/>")
         .append("<path d=\"M2.5 4.5l5.5 4 5.5-4\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg></a>\n");
-    sb.append("      <button type=\"button\" class=\"user-menu\" aria-haspopup=\"menu\" aria-label=\"Open user menu\">")
+    sb.append("      <span class=\"user-menu-wrap\">\n");
+    sb.append("        <button id=\"wavyHeaderUserMenuToggle\" type=\"button\" class=\"user-menu\" aria-haspopup=\"true\" aria-expanded=\"false\" aria-controls=\"wavyHeaderUserMenu\" aria-label=\"Open user menu\" title=\"")
+        .append(escapedAddress)
+        .append("\">")
         .append("<span class=\"avatar\" aria-hidden=\"true\">")
         .append(initials)
         .append("</span>")
         .append("<span class=\"user-email\">")
         .append(escapedAddress)
-        .append("</span></button>\n");
+        .append("</span>")
+        .append("<span class=\"caret\" aria-hidden=\"true\">&#9662;</span></button>\n");
+    appendWavyHeaderUserMenu(sb, escapedAddress, safeBasePath, resolvedReturnTarget, userRole);
+    sb.append("      </span>\n");
     sb.append("    </wavy-header>\n");
+  }
+
+  private static void appendWavyHeaderUserMenu(
+      StringBuilder sb,
+      String safeAddress,
+      String safeBasePath,
+      String resolvedReturnTarget,
+      String userRole) {
+    String base = safeBasePath == null || safeBasePath.isEmpty() ? "/" : safeBasePath;
+    String safeSignOutHref =
+        base + "auth/signout?r=" + escapeHtml(encodeLocalReturnTarget(resolvedReturnTarget));
+    boolean isAdminOrOwner =
+        HumanAccountData.ROLE_ADMIN.equals(userRole) || HumanAccountData.ROLE_OWNER.equals(userRole);
+
+    sb.append("        <div class=\"user-menu-dropdown\" id=\"wavyHeaderUserMenu\" aria-labelledby=\"wavyHeaderUserMenuToggle\">\n");
+    sb.append("          <div class=\"user-info\"><div class=\"user-info-label\">Signed in as</div><div class=\"user-info-address\">")
+        .append(safeAddress)
+        .append("</div></div>\n");
+    sb.append("          <div class=\"menu-section\">\n");
+    sb.append("            <div class=\"section-label\">Account</div>\n");
+    sb.append("            <a href=\"").append(base).append("userprofile/edit\">Edit Profile</a>\n");
+    sb.append("            <a href=\"").append(base).append("account/settings\">Account Settings</a>\n");
+    sb.append("          </div>\n");
+    sb.append("          <div class=\"menu-section\">\n");
+    sb.append("            <div class=\"section-label\">Plugins / Integrations</div>\n");
+    sb.append("            <a class=\"section-link-strong\" href=\"").append(base).append("account/robots\">Robot &amp; Data API</a>\n");
+    sb.append("            <a href=\"").append(base).append("api-docs\" target=\"_blank\" rel=\"noopener noreferrer\">API Docs</a>\n");
+    sb.append("          </div>\n");
+    sb.append("          <div class=\"menu-section\">\n");
+    sb.append("            <div class=\"section-label\">Product / Support</div>\n");
+    sb.append("            <a href=\"").append(base).append("changelog\" target=\"_blank\" rel=\"noopener noreferrer\">What's New</a>\n");
+    sb.append("            <a href=\"").append(base).append("contact\">Contact Us</a>\n");
+    if (isAdminOrOwner) {
+      sb.append("            <a href=\"").append(base).append("admin\">Admin</a>\n");
+    }
+    sb.append("          </div>\n");
+    sb.append("          <div class=\"menu-section\">\n");
+    sb.append("            <div class=\"section-label\">Legal</div>\n");
+    sb.append("            <a href=\"").append(base).append("terms\" target=\"_blank\" rel=\"noopener noreferrer\">Terms of Service</a>\n");
+    sb.append("            <a href=\"").append(base).append("privacy\" target=\"_blank\" rel=\"noopener noreferrer\">Privacy Policy</a>\n");
+    sb.append("          </div>\n");
+    sb.append("          <div class=\"menu-section\">\n");
+    sb.append("            <a class=\"menu-signout\" href=\"").append(safeSignOutHref).append("\">Sign Out</a>\n");
+    sb.append("          </div>\n");
+    sb.append("        </div>\n");
   }
 
   private static void appendLocaleOption(
@@ -4946,6 +5009,7 @@ public final class HtmlRenderer {
     // rewritten by the return-target bootstrap.
     sb.append("  var targetText=document.getElementById('j2cl-root-return-target-text');\n");
     sb.append("  if(targetText){targetText.className='j2cl-status-live-text';targetText.textContent='Return target: ' + target;}\n");
+    sb.append("  document.querySelectorAll('wavy-header[return-target]').forEach(function(header){header.setAttribute('return-target', target);});\n");
     sb.append("  document.querySelectorAll('[data-j2cl-root-signin]').forEach(function(anchor){anchor.href='/auth/signin?r=' + encoded;});\n");
     sb.append("  document.querySelectorAll('[data-j2cl-root-signout]').forEach(function(anchor){anchor.href='/auth/signout?r=' + encoded;});\n");
     sb.append("}\n");

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
@@ -726,6 +726,27 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
         html.contains("locale=\"zh-TW\""));
   }
 
+  public void testUserMenuLinksGetTrailingSlashWhenBasePathLacksOne() {
+    JSONObject session = new JSONObject();
+    session.put("address", "alice@example.com");
+    session.put("role", "user");
+
+    // Return target whose path component has no trailing slash (e.g. "/app?view=j2cl-root").
+    // resolvedBasePath becomes "/app"; without the fix the menu href would be "/appauth/signout".
+    String html = HtmlRenderer.renderJ2clRootShellPage(
+        session, "", "commit", 0L, "rel", "/app?view=j2cl-root", "ws.example:443");
+
+    assertTrue(
+        "user menu signout must use /app/ prefix, not /app concatenated directly",
+        html.contains("href=\"/app/auth/signout?r="));
+    assertTrue(
+        "user menu account link must use /app/ prefix",
+        html.contains("href=\"/app/userprofile/edit\""));
+    assertFalse(
+        "user menu must not produce /appauth/signout from a base path without trailing slash",
+        html.contains("href=\"/appauth/signout"));
+  }
+
   public void testWavyHeaderLocaleResolvesExtensionSuffixedTag() {
     JSONObject session = new JSONObject();
     session.put("address", "alice@example.com");

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
@@ -84,6 +84,28 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
         "compact wavy-header must SSR a netstatus chip",
         html.contains("class=\"netstatus\""));
     assertTrue(
+        "compact wavy-header must SSR the GWT-style user menu toggle",
+        html.contains("id=\"wavyHeaderUserMenuToggle\""));
+    assertTrue(
+        "compact wavy-header must SSR aria-expanded for the user menu",
+        html.contains("aria-expanded=\"false\" aria-controls=\"wavyHeaderUserMenu\""));
+    assertTrue(
+        "compact wavy-header must SSR the user menu dropdown",
+        html.contains("class=\"user-menu-dropdown\" id=\"wavyHeaderUserMenu\""));
+    assertTrue(
+        "compact wavy-header user menu must include account links",
+        html.contains("href=\"/userprofile/edit\"")
+            && html.contains("href=\"/account/settings\""));
+    assertTrue(
+        "admin users must see the Admin menu item",
+        html.contains("href=\"/admin\""));
+    assertTrue(
+        "compact wavy-header user menu must preserve the J2CL return target on sign out",
+        html.contains("href=\"/auth/signout?r=/%3Fview%3Dj2cl-root\""));
+    assertTrue(
+        "J2CL route sync must update wavy-header return-target for the dropdown signout link",
+        html.contains("document.querySelectorAll('wavy-header[return-target]').forEach(function(header){header.setAttribute('return-target', target);});"));
+    assertTrue(
         "signed-in J2CL brand must hop to the GWT-style landing target",
         html.contains("id=\"j2cl-root-brand-link\" href=\"/?view=landing\""));
     assertTrue(
@@ -117,6 +139,25 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
         html.contains("<ul class=\"folders\""));
     assertFalse(html.contains("j2cl-brand-eyebrow"));
     assertFalse(html.contains("J2CL ·"));
+  }
+
+  public void testSignedInTopHeaderSignOutEncodesRawReturnTargetBeforeHtmlEscaping() {
+    JSONObject session = new JSONObject();
+    session.put("address", "alice@example.com");
+    session.put("role", "user");
+
+    String html = HtmlRenderer.renderJ2clRootShellPage(
+        session, "", "commit", 0L, "rel", "/?view=j2cl-root&q=in:inbox", "ws.example:443");
+
+    assertTrue(
+        "signout href must preserve ampersands in the URL-encoded return target",
+        html.contains("href=\"/auth/signout?r=/%3Fview%3Dj2cl-root%26q%3Din%3Ainbox\""));
+    assertFalse(
+        "signout href must not URL-encode an HTML entity from a pre-escaped return target",
+        html.contains("%26amp%3B"));
+    assertFalse(
+        "regular users must not see the Admin menu item",
+        html.contains("href=\"/admin\""));
   }
 
   public void testSignedOutPageUsesSignedOutRoot() {


### PR DESCRIPTION
Fixes #1259

## Summary
- Restores a GWT-style account dropdown on the J2CL compact topbar user/avatar control.
- Aligns the compact J2CL user control with the GWT pill/avatar geometry.
- Adds SSR fallback markup/CSS for the same dropdown contract before Lit upgrades.
- Preserves J2CL return-target handling on Sign Out, including ampersand-bearing targets.

## Verification
- `npm test -- --runInBand test/wavy-header.test.js` from `j2cl/lit`: 25 passed.
- `sbt --batch "testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellTest"`: 33 passed.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`: passed.
- `git diff --check`: passed.
- `npm run build` from `j2cl/lit`: passed.
- `bash scripts/worktree-boot.sh --port 9919`: passed.
- `PORT=9919 ... bash scripts/wave-smoke.sh start && PORT=9919 bash scripts/wave-smoke.sh check`: passed; root/GWT/J2CL/health/webclient probes all 200 or expected optional J2CL asset 404.
- Browser Playwright signed-in J2CL root on port 9919 with built Lit assets staged: `wavy-header` upgraded, dropdown hidden before click, avatar radius 20px, avatar width 28px, click opens dropdown, Sign Out link present with `/%3Fview%3Dj2cl-root`, Escape closes and restores focus.

## Review
- External review round 1 found SSR return-target double-encoding; fixed.
- External review round 2 found no blockers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * User menu dropdown now available on J2CL root topbar compact avatar—click to reveal account, profile, support, and sign-out options.
  * Admin link conditionally displayed for administrators.
  * Dropdown closes via outside-click or Escape key.

* **Bug Fixes**
  * User menu dropdown restored and styled to match compact topbar behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->