### PR TITLE
Make J2CL reply continuation indicator compact

### DIFF
--- a/docs/superpowers/plans/2026-05-18-issue-1262-j2cl-reply-badge-compact.md
+++ b/docs/superpowers/plans/2026-05-18-issue-1262-j2cl-reply-badge-compact.md
@@ -1,0 +1,19 @@
+Plan for issue #1262
+
+Root cause:
+- J2CL renders the same-level reply continuation affordance in wave-blip as a normal-flow `.continuation-row` below every blip.
+- The row is opacity/visibility hidden, but it still has margins and the button's intrinsic height, so compact blip stacks always reserve extra vertical space.
+- GWT's `ContinuationIndicator` renders only an icon/bar affordance whose children are absolutely positioned and whose disabled state can be `display:none`; it is not a persistent text badge row in normal flow.
+
+Implementation plan:
+1. Keep the J2CL continuation request event and composer routing unchanged.
+2. Restyle `.continuation-row` to have zero normal-flow height and position the trigger absolutely near the bottom of the blip body.
+3. Restyle the trigger as a compact GWT-like icon/bar control and remove the visible text label while preserving the aria label and title.
+4. Add focused Lit coverage that the continuation host has no layout height, exposes an icon-only affordance, and still emits `wave-blip-continuation-requested`.
+5. Add a changelog fragment, run the focused Lit test/build checks, then PR and monitor.
+
+Self-review checkpoints:
+- Do not alter toolbar Reply behavior; it still creates an inline/nested reply.
+- Do not change the continuation event name or detail payload.
+- Preserve focus/hover reveal semantics and screen-reader naming.
+- Keep the patch scoped to J2CL read-surface chrome.

--- a/docs/superpowers/plans/2026-05-18-issue-1262-j2cl-reply-badge-compact.md
+++ b/docs/superpowers/plans/2026-05-18-issue-1262-j2cl-reply-badge-compact.md
@@ -1,18 +1,18 @@
-Plan for issue #1262
+# Issue #1262 — J2CL reply continuation indicator compact
 
-Root cause:
+## Root cause
 - J2CL renders the same-level reply continuation affordance in wave-blip as a normal-flow `.continuation-row` below every blip.
 - The row is opacity/visibility hidden, but it still has margins and the button's intrinsic height, so compact blip stacks always reserve extra vertical space.
 - GWT's `ContinuationIndicator` renders only an icon/bar affordance whose children are absolutely positioned and whose disabled state can be `display:none`; it is not a persistent text badge row in normal flow.
 
-Implementation plan:
+## Implementation plan
 1. Keep the J2CL continuation request event and composer routing unchanged.
 2. Restyle `.continuation-row` to have zero normal-flow height and position the trigger absolutely near the bottom of the blip body.
 3. Restyle the trigger as a compact GWT-like icon/bar control and remove the visible text label while preserving the aria label and title.
 4. Add focused Lit coverage that the continuation host has no layout height, exposes an icon-only affordance, and still emits `wave-blip-continuation-requested`.
 5. Add a changelog fragment, run the focused Lit test/build checks, then PR and monitor.
 
