### PR TITLE
Fix J2CL search filter placement

### DIFF
--- a/j2cl/lit/src/elements/wavy-search-rail.js
+++ b/j2cl/lit/src/elements/wavy-search-rail.js
@@ -24,7 +24,7 @@ import {
  *   - panel-level action row matching the GWT toolbar:
  *     [New Wave] [Manage saved searches] [Inbox] [Mentions]
  *     [Tasks] [Public] [Archive] [Pinned] [Refresh]
- *   - Filter-chip strip below results for explicit advanced filtering
+ *   - Filter-chip strip above results for explicit advanced filtering
  *   - Result count
  *   - Slot for <wavy-search-rail-card> digest cards
  *
@@ -982,7 +982,6 @@ export class WavySearchRail extends LitElement {
             </ul>
           `
         : null}
-      <slot name="cards"></slot>
       <details
         class="filters"
         id="wavy-search-filter-strip"
@@ -1015,6 +1014,7 @@ export class WavySearchRail extends LitElement {
         </div>
       </details>
       <p class="result-count" aria-live="polite">${this.resultCount || ""}</p>
+      <slot name="cards"></slot>
       ${this.savedSearchesOpen ? this._renderSavedSearchesDialog() : null}
     `;
   }

--- a/j2cl/lit/test/wavy-search-rail.test.js
+++ b/j2cl/lit/test/wavy-search-rail.test.js
@@ -42,6 +42,17 @@ describe("<wavy-search-rail>", () => {
     expect(labels).to.deep.equal(["Inbox", "Mentions", "Tasks", "Public", "Archive", "Pinned"]);
   });
 
+  it("renders filter chips above result cards to match the GWT search panel controls", async () => {
+    const el = await fixture(html`<wavy-search-rail result-count="5 waves"></wavy-search-rail>`);
+    await el.updateComplete;
+    const children = Array.from(el.renderRoot.children);
+    const filterIndex = children.indexOf(el.renderRoot.querySelector("[data-j2cl-filter-strip]"));
+    const cardsIndex = children.indexOf(el.renderRoot.querySelector('slot[name="cards"]'));
+    expect(filterIndex).to.be.greaterThan(-1);
+    expect(cardsIndex).to.be.greaterThan(-1);
+    expect(filterIndex).to.be.lessThan(cardsIndex);
+  });
+
   it("Enter in the query box emits wavy-search-submit (B.1)", async () => {
     const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
     await el.updateComplete;
@@ -1118,7 +1129,7 @@ describe("<wavy-search-rail>", () => {
       expect(assigned.map((n) => n.dataset.waveId)).to.deep.equal(["w+a", "w+b"]);
     });
 
-    it("preserves compact toolbar above the cards slot and filter strip below it", async () => {
+    it("preserves compact toolbar and filter strip above the cards slot", async () => {
       const el = await fixture(html`<wavy-search-rail></wavy-search-rail>`);
       await el.updateComplete;
       const toolbar = el.renderRoot.querySelector("[data-digest-action-row]");
@@ -1127,9 +1138,10 @@ describe("<wavy-search-rail>", () => {
       expect(toolbar, "toolbar mounts").to.exist;
       expect(slot, "cards slot mounts").to.exist;
       expect(filters, "filter strip mounts").to.exist;
-      // Document order: toolbar, then cards slot, then filter strip.
+      // Document order: toolbar, then filter strip, then cards slot.
       expect(toolbar.compareDocumentPosition(slot) & Node.DOCUMENT_POSITION_FOLLOWING).to.be.greaterThan(0);
-      expect(slot.compareDocumentPosition(filters) & Node.DOCUMENT_POSITION_FOLLOWING).to.be.greaterThan(0);
+      expect(toolbar.compareDocumentPosition(filters) & Node.DOCUMENT_POSITION_FOLLOWING).to.be.greaterThan(0);
+      expect(filters.compareDocumentPosition(slot) & Node.DOCUMENT_POSITION_FOLLOWING).to.be.greaterThan(0);
     });
   });
 });

--- a/wave/config/changelog.d/2026-05-18-j2cl-search-filters-top.json
+++ b/wave/config/changelog.d/2026-05-18-j2cl-search-filters-top.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-18-j2cl-search-filters-top",
+  "version": "J2CL parity",
+  "date": "2026-05-18",
+  "title": "J2CL search filters align with the GWT panel",
+  "summary": "Moves the J2CL search filter chips above the result list so the search panel controls match the GWT layout.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "J2CL search filter chips now render with the upper search controls instead of below the wave results."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Moves the J2CL search filter strip above the result cards so it aligns with the GWT search panel controls.
- Keeps the result count and cards below the filter controls.
- Adds Lit regression coverage for filter-before-card DOM order.
- Adds a changelog fragment.

Fixes #1264

## Verification
- RED: npm test -- --files test/wavy-search-rail.test.js failed before the fix with filter index 4 below cards index 3.
- npm test -- --files test/wavy-search-rail.test.js: 62 passed, 0 failed.
- npm run build: passed.
- python3 scripts/assemble-changelog.py: passed.
- python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json: passed.
- npm test: 882 passed, 0 failed.
- git diff --check: passed.
- Browser sanity: local rail page showed Filters at y=101, filter chips at y=121, result count at y=159, and first card at y=184.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The search filter strip has been repositioned to appear above the results list instead of below. This layout change improves the search experience by presenting filter options prominently and accessibly before the result cards, enabling users to easily adjust filters and browse results more intuitively across the search interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->