-Self-review checkpoints:
+## Self-review checkpoints
 - Do not alter toolbar Reply behavior; it still creates an inline/nested reply.
 - Do not change the continuation event name or detail payload.
 - Preserve focus/hover reveal semantics and screen-reader naming.

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -338,11 +338,14 @@ export class WaveBlip extends LitElement {
     /* GWT parity: a per-blip continuation indicator below the blip body
      * that reveals on hover or focus. Click creates a sibling reply at
      * the same thread level (continuation), distinct from the toolbar
-     * reply icon which creates an inline (nested) reply. Mirrors GWT's
-     * ContinuationIndicator { opacity: 0; } + :hover { opacity: 1.0; }. */
+     * reply icon which creates an inline (nested) reply. GWT's
+     * ContinuationIndicator is an icon/bar affordance that does not
+     * reserve a text badge row in normal layout. */
     .continuation-row {
-      display: flex;
-      margin: 4px 0 2px 3.35em;
+      position: relative;
+      z-index: 3;
+      height: 0;
+      margin: 0 0 0 3.35em;
       opacity: 0;
       pointer-events: none;
       visibility: hidden;
@@ -364,26 +367,32 @@ export class WaveBlip extends LitElement {
     .continuation-trigger {
       display: inline-flex;
       align-items: center;
-      gap: 4px;
-      padding: 3px 10px;
+      justify-content: center;
+      position: absolute;
+      left: 13px;
+      top: -15px;
+      width: 46px;
+      height: 23px;
+      padding: 0;
+      box-sizing: border-box;
       font: var(--wavy-type-meta, 11px / 1.4 Arial, sans-serif);
-      color: #4a5568;
-      background: transparent;
-      border: 1px dashed #cbd5e0;
-      border-radius: var(--wavy-radius-sm, 4px);
+      color: #0077b6;
+      background: #f0f4f8;
+      border: 1.5px solid #0077b6;
+      border-radius: 6px;
       cursor: pointer;
+      opacity: 0.85;
     }
     .continuation-trigger:hover {
-      background: #f0f4f8;
-      border-color: #90cdf4;
-      color: #2b6cb0;
+      background: #e6f3fb;
+      opacity: 1;
     }
     .continuation-trigger:focus-visible {
       outline: none;
       box-shadow: var(--wavy-focus-ring, 0 0 0 2px rgba(0, 119, 182, 0.16));
     }
     .continuation-trigger .glyph {
-      font-size: 12px;
+      font-size: 14px;
       line-height: 1;
     }
   `;
@@ -1016,7 +1025,6 @@ export class WaveBlip extends LitElement {
           @click=${this._onContinuationClick}
         >
           <span class="glyph" aria-hidden="true">↩</span>
-          <span class="label">${t("blip.reply", "Reply")}</span>
         </button>
       </div>
     `;

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -369,9 +369,9 @@ export class WaveBlip extends LitElement {
       align-items: center;
       justify-content: center;
       position: absolute;
-      left: 13px;
+      left: -44px;
       top: -23px;
-      width: 46px;
+      width: 32px;
       height: 23px;
       padding: 0;
       box-sizing: border-box;

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -370,15 +370,15 @@ export class WaveBlip extends LitElement {
       justify-content: center;
       position: absolute;
       left: 13px;
-      top: -15px;
+      top: -23px;
       width: 46px;
       height: 23px;
       padding: 0;
       box-sizing: border-box;
       font: var(--wavy-type-meta, 11px / 1.4 Arial, sans-serif);
-      color: #0077b6;
+      color: var(--wavy-signal-cyan, #0077b6);
       background: #f0f4f8;
-      border: 1.5px solid #0077b6;
+      border: 1.5px solid var(--wavy-signal-cyan, #0077b6);
       border-radius: 6px;
       cursor: pointer;
       opacity: 0.85;

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -346,6 +346,9 @@ describe("<wave-blip>", () => {
     expect(rowStyle.marginTop).to.equal("0px");
     expect(rowStyle.marginBottom).to.equal("0px");
     expect(button).to.exist;
+    expect(button.getBoundingClientRect().right).to.be.at.most(
+      el.renderRoot.querySelector(".body").getBoundingClientRect().left
+    );
     expect(button.getAttribute("aria-label")).to.equal(
       "Reply on the same level as this blip"
     );

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -339,11 +339,17 @@ describe("<wave-blip>", () => {
       <wave-blip data-blip-id="b4" data-wave-id="w4" author-name="A"></wave-blip>
     `);
     await el.updateComplete;
+    const host = el.renderRoot.querySelector("[data-blip-continuation-host]");
     const button = el.renderRoot.querySelector("[data-blip-continuation-trigger]");
+    const rowStyle = getComputedStyle(host);
+    expect(host.getBoundingClientRect().height).to.equal(0);
+    expect(rowStyle.marginTop).to.equal("0px");
+    expect(rowStyle.marginBottom).to.equal("0px");
     expect(button).to.exist;
     expect(button.getAttribute("aria-label")).to.equal(
       "Reply on the same level as this blip"
     );
+    expect(button.querySelector(".label")).to.not.exist;
     setTimeout(() => button.click(), 0);
     const ev = await oneEvent(el, "wave-blip-continuation-requested");
     expect(ev.detail).to.deep.equal({ blipId: "b4", waveId: "w4" });

--- a/wave/config/changelog.d/2026-05-18-issue-1262-j2cl-reply-badge-compact.json
+++ b/wave/config/changelog.d/2026-05-18-issue-1262-j2cl-reply-badge-compact.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-18-issue-1262-j2cl-reply-badge-compact",
+  "version": "J2CL parity",
+  "date": "2026-05-18",
+  "title": "J2CL blip reply continuation control is compact like GWT.",
+  "summary": "The J2CL same-level reply control no longer reserves a full text badge row below every blip, allowing compact blip stacks while preserving the hover/focus reply affordance.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Changed the J2CL below-blip continuation reply affordance to a zero-footprint GWT-style icon/bar.",
+        "Preserved the same-level reply click behavior while removing the always-reserved vertical gap between blips."
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.d/2026-05-18-issue-1262-j2cl-reply-badge-compact.json
+++ b/wave/config/changelog.d/2026-05-18-issue-1262-j2cl-reply-badge-compact.json
@@ -2,7 +2,7 @@
   "releaseId": "2026-05-18-issue-1262-j2cl-reply-badge-compact",
   "version": "J2CL parity",
   "date": "2026-05-18",
-  "title": "J2CL blip reply continuation control is compact like GWT.",
+  "title": "J2CL blip reply continuation control is compact like GWT",
   "summary": "The J2CL same-level reply control no longer reserves a full text badge row below every blip, allowing compact blip stacks while preserving the hover/focus reply affordance.",
   "sections": [
     {


### PR DESCRIPTION
## Summary
- restyle the J2CL below-blip same-level reply continuation affordance as a zero-footprint GWT-style icon/bar
- remove the normal-flow text badge row while preserving the aria label/title and continuation event payload
- add focused Lit coverage for the compact layout footprint

Fixes #1262

## Verification
- git diff --check
- cd j2cl/lit && npm test -- --files test/wave-blip.test.js
- cd j2cl/lit && npm run build
- scripts/assemble-changelog.py
- python3 scripts/validate-changelog.py --changelog wave/config/changelog.json

Note: scripts/validate-changelog.py is not executable in this checkout, so validation was run through python3.