### PR TITLE
Allow GPT bot to use attachment context

### DIFF
--- a/docs/superpowers/plans/2026-05-18-gptbot-attachment-transcription.md
+++ b/docs/superpowers/plans/2026-05-18-gptbot-attachment-transcription.md
@@ -1,0 +1,75 @@
+# GptBot Attachment Transcription Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the SupaWave GPT bot use attached files as prompt context, including OpenAI transcription for supported audio and video attachments.
+
+**Architecture:** Keep attachment handling in the existing `org.waveprotocol.examples.robots.gptbot` robot lane. `GptBotRobot` extracts attachment/image elements from the triggering blip, `SupaWaveApiClient` exports attachment bytes through `robot.exportAttachment`, and `GptBotReplyPlanner` appends bounded attachment context to the user prompt. `OpenAiCodexClient` transcribes supported audio/video files through `/audio/transcriptions`; small textual attachments are converted to markdown-like fenced context, while unsupported binaries are represented by metadata only.
+
+**Tech Stack:** Java 11 HTTP client, existing Wave Robot JSON-RPC/Data API, OpenAI Chat Completions, OpenAI Audio Transcriptions, JUnit 3 style SBT tests.
+
+---
+
+### Task 1: Add Attachment Data Contracts
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/examples/robots/gptbot/CodexClient.java`
+- Modify: `wave/src/main/java/org/waveprotocol/examples/robots/gptbot/SupaWaveClient.java`
+- Create: `wave/src/main/java/org/waveprotocol/examples/robots/gptbot/BotAttachmentContext.java`
+
+- [ ] Add a `CodexClient.transcribeAttachment(String fileName, String mimeType, byte[] data)` default method returning `Optional.empty()`.
+- [ ] Add a `SupaWaveClient.exportAttachment(String attachmentId, String rpcServerUrl)` method returning `Optional<BotAttachmentContext.RawAttachment>`.
+- [ ] Define immutable `BotAttachmentContext` and nested `RawAttachment` value types with bounded text rendering helpers.
+
+### Task 2: Test Attachment Context Flow
+
+**Files:**
+- Modify: `wave/src/test/java/org/waveprotocol/examples/robots/gptbot/GptBotRobotTest.java`
+- Modify: `wave/src/test/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClientTest.java`
+- Modify: `wave/src/test/java/org/waveprotocol/examples/robots/gptbot/OpenAiCodexClientTest.java`
+
+- [ ] Add a failing robot test where a blip contains an attachment element with `mimeType=audio/mpeg`; assert the bot exports the attachment, calls transcription, and includes the transcript in the prompt sent to the model.
+- [ ] Add a failing robot test where a blip contains a text attachment; assert exported bytes are included as fenced attachment context without transcription.
+- [ ] Add a failing SupaWave API client test that verifies `robot.exportAttachment` is posted to the supplied trusted RPC endpoint and parsed from `attachmentData`.
+- [ ] Add a failing OpenAI client test that verifies transcription uses multipart form upload against `/audio/transcriptions` with the configured transcription model.
+
+### Task 3: Implement Export And Transcription
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClient.java`
+- Modify: `wave/src/main/java/org/waveprotocol/examples/robots/gptbot/OpenAiCodexClient.java`
+
+- [ ] Implement `SupaWaveApiClient.exportAttachment` with `robot.exportAttachment`, trusted endpoint resolution, token selection, error handling, and decoded `attachmentData` parsing.
+- [ ] Implement `OpenAiCodexClient.transcribeAttachment` with `multipart/form-data`, `model`, `response_format=json`, file part metadata, OpenAI error logging, and JSON `text` parsing.
+- [ ] Use `GPTBOT_OPENAI_TRANSCRIPTION_MODEL`, defaulting to `gpt-4o-mini-transcribe`.
+
+### Task 4: Wire Attachment Context Into Replies
+
+**Files:**
+- Modify: `wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotRobot.java`
+- Modify: `wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotReplyPlanner.java`
+- Modify: `wave/src/main/java/org/waveprotocol/examples/robots/gptbot/SupaWaveClient.java`
+
+- [ ] Extract attachment IDs, captions, mime types, and display names from `ATTACHMENT` and attachment-backed `IMAGE` elements on the triggering blip.
+- [ ] Export each referenced attachment through `SupaWaveClient`.
+- [ ] For supported audio/video attachments, request `CodexClient.transcribeAttachment` and attach the transcript to the prompt context.
+- [ ] For text/markdown/json/csv attachments, decode UTF-8 text and include a bounded markdown fenced block.
+- [ ] For unsupported or oversized attachments, include metadata and a clear skipped reason.
+
+### Task 5: Verification And PR
+
+**Files:**
+- Create: `wave/config/changelog.d/2026-05-18-gptbot-attachment-transcription.json`
+- Create: `journal/local-verification/2026-05-18-gptbot-attachment-transcription.md`
+
+- [ ] Add a changelog fragment for the user-visible bot behavior change.
+- [ ] Run focused tests: `sbt "wave/testOnly org.waveprotocol.examples.robots.gptbot.GptBotRobotTest org.waveprotocol.examples.robots.gptbot.SupaWaveApiClientTest org.waveprotocol.examples.robots.gptbot.OpenAiCodexClientTest"`.
+- [ ] Run `git diff --check`.
+- [ ] Record worktree, branch, plan path, commit SHA, and verification in the GitHub issue and journal.
+- [ ] Commit, push, open a PR, monitor checks/review threads, address feedback, and merge when gates allow.
+
+### Self-Review
+
+- Spec coverage: attachments are exported, text files are converted to markdown-like context, audio/video use OpenAI transcription, and attachment context reaches reply generation.
+- Scope control: no Telegram-specific server is invented because this repo surface is the existing GPT bot; the implementation extends the robot path already used for OpenAI.
+- Risk checks: bounded attachment text avoids unbounded prompts; unsupported binaries are metadata-only; OpenAI transcription failure does not prevent normal text prompt replies.

--- a/docs/superpowers/plans/2026-05-18-gptbot-attachment-transcription.md
+++ b/docs/superpowers/plans/2026-05-18-gptbot-attachment-transcription.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Add Attachment Data Contracts
+## Task 1: Add Attachment Data Contracts
 
 **Files:**
 - Modify: `wave/src/main/java/org/waveprotocol/examples/robots/gptbot/CodexClient.java`
@@ -21,7 +21,7 @@
 - [ ] Add a `SupaWaveClient.exportAttachment(String attachmentId, String rpcServerUrl)` method returning `Optional<BotAttachmentContext.RawAttachment>`.
 - [ ] Define immutable `BotAttachmentContext` and nested `RawAttachment` value types with bounded text rendering helpers.
 
-### Task 2: Test Attachment Context Flow
+## Task 2: Test Attachment Context Flow
 
 **Files:**
 - Modify: `wave/src/test/java/org/waveprotocol/examples/robots/gptbot/GptBotRobotTest.java`
@@ -33,7 +33,7 @@
 - [ ] Add a failing SupaWave API client test that verifies `robot.exportAttachment` is posted to the supplied trusted RPC endpoint and parsed from `attachmentData`.
 - [ ] Add a failing OpenAI client test that verifies transcription uses multipart form upload against `/audio/transcriptions` with the configured transcription model.
 
-### Task 3: Implement Export And Transcription
+## Task 3: Implement Export And Transcription
 
 **Files:**
 - Modify: `wave/src/main/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClient.java`
@@ -43,7 +43,7 @@
 - [ ] Implement `OpenAiCodexClient.transcribeAttachment` with `multipart/form-data`, `model`, `response_format=json`, file part metadata, OpenAI error logging, and JSON `text` parsing.
 - [ ] Use `GPTBOT_OPENAI_TRANSCRIPTION_MODEL`, defaulting to `gpt-4o-mini-transcribe`.
 
-### Task 4: Wire Attachment Context Into Replies
+## Task 4: Wire Attachment Context Into Replies
 
 **Files:**
 - Modify: `wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotRobot.java`
@@ -56,7 +56,7 @@
 - [ ] For text/markdown/json/csv attachments, decode UTF-8 text and include a bounded markdown fenced block.
 - [ ] For unsupported or oversized attachments, include metadata and a clear skipped reason.
 
-### Task 5: Verification And PR
+## Task 5: Verification And PR
 
 **Files:**
 - Create: `wave/config/changelog.d/2026-05-18-gptbot-attachment-transcription.json`
@@ -68,7 +68,7 @@
 - [ ] Record worktree, branch, plan path, commit SHA, and verification in the GitHub issue and journal.
 - [ ] Commit, push, open a PR, monitor checks/review threads, address feedback, and merge when gates allow.
 
-### Self-Review
+## Self-Review
 
 - Spec coverage: attachments are exported, text files are converted to markdown-like context, audio/video use OpenAI transcription, and attachment context reaches reply generation.
 - Scope control: no Telegram-specific server is invented because this repo surface is the existing GPT bot; the implementation extends the robot path already used for OpenAI.

--- a/journal/local-verification/2026-05-18-issue-1266-gptbot-attachment-transcription.md
+++ b/journal/local-verification/2026-05-18-issue-1266-gptbot-attachment-transcription.md
@@ -1,0 +1,24 @@
+# Issue 1266 GPT Bot Attachment Transcription
+
+- Worktree: `/Users/vega/devroot/worktrees/codex/telegram-bot-attachments-openai`
+- Branch: `codex/telegram-bot-attachments-openai`
+- Plan: `docs/superpowers/plans/2026-05-18-gptbot-attachment-transcription.md`
+- Issue: https://github.com/vega113/supawave/issues/1266
+
+## Verification
+
+- `python3 scripts/assemble-changelog.py`
+  - Result: `assembled 381 entries -> wave/config/changelog.json`
+- `python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`
+  - Result: `changelog validation passed`
+- `git diff --check`
+  - Result: exit 0
+- `sbt "wave/testOnly org.waveprotocol.examples.robots.gptbot.GptBotRobotTest org.waveprotocol.examples.robots.gptbot.SupaWaveApiClientTest org.waveprotocol.examples.robots.gptbot.OpenAiCodexClientTest"`
+  - Result: `Passed: Total 34, Failed 0, Errors 0, Passed 34`
+
+## Self-Review
+
+- Attachment context is limited to the triggering blip, so the bot does not scan unrelated wave history for files.
+- Text-like attachment content is bounded before entering the model prompt.
+- Audio/video transcription uses the OpenAI audio transcription endpoint and skips files larger than 25 MB.
+- Failed attachment export or transcription degrades to normal bot handling instead of blocking replies.

--- a/wave/config/changelog.d/2026-05-18-gptbot-attachment-transcription.json
+++ b/wave/config/changelog.d/2026-05-18-gptbot-attachment-transcription.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-18-gptbot-attachment-transcription",
+  "version": "Upcoming",
+  "date": "2026-05-18",
+  "title": "GPT Bot Attachment Understanding",
+  "summary": "GPT bot replies can now use Wave attachments as context, including OpenAI transcription for supported audio and video files.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "The GPT bot exports attached files from the triggering blip and includes bounded text attachment content in its prompt context",
+        "Supported audio and video attachments are transcribed through OpenAI before the bot answers"
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/com/google/wave/api/JsonRpcConstant.java
+++ b/wave/src/main/java/com/google/wave/api/JsonRpcConstant.java
@@ -147,7 +147,8 @@ public class JsonRpcConstant {
     RAW_DELTAS("rawDeltas", List.class),
     TARGET_VERSION("targetVersion", byte[].class),
     ATTACHMENT_DATA("attachmentData", RawAttachmentData.class),
-    IMPORTED_FROM_VERSION("importedFromVersion", Long.class);
+    IMPORTED_FROM_VERSION("importedFromVersion", Long.class),
+    MAX_SIZE_BYTES("maxSizeBytes", Long.class);
 
     private static final Logger LOG = Logger.getLogger(ParamsProperty.class.getName());
 

--- a/wave/src/main/java/org/waveprotocol/box/server/robots/operations/ExportAttachmentService.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/robots/operations/ExportAttachmentService.java
@@ -48,8 +48,6 @@ import java.util.Map;
  */
 public class ExportAttachmentService implements OperationService {
   private static final Log LOG = Log.get(ExportAttachmentService.class);
-  // Attachment export size limit — matches the client-side MAX_TRANSCRIPTION_BYTES (25 MB).
-  private static final long MAX_EXPORT_BYTES = 25L * 1024 * 1024;
 
   private final AttachmentService attachmentService;
 
@@ -68,11 +66,13 @@ public class ExportAttachmentService implements OperationService {
     } catch (InvalidIdException ex) {
       throw new InvalidRequestException("Invalid id", operation, ex);
     }
+    Long maxSizeBytes = OperationUtil.<Long>getOptionalParameter(operation,
+        ParamsProperty.MAX_SIZE_BYTES);
     AttachmentMetadata meta;
     byte[] data;
     try {
       meta = attachmentService.getMetadata(attachmentId);
-      if (meta.getSize() > MAX_EXPORT_BYTES) {
+      if (maxSizeBytes != null && meta.getSize() > maxSizeBytes) {
         context.constructErrorResponse(operation,
             "Attachment too large to export: " + meta.getSize() + " bytes");
         return;

--- a/wave/src/main/java/org/waveprotocol/box/server/robots/operations/ExportAttachmentService.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/robots/operations/ExportAttachmentService.java
@@ -48,6 +48,8 @@ import java.util.Map;
  */
 public class ExportAttachmentService implements OperationService {
   private static final Log LOG = Log.get(ExportAttachmentService.class);
+  // Attachment export size limit — matches the client-side MAX_TRANSCRIPTION_BYTES (25 MB).
+  private static final long MAX_EXPORT_BYTES = 25L * 1024 * 1024;
 
   private final AttachmentService attachmentService;
 
@@ -70,6 +72,11 @@ public class ExportAttachmentService implements OperationService {
     byte[] data;
     try {
       meta = attachmentService.getMetadata(attachmentId);
+      if (meta.getSize() > MAX_EXPORT_BYTES) {
+        context.constructErrorResponse(operation,
+            "Attachment too large to export: " + meta.getSize() + " bytes");
+        return;
+      }
       data = readInputStreamToBytes(attachmentService.getAttachment(attachmentId).getInputStream());
     } catch (IOException ex) {
       LOG.info("Get attachment", ex);

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/BotAttachmentContext.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/BotAttachmentContext.java
@@ -46,7 +46,7 @@ public final class BotAttachmentContext {
     this.attachmentId = clean(attachmentId);
     this.fileName = clean(fileName);
     this.mimeType = clean(mimeType);
-    this.renderedContext = clean(renderedContext);
+    this.renderedContext = clamp(clean(renderedContext));
   }
 
   public String render() {

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/BotAttachmentContext.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/BotAttachmentContext.java
@@ -85,6 +85,21 @@ public final class BotAttachmentContext {
         header + "\nSkipped: unsupported binary attachment.");
   }
 
+  /**
+   * Returns true if the attachment type is text-like or audio/video — i.e. might yield
+   * useful prompt context. Binary attachments that fail this check can be skipped before
+   * calling the export RPC to avoid loading large unsupported files on the server side.
+   */
+  public static boolean mightBeUsable(String mimeType, String fileName) {
+    String normalizedMime = mimeType == null ? "" : mimeType.trim().toLowerCase(Locale.ROOT);
+    if (normalizedMime.isEmpty()) {
+      normalizedMime = "application/octet-stream";
+    }
+    String normalizedFileName = fileName == null ? "" : fileName.trim();
+    return isTranscribable(normalizedMime, normalizedFileName)
+        || isTextLike(normalizedMime, normalizedFileName);
+  }
+
   private static boolean isTranscribable(String mimeType, String fileName) {
     String lowerName = fileName.toLowerCase(Locale.ROOT);
     return mimeType.startsWith("audio/")

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/BotAttachmentContext.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/BotAttachmentContext.java
@@ -57,12 +57,13 @@ public final class BotAttachmentContext {
     String mimeType = normalizedMime(raw.getMimeType());
     String fileName = fallback(raw.getFileName(), raw.getAttachmentId());
     String header = "Attachment: " + fileName + " (" + mimeType + ")";
+    byte[] data = raw.getData();
     if (isTranscribable(mimeType, fileName)) {
-      if (raw.getData().length > MAX_TRANSCRIPTION_BYTES) {
+      if (data.length > MAX_TRANSCRIPTION_BYTES) {
         return new BotAttachmentContext(raw.getAttachmentId(), fileName, mimeType,
             header + "\nSkipped: audio/video attachment is larger than 25 MB.");
       }
-      Optional<String> transcript = codexClient.transcribeAttachment(fileName, mimeType, raw.getData());
+      Optional<String> transcript = codexClient.transcribeAttachment(fileName, mimeType, data);
       if (transcript.isPresent() && !transcript.get().isBlank()) {
         return new BotAttachmentContext(raw.getAttachmentId(), fileName, mimeType,
             header + "\nTranscript:\n" + clamp(transcript.get().strip()));
@@ -71,7 +72,7 @@ public final class BotAttachmentContext {
           header + "\nSkipped: audio/video transcription failed.");
     }
     if (isTextLike(mimeType, fileName)) {
-      Optional<String> text = decodeText(raw.getData());
+      Optional<String> text = decodeText(data);
       if (text.isPresent()) {
         String fence = fenceLanguage(mimeType, fileName);
         return new BotAttachmentContext(raw.getAttachmentId(), fileName, mimeType,
@@ -181,10 +182,15 @@ public final class BotAttachmentContext {
     private final byte[] data;
 
     public RawAttachment(String attachmentId, String fileName, String mimeType, byte[] data) {
+      this(attachmentId, fileName, mimeType, data, true);
+    }
+
+    private RawAttachment(String attachmentId, String fileName, String mimeType, byte[] data,
+        boolean copyData) {
       this.attachmentId = clean(attachmentId);
       this.fileName = clean(fileName);
       this.mimeType = clean(mimeType);
-      this.data = data == null ? new byte[0] : data.clone();
+      this.data = data == null ? new byte[0] : (copyData ? data.clone() : data);
     }
 
     public String getAttachmentId() {
@@ -208,7 +214,7 @@ public final class BotAttachmentContext {
       String effectiveMimeType = this.mimeType.isEmpty()
           || "application/octet-stream".equals(this.mimeType)
           ? mimeType : this.mimeType;
-      return new RawAttachment(attachmentId, effectiveFileName, effectiveMimeType, data);
+      return new RawAttachment(attachmentId, effectiveFileName, effectiveMimeType, data, false);
     }
   }
 }

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/BotAttachmentContext.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/BotAttachmentContext.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 public final class BotAttachmentContext {
 
   static final int MAX_TEXT_BYTES = 64 * 1024;
+  static final int MAX_ATTACHMENT_CONTEXT_ITEMS = 5;
   static final int MAX_TRANSCRIPTION_BYTES = 25 * 1024 * 1024;
   private static final int MAX_RENDERED_CHARS = 12000;
 
@@ -112,7 +113,16 @@ public final class BotAttachmentContext {
   private static Optional<String> decodeText(byte[] data) {
     byte[] bytes = data == null ? new byte[0] : data;
     if (bytes.length > MAX_TEXT_BYTES) {
-      return Optional.of(new String(bytes, 0, MAX_TEXT_BYTES, StandardCharsets.UTF_8)
+      // Walk back to a valid UTF-8 codepoint boundary so we don't split a multi-byte sequence.
+      int safeLen = MAX_TEXT_BYTES;
+      while (safeLen > 0 && (bytes[safeLen - 1] & 0xC0) == 0x80) {
+        safeLen--;
+      }
+      // If we landed on a multi-byte start byte, its continuation bytes were cut — skip it too.
+      if (safeLen > 0 && (bytes[safeLen - 1] & 0xC0) == 0xC0) {
+        safeLen--;
+      }
+      return Optional.of(new String(bytes, 0, safeLen, StandardCharsets.UTF_8)
           + "\n[truncated after " + MAX_TEXT_BYTES + " bytes]");
     }
     CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder()

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/BotAttachmentContext.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/BotAttachmentContext.java
@@ -1,0 +1,204 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.waveprotocol.examples.robots.gptbot;
+
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Bounded text context derived from a Wave attachment for the GPT bot prompt.
+ */
+public final class BotAttachmentContext {
+
+  static final int MAX_TEXT_BYTES = 64 * 1024;
+  static final int MAX_TRANSCRIPTION_BYTES = 25 * 1024 * 1024;
+  private static final int MAX_RENDERED_CHARS = 12000;
+
+  private final String attachmentId;
+  private final String fileName;
+  private final String mimeType;
+  private final String renderedContext;
+
+  private BotAttachmentContext(String attachmentId, String fileName, String mimeType,
+      String renderedContext) {
+    this.attachmentId = clean(attachmentId);
+    this.fileName = clean(fileName);
+    this.mimeType = clean(mimeType);
+    this.renderedContext = clean(renderedContext);
+  }
+
+  public String render() {
+    return renderedContext;
+  }
+
+  static BotAttachmentContext fromRaw(RawAttachment raw, CodexClient codexClient) {
+    String mimeType = normalizedMime(raw.getMimeType());
+    String fileName = fallback(raw.getFileName(), raw.getAttachmentId());
+    String header = "Attachment: " + fileName + " (" + mimeType + ")";
+    if (isTranscribable(mimeType, fileName)) {
+      if (raw.getData().length > MAX_TRANSCRIPTION_BYTES) {
+        return new BotAttachmentContext(raw.getAttachmentId(), fileName, mimeType,
+            header + "\nSkipped: audio/video attachment is larger than 25 MB.");
+      }
+      Optional<String> transcript = codexClient.transcribeAttachment(fileName, mimeType, raw.getData());
+      if (transcript.isPresent() && !transcript.get().isBlank()) {
+        return new BotAttachmentContext(raw.getAttachmentId(), fileName, mimeType,
+            header + "\nTranscript:\n" + clamp(transcript.get().strip()));
+      }
+      return new BotAttachmentContext(raw.getAttachmentId(), fileName, mimeType,
+          header + "\nSkipped: audio/video transcription failed.");
+    }
+    if (isTextLike(mimeType, fileName)) {
+      Optional<String> text = decodeText(raw.getData());
+      if (text.isPresent()) {
+        String fence = fenceLanguage(mimeType, fileName);
+        return new BotAttachmentContext(raw.getAttachmentId(), fileName, mimeType,
+            header + "\n```" + fence + "\n" + clamp(text.get().strip()) + "\n```");
+      }
+      return new BotAttachmentContext(raw.getAttachmentId(), fileName, mimeType,
+          header + "\nSkipped: text attachment could not be decoded as UTF-8.");
+    }
+    return new BotAttachmentContext(raw.getAttachmentId(), fileName, mimeType,
+        header + "\nSkipped: unsupported binary attachment.");
+  }
+
+  private static boolean isTranscribable(String mimeType, String fileName) {
+    String lowerName = fileName.toLowerCase(Locale.ROOT);
+    return mimeType.startsWith("audio/")
+        || mimeType.startsWith("video/")
+        || lowerName.endsWith(".mp3")
+        || lowerName.endsWith(".mp4")
+        || lowerName.endsWith(".mpeg")
+        || lowerName.endsWith(".mpga")
+        || lowerName.endsWith(".m4a")
+        || lowerName.endsWith(".wav")
+        || lowerName.endsWith(".webm");
+  }
+
+  private static boolean isTextLike(String mimeType, String fileName) {
+    String lowerName = fileName.toLowerCase(Locale.ROOT);
+    return mimeType.startsWith("text/")
+        || mimeType.contains("json")
+        || mimeType.contains("xml")
+        || lowerName.endsWith(".md")
+        || lowerName.endsWith(".markdown")
+        || lowerName.endsWith(".txt")
+        || lowerName.endsWith(".json")
+        || lowerName.endsWith(".csv")
+        || lowerName.endsWith(".xml");
+  }
+
+  private static Optional<String> decodeText(byte[] data) {
+    byte[] bytes = data == null ? new byte[0] : data;
+    if (bytes.length > MAX_TEXT_BYTES) {
+      return Optional.of(new String(bytes, 0, MAX_TEXT_BYTES, StandardCharsets.UTF_8)
+          + "\n[truncated after " + MAX_TEXT_BYTES + " bytes]");
+    }
+    CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder()
+        .onMalformedInput(CodingErrorAction.REPORT)
+        .onUnmappableCharacter(CodingErrorAction.REPORT);
+    try {
+      return Optional.of(decoder.decode(java.nio.ByteBuffer.wrap(bytes)).toString());
+    } catch (CharacterCodingException e) {
+      return Optional.empty();
+    }
+  }
+
+  private static String fenceLanguage(String mimeType, String fileName) {
+    String lowerName = fileName.toLowerCase(Locale.ROOT);
+    if (mimeType.contains("markdown") || lowerName.endsWith(".md")
+        || lowerName.endsWith(".markdown")) {
+      return "markdown";
+    }
+    if (mimeType.contains("json") || lowerName.endsWith(".json")) {
+      return "json";
+    }
+    if (lowerName.endsWith(".csv")) {
+      return "csv";
+    }
+    if (mimeType.contains("xml") || lowerName.endsWith(".xml")) {
+      return "xml";
+    }
+    return "text";
+  }
+
+  private static String normalizedMime(String mimeType) {
+    String normalized = clean(mimeType).toLowerCase(Locale.ROOT);
+    return normalized.isEmpty() ? "application/octet-stream" : normalized;
+  }
+
+  private static String fallback(String value, String fallback) {
+    String cleaned = clean(value);
+    return cleaned.isEmpty() ? clean(fallback) : cleaned;
+  }
+
+  private static String clamp(String value) {
+    String text = clean(value);
+    return text.length() > MAX_RENDERED_CHARS
+        ? text.substring(0, MAX_RENDERED_CHARS).strip() + "\n[truncated]"
+        : text;
+  }
+
+  private static String clean(String value) {
+    return value == null ? "" : value.trim();
+  }
+
+  public static final class RawAttachment {
+    private final String attachmentId;
+    private final String fileName;
+    private final String mimeType;
+    private final byte[] data;
+
+    public RawAttachment(String attachmentId, String fileName, String mimeType, byte[] data) {
+      this.attachmentId = clean(attachmentId);
+      this.fileName = clean(fileName);
+      this.mimeType = clean(mimeType);
+      this.data = data == null ? new byte[0] : data.clone();
+    }
+
+    public String getAttachmentId() {
+      return attachmentId;
+    }
+
+    public String getFileName() {
+      return fileName;
+    }
+
+    public String getMimeType() {
+      return mimeType;
+    }
+
+    public byte[] getData() {
+      return data.clone();
+    }
+
+    RawAttachment withFallbackMetadata(String fileName, String mimeType) {
+      String effectiveFileName = this.fileName.isEmpty() ? fileName : this.fileName;
+      String effectiveMimeType = this.mimeType.isEmpty()
+          || "application/octet-stream".equals(this.mimeType)
+          ? mimeType : this.mimeType;
+      return new RawAttachment(attachmentId, effectiveFileName, effectiveMimeType, data);
+    }
+  }
+}

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/BotAttachmentContext.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/BotAttachmentContext.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 public final class BotAttachmentContext {
 
   static final int MAX_TEXT_BYTES = 64 * 1024;
+  static final int MAX_ATTACHMENT_CONTEXT_ITEMS = 5;
   static final int MAX_TRANSCRIPTION_BYTES = 25 * 1024 * 1024;
   private static final int MAX_RENDERED_CHARS = 12000;
 

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/BotAttachmentContext.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/BotAttachmentContext.java
@@ -32,7 +32,6 @@ import java.util.Optional;
 public final class BotAttachmentContext {
 
   static final int MAX_TEXT_BYTES = 64 * 1024;
-  static final int MAX_ATTACHMENT_CONTEXT_ITEMS = 5;
   static final int MAX_TRANSCRIPTION_BYTES = 25 * 1024 * 1024;
   private static final int MAX_RENDERED_CHARS = 12000;
 
@@ -113,23 +112,26 @@ public final class BotAttachmentContext {
   private static Optional<String> decodeText(byte[] data) {
     byte[] bytes = data == null ? new byte[0] : data;
     if (bytes.length > MAX_TEXT_BYTES) {
-      // Walk back to a valid UTF-8 codepoint boundary so we don't split a multi-byte sequence.
-      int safeLen = MAX_TEXT_BYTES;
-      while (safeLen > 0 && (bytes[safeLen - 1] & 0xC0) == 0x80) {
-        safeLen--;
+      // Back off up to 3 bytes from the cut to avoid slicing a multi-byte UTF-8 sequence.
+      // Binary data mislabeled as text will fail all attempts and return empty.
+      for (int cutAt = MAX_TEXT_BYTES; cutAt >= MAX_TEXT_BYTES - 3 && cutAt >= 0; cutAt--) {
+        try {
+          String text = StandardCharsets.UTF_8.newDecoder()
+              .onMalformedInput(CodingErrorAction.REPORT)
+              .onUnmappableCharacter(CodingErrorAction.REPORT)
+              .decode(java.nio.ByteBuffer.wrap(bytes, 0, cutAt)).toString();
+          return Optional.of(text + "\n[truncated after " + MAX_TEXT_BYTES + " bytes]");
+        } catch (CharacterCodingException e) {
+          // try one byte shorter
+        }
       }
-      // If we landed on a multi-byte start byte, its continuation bytes were cut — skip it too.
-      if (safeLen > 0 && (bytes[safeLen - 1] & 0xC0) == 0xC0) {
-        safeLen--;
-      }
-      return Optional.of(new String(bytes, 0, safeLen, StandardCharsets.UTF_8)
-          + "\n[truncated after " + MAX_TEXT_BYTES + " bytes]");
+      return Optional.empty();
     }
-    CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder()
-        .onMalformedInput(CodingErrorAction.REPORT)
-        .onUnmappableCharacter(CodingErrorAction.REPORT);
     try {
-      return Optional.of(decoder.decode(java.nio.ByteBuffer.wrap(bytes)).toString());
+      return Optional.of(StandardCharsets.UTF_8.newDecoder()
+          .onMalformedInput(CodingErrorAction.REPORT)
+          .onUnmappableCharacter(CodingErrorAction.REPORT)
+          .decode(java.nio.ByteBuffer.wrap(bytes)).toString());
     } catch (CharacterCodingException e) {
       return Optional.empty();
     }

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/CodexClient.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/CodexClient.java
@@ -19,6 +19,8 @@
 
 package org.waveprotocol.examples.robots.gptbot;
 
+import java.util.Optional;
+
 /**
  * Generates a natural-language response for a prompt.
  */
@@ -65,5 +67,9 @@ public interface CodexClient {
       listener.onText(response);
     }
     return response;
+  }
+
+  default Optional<String> transcribeAttachment(String fileName, String mimeType, byte[] data) {
+    return Optional.empty();
   }
 }

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotReplyPlanner.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotReplyPlanner.java
@@ -38,6 +38,8 @@ public final class GptBotReplyPlanner {
   private static final Log LOG = Log.get(GptBotReplyPlanner.class);
   private static final int MAX_CONTEXT_CHARS = 2000;
   private static final int MAX_PROMPT_CHARS = 3000;
+  /** Minimum chars needed to render a useful attachment entry (header + short message). */
+  private static final int MIN_ATTACHMENT_RENDERED_CHARS = 80;
   /** Drop oldest history turns when estimated token count exceeds this threshold. */
   private static final int DEFAULT_MAX_HISTORY_TOKENS = 80000;
   /** Evict least-recently-added waves when the map exceeds this size to bound memory. */
@@ -199,7 +201,8 @@ public final class GptBotReplyPlanner {
         continue;
       }
       int allowed = remaining - sep.length();
-      if (allowed <= 0) {
+      if (allowed < MIN_ATTACHMENT_RENDERED_CHARS) {
+        // Budget too small for useful content; skip to avoid transcription cost.
         break;
       }
       String rendered = BotAttachmentContext.fromRaw(raw, codexClient).render();

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotReplyPlanner.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotReplyPlanner.java
@@ -176,8 +176,14 @@ public final class GptBotReplyPlanner {
     if (attachments == null || attachments.isEmpty()) {
       return promptText;
     }
+    String sectionHeader = "\n\nAttachment context:";
+    String sep = "\n\n";
+    int remaining = MAX_PROMPT_CHARS - promptText.length() - sectionHeader.length();
+    if (remaining <= 0) {
+      return promptText;
+    }
     StringBuilder prompt = new StringBuilder(promptText);
-    prompt.append("\n\nAttachment context:");
+    prompt.append(sectionHeader);
     int count = 0;
     for (BotAttachmentContext.RawAttachment raw : attachments) {
       if (count >= BotAttachmentContext.MAX_ATTACHMENT_CONTEXT_ITEMS) {
@@ -186,8 +192,15 @@ public final class GptBotReplyPlanner {
       if (raw == null) {
         continue;
       }
+      int allowed = remaining - sep.length();
+      if (allowed <= 0) {
+        break;
+      }
+      String rendered = BotAttachmentContext.fromRaw(raw, codexClient).render();
+      String capped = rendered.length() > allowed ? rendered.substring(0, allowed) : rendered;
+      prompt.append(sep).append(capped);
+      remaining -= sep.length() + capped.length();
       count++;
-      prompt.append("\n\n").append(BotAttachmentContext.fromRaw(raw, codexClient).render());
     }
     return prompt.toString();
   }

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotReplyPlanner.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotReplyPlanner.java
@@ -42,6 +42,7 @@ public final class GptBotReplyPlanner {
   private static final int DEFAULT_MAX_HISTORY_TOKENS = 80000;
   /** Evict least-recently-added waves when the map exceeds this size to bound memory. */
   private static final int MAX_WAVE_COUNT = 500;
+  static final int MAX_ATTACHMENT_CONTEXT_ITEMS = 5;
   private static final String CLARIFYING_PROMPT =
       "The user mentioned you without asking a clear question. Ask a short clarifying question.";
 
@@ -107,6 +108,18 @@ public final class GptBotReplyPlanner {
 
   private String runCompletion(String promptText, String waveContext, String waveId,
       List<BotAttachmentContext.RawAttachment> attachments, CodexClient.StreamingListener listener) {
+    // Normalize prompt and build attachment context (may call transcribeAttachment) before
+    // acquiring the wave mutex so slow network calls never block other completions on the same wave.
+    String normalizedPrompt = promptText == null ? "" : promptText.strip();
+    if (normalizedPrompt.isEmpty()) {
+      normalizedPrompt = CLARIFYING_PROMPT;
+    }
+    boolean hasAttachments = attachments != null && !attachments.isEmpty();
+    int promptBudget = hasAttachments ? MAX_PROMPT_CHARS / 2 : MAX_PROMPT_CHARS;
+    if (normalizedPrompt.length() > promptBudget) {
+      normalizedPrompt = normalizedPrompt.substring(0, promptBudget);
+    }
+    String promptWithAttachments = appendAttachmentContext(normalizedPrompt, attachments);
     if (waveId != null && !waveId.isEmpty()) {
       while (true) {
         // Retired mutex entries can linger briefly until the last releaser evicts them.
@@ -117,7 +130,7 @@ public final class GptBotReplyPlanner {
         }
         waveMutex.lock();
         try {
-          return doRunCompletion(promptText, waveContext, waveId, attachments, listener);
+          return doRunCompletion(promptWithAttachments, waveContext, waveId, listener);
         } finally {
           waveMutex.unlock();
           if (waveMutex.release()) {
@@ -126,22 +139,12 @@ public final class GptBotReplyPlanner {
         }
       }
     }
-    return doRunCompletion(promptText, waveContext, waveId, attachments, listener);
+    return doRunCompletion(promptWithAttachments, waveContext, waveId, listener);
   }
 
-  private String doRunCompletion(String promptText, String waveContext, String waveId,
-      List<BotAttachmentContext.RawAttachment> attachments, CodexClient.StreamingListener listener) {
-    String normalizedPrompt = promptText == null ? "" : promptText.strip();
-    if (normalizedPrompt.isEmpty()) {
-      normalizedPrompt = CLARIFYING_PROMPT;
-    }
-
+  private String doRunCompletion(String promptWithAttachments, String waveContext, String waveId,
+      CodexClient.StreamingListener listener) {
     Map<String, String> userMsg = new LinkedHashMap<>();
-    // Cap user text to half the budget so attachment context is not squeezed out.
-    String basePrompt = !attachments.isEmpty() && normalizedPrompt.length() > MAX_PROMPT_CHARS / 2
-        ? normalizedPrompt.substring(0, MAX_PROMPT_CHARS / 2)
-        : normalizedPrompt;
-    String promptWithAttachments = appendAttachmentContext(basePrompt, attachments);
     List<Map<String, String>> messages =
         buildMessages(promptWithAttachments, waveContext, waveId, userMsg);
 
@@ -174,11 +177,11 @@ public final class GptBotReplyPlanner {
     prompt.append("\n\nAttachment context:");
     int count = 0;
     for (BotAttachmentContext.RawAttachment raw : attachments) {
-      if (count >= BotAttachmentContext.MAX_ATTACHMENT_CONTEXT_ITEMS) {
-        break;
-      }
       if (raw == null) {
         continue;
+      }
+      if (count >= MAX_ATTACHMENT_CONTEXT_ITEMS) {
+        break;
       }
       count++;
       prompt.append("\n\n").append(BotAttachmentContext.fromRaw(raw, codexClient).render());
@@ -214,7 +217,8 @@ public final class GptBotReplyPlanner {
     }
 
     userMsg.put("role", "user");
-    userMsg.put("content", sanitize(normalizedPrompt, MAX_PROMPT_CHARS));
+    // Apply secret-redaction to the combined content; size is already bounded per component.
+    userMsg.put("content", sanitize(normalizedPrompt, Integer.MAX_VALUE));
     messages.add(userMsg);
     return messages;
   }

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotReplyPlanner.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotReplyPlanner.java
@@ -137,11 +137,17 @@ public final class GptBotReplyPlanner {
     if (normalizedPrompt.isEmpty()) {
       normalizedPrompt = CLARIFYING_PROMPT;
     }
-    // Cap user text to half the budget so attachment context is not squeezed out.
     boolean hasAttachments = attachments != null && !attachments.isEmpty();
-    String basePrompt = hasAttachments && normalizedPrompt.length() > MAX_PROMPT_CHARS / 2
-        ? normalizedPrompt.substring(0, MAX_PROMPT_CHARS / 2)
-        : normalizedPrompt;
+    String basePrompt;
+    if (hasAttachments) {
+      // Cap user text to half the budget so attachment context is not squeezed out.
+      basePrompt = normalizedPrompt.length() > MAX_PROMPT_CHARS / 2
+          ? normalizedPrompt.substring(0, MAX_PROMPT_CHARS / 2) : normalizedPrompt;
+    } else {
+      // No attachments: apply the full budget cap here so buildMessages can redact-only.
+      basePrompt = normalizedPrompt.length() > MAX_PROMPT_CHARS
+          ? normalizedPrompt.substring(0, MAX_PROMPT_CHARS) : normalizedPrompt;
+    }
     return appendAttachmentContext(basePrompt, attachments);
   }
 
@@ -233,7 +239,8 @@ public final class GptBotReplyPlanner {
     }
 
     userMsg.put("role", "user");
-    userMsg.put("content", sanitize(normalizedPrompt, MAX_PROMPT_CHARS));
+    // Size already bounded in buildPromptWithAttachments; only redact secrets here.
+    userMsg.put("content", sanitize(normalizedPrompt, Integer.MAX_VALUE));
     messages.add(userMsg);
     return messages;
   }

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotReplyPlanner.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotReplyPlanner.java
@@ -86,16 +86,27 @@ public final class GptBotReplyPlanner {
   }
 
   Optional<String> replyForPrompt(String promptText, String waveContext, String waveId) {
-    return Optional.of(runCompletion(promptText, waveContext, waveId, null));
+    return replyForPrompt(promptText, waveContext, waveId, java.util.Collections.emptyList());
+  }
+
+  Optional<String> replyForPrompt(String promptText, String waveContext, String waveId,
+      List<BotAttachmentContext.RawAttachment> attachments) {
+    return Optional.of(runCompletion(promptText, waveContext, waveId, attachments, null));
   }
 
   Optional<String> replyForPromptStreaming(String promptText, String waveContext, String waveId,
       CodexClient.StreamingListener listener) {
-    return Optional.of(runCompletion(promptText, waveContext, waveId, listener));
+    return replyForPromptStreaming(promptText, waveContext, waveId,
+        java.util.Collections.emptyList(), listener);
+  }
+
+  Optional<String> replyForPromptStreaming(String promptText, String waveContext, String waveId,
+      List<BotAttachmentContext.RawAttachment> attachments, CodexClient.StreamingListener listener) {
+    return Optional.of(runCompletion(promptText, waveContext, waveId, attachments, listener));
   }
 
   private String runCompletion(String promptText, String waveContext, String waveId,
-      CodexClient.StreamingListener listener) {
+      List<BotAttachmentContext.RawAttachment> attachments, CodexClient.StreamingListener listener) {
     if (waveId != null && !waveId.isEmpty()) {
       while (true) {
         // Retired mutex entries can linger briefly until the last releaser evicts them.
@@ -106,7 +117,7 @@ public final class GptBotReplyPlanner {
         }
         waveMutex.lock();
         try {
-          return doRunCompletion(promptText, waveContext, waveId, listener);
+          return doRunCompletion(promptText, waveContext, waveId, attachments, listener);
         } finally {
           waveMutex.unlock();
           if (waveMutex.release()) {
@@ -115,18 +126,20 @@ public final class GptBotReplyPlanner {
         }
       }
     }
-    return doRunCompletion(promptText, waveContext, waveId, listener);
+    return doRunCompletion(promptText, waveContext, waveId, attachments, listener);
   }
 
   private String doRunCompletion(String promptText, String waveContext, String waveId,
-      CodexClient.StreamingListener listener) {
+      List<BotAttachmentContext.RawAttachment> attachments, CodexClient.StreamingListener listener) {
     String normalizedPrompt = promptText == null ? "" : promptText.strip();
     if (normalizedPrompt.isEmpty()) {
       normalizedPrompt = CLARIFYING_PROMPT;
     }
 
     Map<String, String> userMsg = new LinkedHashMap<>();
-    List<Map<String, String>> messages = buildMessages(normalizedPrompt, waveContext, waveId, userMsg);
+    String promptWithAttachments = appendAttachmentContext(normalizedPrompt, attachments);
+    List<Map<String, String>> messages =
+        buildMessages(promptWithAttachments, waveContext, waveId, userMsg);
 
     String response = "";
     try {
@@ -146,6 +159,24 @@ public final class GptBotReplyPlanner {
 
     recordConversationTurn(waveId, userMsg, response);
     return response;
+  }
+
+  private String appendAttachmentContext(String promptText,
+      List<BotAttachmentContext.RawAttachment> attachments) {
+    if (attachments == null || attachments.isEmpty()) {
+      return promptText;
+    }
+    StringBuilder prompt = new StringBuilder(promptText);
+    prompt.append("\n\nAttachment context:");
+    int count = 0;
+    for (BotAttachmentContext.RawAttachment raw : attachments) {
+      if (raw == null || count >= 5) {
+        continue;
+      }
+      count++;
+      prompt.append("\n\n").append(BotAttachmentContext.fromRaw(raw, codexClient).render());
+    }
+    return prompt.toString();
   }
 
   private List<Map<String, String>> buildMessages(String normalizedPrompt, String waveContext,

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotReplyPlanner.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotReplyPlanner.java
@@ -42,7 +42,6 @@ public final class GptBotReplyPlanner {
   private static final int DEFAULT_MAX_HISTORY_TOKENS = 80000;
   /** Evict least-recently-added waves when the map exceeds this size to bound memory. */
   private static final int MAX_WAVE_COUNT = 500;
-  static final int MAX_ATTACHMENT_CONTEXT_ITEMS = 5;
   private static final String CLARIFYING_PROMPT =
       "The user mentioned you without asking a clear question. Ask a short clarifying question.";
 
@@ -115,9 +114,8 @@ public final class GptBotReplyPlanner {
       normalizedPrompt = CLARIFYING_PROMPT;
     }
     boolean hasAttachments = attachments != null && !attachments.isEmpty();
-    int promptBudget = hasAttachments ? MAX_PROMPT_CHARS / 2 : MAX_PROMPT_CHARS;
-    if (normalizedPrompt.length() > promptBudget) {
-      normalizedPrompt = normalizedPrompt.substring(0, promptBudget);
+    if (hasAttachments && normalizedPrompt.length() > MAX_PROMPT_CHARS / 2) {
+      normalizedPrompt = normalizedPrompt.substring(0, MAX_PROMPT_CHARS / 2);
     }
     String promptWithAttachments = appendAttachmentContext(normalizedPrompt, attachments);
     if (waveId != null && !waveId.isEmpty()) {
@@ -177,11 +175,11 @@ public final class GptBotReplyPlanner {
     prompt.append("\n\nAttachment context:");
     int count = 0;
     for (BotAttachmentContext.RawAttachment raw : attachments) {
+      if (count >= BotAttachmentContext.MAX_ATTACHMENT_CONTEXT_ITEMS) {
+        break;
+      }
       if (raw == null) {
         continue;
-      }
-      if (count >= MAX_ATTACHMENT_CONTEXT_ITEMS) {
-        break;
       }
       count++;
       prompt.append("\n\n").append(BotAttachmentContext.fromRaw(raw, codexClient).render());
@@ -217,8 +215,7 @@ public final class GptBotReplyPlanner {
     }
 
     userMsg.put("role", "user");
-    // Apply secret-redaction to the combined content; size is already bounded per component.
-    userMsg.put("content", sanitize(normalizedPrompt, Integer.MAX_VALUE));
+    userMsg.put("content", sanitize(normalizedPrompt, MAX_PROMPT_CHARS));
     messages.add(userMsg);
     return messages;
   }

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotReplyPlanner.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotReplyPlanner.java
@@ -239,8 +239,7 @@ public final class GptBotReplyPlanner {
     }
 
     userMsg.put("role", "user");
-    // Size already bounded in buildPromptWithAttachments; only redact secrets here.
-    userMsg.put("content", sanitize(normalizedPrompt, Integer.MAX_VALUE));
+    userMsg.put("content", sanitize(normalizedPrompt, MAX_PROMPT_CHARS));
     messages.add(userMsg);
     return messages;
   }

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotReplyPlanner.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotReplyPlanner.java
@@ -107,6 +107,7 @@ public final class GptBotReplyPlanner {
 
   private String runCompletion(String promptText, String waveContext, String waveId,
       List<BotAttachmentContext.RawAttachment> attachments, CodexClient.StreamingListener listener) {
+    String promptWithAttachments = buildPromptWithAttachments(promptText, attachments);
     if (waveId != null && !waveId.isEmpty()) {
       while (true) {
         // Retired mutex entries can linger briefly until the last releaser evicts them.
@@ -117,7 +118,7 @@ public final class GptBotReplyPlanner {
         }
         waveMutex.lock();
         try {
-          return doRunCompletion(promptText, waveContext, waveId, attachments, listener);
+          return doRunCompletion(promptWithAttachments, waveContext, waveId, listener);
         } finally {
           waveMutex.unlock();
           if (waveMutex.release()) {
@@ -126,22 +127,26 @@ public final class GptBotReplyPlanner {
         }
       }
     }
-    return doRunCompletion(promptText, waveContext, waveId, attachments, listener);
+    return doRunCompletion(promptWithAttachments, waveContext, waveId, listener);
   }
 
-  private String doRunCompletion(String promptText, String waveContext, String waveId,
-      List<BotAttachmentContext.RawAttachment> attachments, CodexClient.StreamingListener listener) {
+  private String buildPromptWithAttachments(String promptText,
+      List<BotAttachmentContext.RawAttachment> attachments) {
     String normalizedPrompt = promptText == null ? "" : promptText.strip();
     if (normalizedPrompt.isEmpty()) {
       normalizedPrompt = CLARIFYING_PROMPT;
     }
-
-    Map<String, String> userMsg = new LinkedHashMap<>();
     // Cap user text to half the budget so attachment context is not squeezed out.
-    String basePrompt = !attachments.isEmpty() && normalizedPrompt.length() > MAX_PROMPT_CHARS / 2
+    boolean hasAttachments = attachments != null && !attachments.isEmpty();
+    String basePrompt = hasAttachments && normalizedPrompt.length() > MAX_PROMPT_CHARS / 2
         ? normalizedPrompt.substring(0, MAX_PROMPT_CHARS / 2)
         : normalizedPrompt;
-    String promptWithAttachments = appendAttachmentContext(basePrompt, attachments);
+    return appendAttachmentContext(basePrompt, attachments);
+  }
+
+  private String doRunCompletion(String promptWithAttachments, String waveContext, String waveId,
+      CodexClient.StreamingListener listener) {
+    Map<String, String> userMsg = new LinkedHashMap<>();
     List<Map<String, String>> messages =
         buildMessages(promptWithAttachments, waveContext, waveId, userMsg);
 

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotReplyPlanner.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotReplyPlanner.java
@@ -137,7 +137,11 @@ public final class GptBotReplyPlanner {
     }
 
     Map<String, String> userMsg = new LinkedHashMap<>();
-    String promptWithAttachments = appendAttachmentContext(normalizedPrompt, attachments);
+    // Cap user text to half the budget so attachment context is not squeezed out.
+    String basePrompt = !attachments.isEmpty() && normalizedPrompt.length() > MAX_PROMPT_CHARS / 2
+        ? normalizedPrompt.substring(0, MAX_PROMPT_CHARS / 2)
+        : normalizedPrompt;
+    String promptWithAttachments = appendAttachmentContext(basePrompt, attachments);
     List<Map<String, String>> messages =
         buildMessages(promptWithAttachments, waveContext, waveId, userMsg);
 
@@ -170,7 +174,10 @@ public final class GptBotReplyPlanner {
     prompt.append("\n\nAttachment context:");
     int count = 0;
     for (BotAttachmentContext.RawAttachment raw : attachments) {
-      if (raw == null || count >= 5) {
+      if (count >= BotAttachmentContext.MAX_ATTACHMENT_CONTEXT_ITEMS) {
+        break;
+      }
+      if (raw == null) {
         continue;
       }
       count++;

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotRobot.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotRobot.java
@@ -333,7 +333,22 @@ public final class GptBotRobot {
       fileName = attachmentId;
     }
     String mimeType = element.getProperty(Attachment.MIME_TYPE);
+    if ((mimeType == null || mimeType.isBlank()) && element.isImage()) {
+      mimeType = inferImageMimeType(fileName);
+    }
     return new AttachmentReference(attachmentId, fileName, mimeType);
+  }
+
+  private static String inferImageMimeType(String fileName) {
+    if (fileName != null) {
+      String lower = fileName.toLowerCase(Locale.ROOT);
+      if (lower.endsWith(".png")) return "image/png";
+      if (lower.endsWith(".gif")) return "image/gif";
+      if (lower.endsWith(".webp")) return "image/webp";
+      if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+      if (lower.endsWith(".svg")) return "image/svg+xml";
+    }
+    return "image/jpeg";
   }
 
   private static final class AttachmentReference {

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotRobot.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotRobot.java
@@ -307,7 +307,7 @@ public final class GptBotRobot {
         LOG.warning("Unable to export attachment for GPT bot context: "
             + reference.attachmentId, e);
       }
-      if (attachments.size() >= BotAttachmentContext.MAX_ATTACHMENT_CONTEXT_ITEMS) {
+      if (attachments.size() >= GptBotReplyPlanner.MAX_ATTACHMENT_CONTEXT_ITEMS) {
         break;
       }
     }

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotRobot.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotRobot.java
@@ -289,13 +289,22 @@ public final class GptBotRobot {
 
   private List<BotAttachmentContext.RawAttachment> collectAttachments(Blip blip,
       String rpcServerUrl) {
-    List<BotAttachmentContext.RawAttachment> attachments =
-        new ArrayList<BotAttachmentContext.RawAttachment>();
+    List<BotAttachmentContext.RawAttachment> attachments = new ArrayList<>();
+    int attempts = 0;
     for (Element element : blip.getElements().values()) {
+      if (attempts >= BotAttachmentContext.MAX_ATTACHMENT_CONTEXT_ITEMS) {
+        break;
+      }
       AttachmentReference reference = attachmentReference(element);
       if (reference == null) {
         continue;
       }
+      // Skip clearly unsupported binary types before invoking the export RPC — the server
+      // materializes the full file into memory regardless of client-side response guards.
+      if (!BotAttachmentContext.mightBeUsable(reference.mimeType, reference.fileName)) {
+        continue;
+      }
+      attempts++;
       try {
         Optional<BotAttachmentContext.RawAttachment> exported =
             apiClient.exportAttachment(reference.attachmentId, rpcServerUrl);
@@ -306,9 +315,6 @@ public final class GptBotRobot {
       } catch (RuntimeException e) {
         LOG.warning("Unable to export attachment for GPT bot context: "
             + reference.attachmentId, e);
-      }
-      if (attachments.size() >= BotAttachmentContext.MAX_ATTACHMENT_CONTEXT_ITEMS) {
-        break;
       }
     }
     return attachments;

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotRobot.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotRobot.java
@@ -22,8 +22,11 @@ package org.waveprotocol.examples.robots.gptbot;
 import com.google.gson.Gson;
 import com.google.wave.api.Annotation;
 import com.google.wave.api.Annotations;
+import com.google.wave.api.Attachment;
 import com.google.wave.api.Blip;
 import com.google.wave.api.BlipThread;
+import com.google.wave.api.Element;
+import com.google.wave.api.Image;
 import com.google.wave.api.OperationQueue;
 import com.google.wave.api.OperationRequest;
 import com.google.wave.api.ParticipantProfile;
@@ -39,6 +42,7 @@ import org.waveprotocol.wave.util.logging.Log;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -213,14 +217,17 @@ public final class GptBotRobot {
     try {
       String waveContext = apiClient.fetchWaveContext(waveId, waveletId).orElse("");
       LOG.info("handleBlip: waveContextLen=" + waveContext.length());
+      List<BotAttachmentContext.RawAttachment> attachments =
+          collectAttachments(blip, rpcServerUrl);
+      LOG.info("handleBlip: attachmentContextCount=" + attachments.size());
 
       if (config.getReplyMode() == GptBotConfig.ReplyMode.ACTIVE_STREAM) {
         LOG.info("handleBlip: ACTIVE_STREAM mode — starting streamed reply for blipId=" + blipId);
         StreamingReplyWriter writer = new StreamingReplyWriter(apiClient, waveId, waveletId,
             blipId, rpcServerUrl);
         final boolean[] started = {false};
-        Optional<String> reply = replyPlanner.replyForPromptStreaming(prompt.get(), waveContext, waveId,
-            accumulatedText -> {
+        Optional<String> reply = replyPlanner.replyForPromptStreaming(prompt.get(), waveContext,
+            waveId, attachments, accumulatedText -> {
               if (!started[0] && accumulatedText != null && !accumulatedText.isEmpty()) {
                 started[0] = writer.start(accumulatedText);
                 if (!started[0]) {
@@ -251,7 +258,8 @@ public final class GptBotRobot {
         return;
       }
 
-      Optional<String> reply = replyPlanner.replyForPrompt(prompt.get(), waveContext, waveId);
+      Optional<String> reply = replyPlanner.replyForPrompt(prompt.get(), waveContext, waveId,
+          attachments);
       if (!reply.isPresent()) {
         LOG.warning("handleBlip: replyForPrompt returned empty — LLM may have failed");
         return;
@@ -276,6 +284,67 @@ public final class GptBotRobot {
       }
     } catch (Exception e) {
       LOG.warning("handleBlip: exception during reply generation for blipId=" + blipId, e);
+    }
+  }
+
+  private List<BotAttachmentContext.RawAttachment> collectAttachments(Blip blip,
+      String rpcServerUrl) {
+    List<BotAttachmentContext.RawAttachment> attachments =
+        new ArrayList<BotAttachmentContext.RawAttachment>();
+    for (Element element : blip.getElements().values()) {
+      AttachmentReference reference = attachmentReference(element);
+      if (reference == null) {
+        continue;
+      }
+      try {
+        Optional<BotAttachmentContext.RawAttachment> exported =
+            apiClient.exportAttachment(reference.attachmentId, rpcServerUrl);
+        if (exported.isPresent()) {
+          attachments.add(exported.get().withFallbackMetadata(reference.fileName,
+              reference.mimeType));
+        }
+      } catch (RuntimeException e) {
+        LOG.warning("Unable to export attachment for GPT bot context: "
+            + reference.attachmentId, e);
+      }
+      if (attachments.size() >= 5) {
+        break;
+      }
+    }
+    return attachments;
+  }
+
+  private AttachmentReference attachmentReference(Element element) {
+    if (element == null || (!element.isAttachment() && !element.isImage())) {
+      return null;
+    }
+    String attachmentId = element.getProperty(Attachment.ATTACHMENT_ID);
+    if (attachmentId == null || attachmentId.isBlank()) {
+      attachmentId = element.getProperty(Image.ATTACHMENT_ID);
+    }
+    if (attachmentId == null || attachmentId.isBlank()) {
+      return null;
+    }
+    String fileName = element.getProperty(Attachment.CAPTION);
+    if (fileName == null || fileName.isBlank()) {
+      fileName = element.getProperty(Image.CAPTION);
+    }
+    if (fileName == null || fileName.isBlank()) {
+      fileName = attachmentId;
+    }
+    String mimeType = element.getProperty(Attachment.MIME_TYPE);
+    return new AttachmentReference(attachmentId, fileName, mimeType);
+  }
+
+  private static final class AttachmentReference {
+    private final String attachmentId;
+    private final String fileName;
+    private final String mimeType;
+
+    private AttachmentReference(String attachmentId, String fileName, String mimeType) {
+      this.attachmentId = attachmentId;
+      this.fileName = fileName;
+      this.mimeType = mimeType;
     }
   }
 

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotRobot.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotRobot.java
@@ -307,7 +307,7 @@ public final class GptBotRobot {
         LOG.warning("Unable to export attachment for GPT bot context: "
             + reference.attachmentId, e);
       }
-      if (attachments.size() >= GptBotReplyPlanner.MAX_ATTACHMENT_CONTEXT_ITEMS) {
+      if (attachments.size() >= BotAttachmentContext.MAX_ATTACHMENT_CONTEXT_ITEMS) {
         break;
       }
     }

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotRobot.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/GptBotRobot.java
@@ -307,7 +307,7 @@ public final class GptBotRobot {
         LOG.warning("Unable to export attachment for GPT bot context: "
             + reference.attachmentId, e);
       }
-      if (attachments.size() >= 5) {
+      if (attachments.size() >= BotAttachmentContext.MAX_ATTACHMENT_CONTEXT_ITEMS) {
         break;
       }
     }

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/OpenAiCodexClient.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/OpenAiCodexClient.java
@@ -25,14 +25,18 @@ import com.google.gson.JsonParser;
 
 import org.waveprotocol.wave.util.logging.Log;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 /**
@@ -56,6 +60,7 @@ public final class OpenAiCodexClient implements CodexClient {
   private final String apiKey;
   private final String baseUrl;
   private final String model;
+  private final String transcriptionModel;
   private final HttpClient httpClient;
   private final boolean webSearchEnabled;
 
@@ -65,6 +70,9 @@ public final class OpenAiCodexClient implements CodexClient {
     this.baseUrl = (base != null && !base.isBlank()) ? stripTrailingSlash(base) : "https://api.openai.com/v1";
     String envModel = System.getenv("GPTBOT_OPENAI_MODEL");
     this.model = (envModel != null && !envModel.isBlank()) ? envModel.trim() : "gpt-4o-mini";
+    String envTranscriptionModel = System.getenv("GPTBOT_OPENAI_TRANSCRIPTION_MODEL");
+    this.transcriptionModel = (envTranscriptionModel != null && !envTranscriptionModel.isBlank())
+        ? envTranscriptionModel.trim() : "gpt-4o-mini-transcribe";
     String webSearch = System.getenv("GPTBOT_WEB_SEARCH_ENABLED");
     this.webSearchEnabled = "true".equalsIgnoreCase(webSearch == null ? "" : webSearch.trim());
     this.httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(15)).build();
@@ -74,11 +82,17 @@ public final class OpenAiCodexClient implements CodexClient {
 
   OpenAiCodexClient(String apiKey, String baseUrl, String model, HttpClient httpClient,
       boolean webSearchEnabled) {
+    this(apiKey, baseUrl, model, httpClient, webSearchEnabled, "gpt-4o-mini-transcribe");
+  }
+
+  OpenAiCodexClient(String apiKey, String baseUrl, String model, HttpClient httpClient,
+      boolean webSearchEnabled, String transcriptionModel) {
     this.apiKey = apiKey;
     this.baseUrl = stripTrailingSlash(baseUrl);
     this.model = model;
     this.httpClient = httpClient;
     this.webSearchEnabled = webSearchEnabled;
+    this.transcriptionModel = transcriptionModel;
   }
 
   @Override
@@ -196,6 +210,35 @@ public final class OpenAiCodexClient implements CodexClient {
       }
       LOG.warning("OpenAI streaming API call failed", e);
       return "I'm having trouble generating a response right now.";
+    }
+  }
+
+  @Override
+  public Optional<String> transcribeAttachment(String fileName, String mimeType, byte[] data) {
+    try {
+      String boundary = "----SupaWaveGptBot" + UUID.randomUUID().toString().replace("-", "");
+      byte[] body = buildTranscriptionMultipartBody(boundary, fileName, mimeType, data);
+      HttpRequest request = HttpRequest.newBuilder()
+          .uri(URI.create(baseUrl + "/audio/transcriptions"))
+          .timeout(REQUEST_TIMEOUT)
+          .header("Authorization", "Bearer " + apiKey)
+          .header("Content-Type", "multipart/form-data; boundary=" + boundary)
+          .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+          .build();
+
+      HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() < 200 || response.statusCode() >= 300) {
+        LOG.warning("OpenAI transcription returned HTTP " + response.statusCode() + ": "
+            + truncate(response.body(), 200));
+        return Optional.empty();
+      }
+      return extractTranscript(response.body());
+    } catch (IOException | InterruptedException e) {
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+      LOG.warning("OpenAI transcription call failed", e);
+      return Optional.empty();
     }
   }
 
@@ -357,6 +400,46 @@ public final class OpenAiCodexClient implements CodexClient {
     return body;
   }
 
+  private byte[] buildTranscriptionMultipartBody(String boundary, String fileName, String mimeType,
+      byte[] data) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    writePart(out, boundary, "model", null, null,
+        transcriptionModel.getBytes(StandardCharsets.UTF_8));
+    writePart(out, boundary, "response_format", null, null,
+        "json".getBytes(StandardCharsets.UTF_8));
+    writePart(out, boundary, "file", safeFileName(fileName), safeMimeType(mimeType),
+        data == null ? new byte[0] : data);
+    out.write(("--" + boundary + "--\r\n").getBytes(StandardCharsets.UTF_8));
+    return out.toByteArray();
+  }
+
+  private static void writePart(ByteArrayOutputStream out, String boundary, String name,
+      String fileName, String mimeType, byte[] data) throws IOException {
+    out.write(("--" + boundary + "\r\n").getBytes(StandardCharsets.UTF_8));
+    String disposition = "Content-Disposition: form-data; name=\"" + name + "\"";
+    if (fileName != null) {
+      disposition += "; filename=\"" + fileName + "\"";
+    }
+    out.write((disposition + "\r\n").getBytes(StandardCharsets.UTF_8));
+    if (mimeType != null) {
+      out.write(("Content-Type: " + mimeType + "\r\n").getBytes(StandardCharsets.UTF_8));
+    }
+    out.write("\r\n".getBytes(StandardCharsets.UTF_8));
+    out.write(data);
+    out.write("\r\n".getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static String safeFileName(String fileName) {
+    String cleaned = fileName == null || fileName.isBlank() ? "attachment" : fileName.trim();
+    return cleaned.replace("\\", "_").replace("\"", "_").replace("\r", "_").replace("\n", "_");
+  }
+
+  private static String safeMimeType(String mimeType) {
+    String cleaned = mimeType == null || mimeType.isBlank()
+        ? "application/octet-stream" : mimeType.trim();
+    return cleaned.replace("\r", "").replace("\n", "");
+  }
+
   private JsonArray buildMessagesArray(List<Map<String, String>> messages) {
     JsonArray messagesArray = new JsonArray();
     for (Map<String, String> msg : messages) {
@@ -435,6 +518,21 @@ public final class OpenAiCodexClient implements CodexClient {
       LOG.warning("Failed to parse OpenAI response", e);
     }
     return "I received your message but couldn't generate a response.";
+  }
+
+  private static Optional<String> extractTranscript(String responseBody) {
+    try {
+      JsonObject json = JsonParser.parseString(responseBody).getAsJsonObject();
+      if (json.has("text")) {
+        String text = json.get("text").getAsString().trim();
+        if (!text.isEmpty()) {
+          return Optional.of(text);
+        }
+      }
+    } catch (Exception e) {
+      LOG.warning("Failed to parse OpenAI transcription response", e);
+    }
+    return Optional.empty();
   }
 
   private static String requireEnv(String name) {

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClient.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClient.java
@@ -27,6 +27,7 @@ import com.google.gson.JsonParser;
 import org.waveprotocol.wave.util.logging.Log;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
@@ -47,6 +48,9 @@ public final class SupaWaveApiClient implements SupaWaveClient {
   private static final Log LOG = Log.get(SupaWaveApiClient.class);
   private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(15);
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(45);
+  // Base64 expands by 4/3; add a small JSON envelope margin.
+  private static final long MAX_EXPORT_RESPONSE_BYTES =
+      (long) BotAttachmentContext.MAX_TRANSCRIPTION_BYTES * 4 / 3 + 4096;
 
   private final GptBotConfig config;
   private final HttpClient httpClient;
@@ -98,8 +102,8 @@ public final class SupaWaveApiClient implements SupaWaveClient {
     if (attachmentId != null && !attachmentId.isBlank() && config.hasApiCredentials()) {
       try {
         String endpoint = resolveRpcEndpoint(rpcServerUrl);
-        JsonArray response = postRpc(exportAttachmentRequest(attachmentId), endpoint,
-            accessTokenForEndpoint(endpoint));
+        JsonArray response = postRpcBounded(exportAttachmentRequest(attachmentId), endpoint,
+            accessTokenForEndpoint(endpoint), MAX_EXPORT_RESPONSE_BYTES);
         attachment = extractAttachmentData(attachmentId, response);
       } catch (IOException | InterruptedException | RuntimeException e) {
         logWarningAndRestoreInterrupt("Unable to export attachment through SupaWave RPC", e);
@@ -261,6 +265,33 @@ public final class SupaWaveApiClient implements SupaWaveClient {
       throw new IOException("Unexpected SupaWave RPC status: " + response.statusCode());
     }
     return JsonParser.parseString(response.body()).getAsJsonArray();
+  }
+
+  private JsonArray postRpcBounded(JsonArray body, String endpoint, String accessToken,
+      long maxBytes) throws IOException, InterruptedException {
+    HttpRequest httpRequest = HttpRequest.newBuilder()
+        .uri(URI.create(endpoint))
+        .timeout(REQUEST_TIMEOUT)
+        .header("Authorization", "Bearer " + accessToken)
+        .header("Content-Type", "application/json")
+        .POST(HttpRequest.BodyPublishers.ofString(body.toString()))
+        .build();
+
+    HttpResponse<InputStream> response = httpClient.send(httpRequest,
+        HttpResponse.BodyHandlers.ofInputStream());
+    if (response.statusCode() < 200 || response.statusCode() >= 300) {
+      response.body().close();
+      throw new IOException("Unexpected SupaWave RPC status: " + response.statusCode());
+    }
+    try (InputStream is = response.body()) {
+      // Read one byte beyond the limit so we can detect oversized responses without buffering them.
+      int readLimit = (int) Math.min(maxBytes + 1, Integer.MAX_VALUE);
+      byte[] buf = is.readNBytes(readLimit);
+      if (buf.length > maxBytes) {
+        throw new IOException("Export response exceeds size limit of " + maxBytes + " bytes");
+      }
+      return JsonParser.parseString(new String(buf, StandardCharsets.UTF_8)).getAsJsonArray();
+    }
   }
 
   private String contextAccessToken() throws IOException, InterruptedException {

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClient.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClient.java
@@ -474,9 +474,11 @@ public final class SupaWaveApiClient implements SupaWaveClient {
       String mimeType = attachmentData.has("mimeType")
           ? attachmentData.get("mimeType").getAsString() : "application/octet-stream";
       String encoded = attachmentData.has("data") ? attachmentData.get("data").getAsString() : "";
-      // Base64 expands by ~4/3; reject payloads that exceed the transcription cap before decoding.
-      if (encoded.length() > (long) BotAttachmentContext.MAX_TRANSCRIPTION_BYTES * 4 / 3 + 1024) {
-        return Optional.empty();
+      // Reject oversized payloads before decoding to avoid holding the full byte array in memory
+      // for attachments that BotAttachmentContext will discard anyway.
+      long maxEncodedLen = (long) BotAttachmentContext.MAX_TRANSCRIPTION_BYTES * 4 / 3 + 1024;
+      if (encoded.length() > maxEncodedLen) {
+        continue;
       }
       byte[] bytes = Base64.getDecoder().decode(encoded);
       return Optional.of(new BotAttachmentContext.RawAttachment(attachmentId, fileName,

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClient.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClient.java
@@ -188,6 +188,9 @@ public final class SupaWaveApiClient implements SupaWaveClient {
   private JsonArray exportAttachmentRequest(String attachmentId) {
     JsonObject params = new JsonObject();
     params.addProperty("attachmentId", attachmentId);
+    // Tell the server to reject attachments larger than MAX_TRANSCRIPTION_BYTES before reading,
+    // so it never materializes oversized files into memory on the bot's behalf.
+    params.addProperty("maxSizeBytes", (long) BotAttachmentContext.MAX_TRANSCRIPTION_BYTES);
 
     JsonObject request = new JsonObject();
     request.addProperty("id", "gpt-bot-attachment-1");

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClient.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClient.java
@@ -481,6 +481,9 @@ public final class SupaWaveApiClient implements SupaWaveClient {
         continue;
       }
       byte[] bytes = Base64.getDecoder().decode(encoded);
+      if (bytes.length > BotAttachmentContext.MAX_TRANSCRIPTION_BYTES) {
+        continue;
+      }
       return Optional.of(new BotAttachmentContext.RawAttachment(attachmentId, fileName,
           mimeType, bytes));
     }

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClient.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClient.java
@@ -474,6 +474,10 @@ public final class SupaWaveApiClient implements SupaWaveClient {
       String mimeType = attachmentData.has("mimeType")
           ? attachmentData.get("mimeType").getAsString() : "application/octet-stream";
       String encoded = attachmentData.has("data") ? attachmentData.get("data").getAsString() : "";
+      // Base64 expands by ~4/3; reject payloads that exceed the transcription cap before decoding.
+      if (encoded.length() > (long) BotAttachmentContext.MAX_TRANSCRIPTION_BYTES * 4 / 3 + 1024) {
+        return Optional.empty();
+      }
       byte[] bytes = Base64.getDecoder().decode(encoded);
       return Optional.of(new BotAttachmentContext.RawAttachment(attachmentId, fileName,
           mimeType, bytes));

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClient.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClient.java
@@ -35,6 +35,7 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -88,6 +89,23 @@ public final class SupaWaveApiClient implements SupaWaveClient {
       }
     }
     return summary;
+  }
+
+  @Override
+  public Optional<BotAttachmentContext.RawAttachment> exportAttachment(String attachmentId,
+      String rpcServerUrl) {
+    Optional<BotAttachmentContext.RawAttachment> attachment = Optional.empty();
+    if (attachmentId != null && !attachmentId.isBlank() && config.hasApiCredentials()) {
+      try {
+        String endpoint = resolveRpcEndpoint(rpcServerUrl);
+        JsonArray response = postRpc(exportAttachmentRequest(attachmentId), endpoint,
+            accessTokenForEndpoint(endpoint));
+        attachment = extractAttachmentData(attachmentId, response);
+      } catch (IOException | InterruptedException | RuntimeException e) {
+        logWarningAndRestoreInterrupt("Unable to export attachment through SupaWave RPC", e);
+      }
+    }
+    return attachment;
   }
 
   @Override
@@ -156,6 +174,20 @@ public final class SupaWaveApiClient implements SupaWaveClient {
     JsonObject request = new JsonObject();
     request.addProperty("id", "gpt-bot-search-1");
     request.addProperty("method", "robot.search");
+    request.add("params", params);
+
+    JsonArray body = new JsonArray();
+    body.add(request);
+    return body;
+  }
+
+  private JsonArray exportAttachmentRequest(String attachmentId) {
+    JsonObject params = new JsonObject();
+    params.addProperty("attachmentId", attachmentId);
+
+    JsonObject request = new JsonObject();
+    request.addProperty("id", "gpt-bot-attachment-1");
+    request.addProperty("method", "robot.exportAttachment");
     request.add("params", params);
 
     JsonArray body = new JsonArray();
@@ -420,6 +452,31 @@ public final class SupaWaveApiClient implements SupaWaveClient {
           }
         }
       }
+    }
+    return Optional.empty();
+  }
+
+  private Optional<BotAttachmentContext.RawAttachment> extractAttachmentData(String attachmentId,
+      JsonArray response) {
+    for (JsonElement element : response) {
+      if (!element.isJsonObject()) {
+        continue;
+      }
+      JsonObject object = element.getAsJsonObject();
+      JsonObject data = object.has("data") && object.get("data").isJsonObject()
+          ? object.getAsJsonObject("data") : object;
+      if (!data.has("attachmentData") || !data.get("attachmentData").isJsonObject()) {
+        continue;
+      }
+      JsonObject attachmentData = data.getAsJsonObject("attachmentData");
+      String fileName = attachmentData.has("fileName")
+          ? attachmentData.get("fileName").getAsString() : attachmentId;
+      String mimeType = attachmentData.has("mimeType")
+          ? attachmentData.get("mimeType").getAsString() : "application/octet-stream";
+      String encoded = attachmentData.has("data") ? attachmentData.get("data").getAsString() : "";
+      byte[] bytes = Base64.getDecoder().decode(encoded);
+      return Optional.of(new BotAttachmentContext.RawAttachment(attachmentId, fileName,
+          mimeType, bytes));
     }
     return Optional.empty();
   }

--- a/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/SupaWaveClient.java
+++ b/wave/src/main/java/org/waveprotocol/examples/robots/gptbot/SupaWaveClient.java
@@ -30,6 +30,9 @@ public interface SupaWaveClient {
 
   Optional<String> search(String query);
 
+  Optional<BotAttachmentContext.RawAttachment> exportAttachment(String attachmentId,
+      String rpcServerUrl);
+
   Optional<String> createReply(String waveId, String waveletId, String parentBlipId,
       String initialContent, String rpcServerUrl);
 

--- a/wave/src/test/java/org/waveprotocol/examples/robots/gptbot/GptBotRobotTest.java
+++ b/wave/src/test/java/org/waveprotocol/examples/robots/gptbot/GptBotRobotTest.java
@@ -19,9 +19,11 @@
 
 package org.waveprotocol.examples.robots.gptbot;
 
+import com.google.wave.api.Attachment;
 import com.google.wave.api.Annotation;
 import com.google.wave.api.BlipData;
 import com.google.wave.api.BlipThread;
+import com.google.wave.api.Element;
 import com.google.wave.api.event.DocumentChangedEvent;
 import com.google.wave.api.impl.EventMessageBundle;
 import com.google.wave.api.impl.GsonFactory;
@@ -34,7 +36,9 @@ import junit.framework.TestCase;
 
 import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -60,6 +64,51 @@ public class GptBotRobotTest extends TestCase {
     assertEquals(0, apiClient.appendCalls);
     assertEquals(1, apiClient.fetchCalls);
     assertEquals(1, codexClient.completeCalls);
+  }
+
+  public void testAudioAttachmentIsExportedTranscribedAndIncludedInPrompt() {
+    RecordingCodexClient codexClient = new RecordingCodexClient();
+    codexClient.response = "The audio asks for a summary.";
+    codexClient.transcriptionResponse = "Please summarize yesterday's launch.";
+    RecordingSupaWaveClient apiClient = new RecordingSupaWaveClient();
+    apiClient.exportedAttachment = new BotAttachmentContext.RawAttachment(
+        "att-audio", "voice-message.mp3", "audio/mpeg",
+        "pretend audio".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    GptBotRobot robot = new GptBotRobot(TEST_CONFIG,
+        new GptBotReplyPlanner(TEST_CONFIG.getRobotName(), codexClient), apiClient);
+
+    String response = robot.handleEventBundle(exampleBundleJsonWithAttachment(TEST_CONFIG,
+        "\n@" + TEST_CONFIG.getRobotName() + " answer this audio",
+        "att-audio", "voice-message.mp3", "audio/mpeg",
+        new BlipEditingDoneEvent(null, null, "alice@example.com", 1L, "b+root")));
+
+    assertTrue(response.contains("The audio asks for a summary."));
+    assertEquals(1, apiClient.exportAttachmentCalls);
+    assertEquals("att-audio", apiClient.lastExportedAttachmentId);
+    assertEquals(1, codexClient.transcriptionCalls);
+    assertTrue(codexClient.lastPrompt.contains("Transcript"));
+    assertTrue(codexClient.lastPrompt.contains("Please summarize yesterday's launch."));
+  }
+
+  public void testTextAttachmentIsConvertedToMarkdownContextWithoutTranscription() {
+    RecordingCodexClient codexClient = new RecordingCodexClient();
+    codexClient.response = "The note says launch checklist.";
+    RecordingSupaWaveClient apiClient = new RecordingSupaWaveClient();
+    apiClient.exportedAttachment = new BotAttachmentContext.RawAttachment(
+        "att-note", "notes.md", "text/markdown",
+        "# Launch checklist\n- verify metrics".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    GptBotRobot robot = new GptBotRobot(TEST_CONFIG,
+        new GptBotReplyPlanner(TEST_CONFIG.getRobotName(), codexClient), apiClient);
+
+    robot.handleEventBundle(exampleBundleJsonWithAttachment(TEST_CONFIG,
+        "\n@" + TEST_CONFIG.getRobotName() + " use the note",
+        "att-note", "notes.md", "text/markdown",
+        new BlipEditingDoneEvent(null, null, "alice@example.com", 1L, "b+root")));
+
+    assertEquals(1, apiClient.exportAttachmentCalls);
+    assertEquals(0, codexClient.transcriptionCalls);
+    assertTrue(codexClient.lastPrompt.contains("```markdown"));
+    assertTrue(codexClient.lastPrompt.contains("verify metrics"));
   }
 
   public void testCallbackBundleCanReplyThroughActiveApi() {
@@ -485,6 +534,30 @@ public class GptBotRobotTest extends TestCase {
     return new GsonFactory().create().toJson(bundle);
   }
 
+  private static String exampleBundleJsonWithAttachment(GptBotConfig config, String content,
+      String attachmentId, String fileName, String mimeType, Event... events) {
+    EventMessageBundle bundle = new EventMessageBundle(config.getParticipantId(),
+        "http://localhost:8087/_wave/robot/jsonrpc");
+    WaveletData waveletData = new WaveletData("example.com!w+abc123", "example.com!conv+root",
+        "b+root", (BlipThread) null);
+    waveletData.addParticipant("alice@example.com");
+    bundle.setWaveletData(waveletData);
+    BlipData blipData = new BlipData("example.com!w+abc123",
+        "example.com!conv+root", "b+root", content + " ");
+    Map<String, String> properties = new HashMap<String, String>();
+    properties.put(Attachment.ATTACHMENT_ID, attachmentId);
+    properties.put(Attachment.CAPTION, fileName);
+    properties.put(Attachment.MIME_TYPE, mimeType);
+    Map<Integer, Element> elements = new HashMap<Integer, Element>();
+    elements.put(Integer.valueOf(content.length()), new Attachment(properties, null));
+    blipData.setElements(elements);
+    bundle.addBlip("b+root", blipData);
+    for (Event event : events) {
+      bundle.addEvent(event);
+    }
+    return new GsonFactory().create().toJson(bundle);
+  }
+
   private static String exampleBundleJsonWithChildBlip(GptBotConfig config, String content,
       Event... events) {
     EventMessageBundle bundle = new EventMessageBundle(config.getParticipantId(),
@@ -634,13 +707,23 @@ public class GptBotRobotTest extends TestCase {
 
     private int completeCalls;
     private int completeStreamingCalls;
+    private int transcriptionCalls;
     private String response = "answer";
+    private String transcriptionResponse = "transcript";
+    private String lastPrompt = "";
     private List<String> streamingResponses;
 
     @Override
     public String complete(String prompt) {
       completeCalls++;
+      lastPrompt = prompt;
       return response;
+    }
+
+    @Override
+    public Optional<String> transcribeAttachment(String fileName, String mimeType, byte[] data) {
+      transcriptionCalls++;
+      return Optional.of(transcriptionResponse);
     }
 
     @Override
@@ -661,9 +744,12 @@ public class GptBotRobotTest extends TestCase {
 
     private int appendCalls;
     private int createReplyCalls;
+    private int exportAttachmentCalls;
     private int fetchCalls;
     private boolean appendSucceeds;
+    private BotAttachmentContext.RawAttachment exportedAttachment;
     private String createReplyId = "b+reply";
+    private String lastExportedAttachmentId;
     private String lastReply;
     private String lastCreatedReplyId;
     private String lastCreatedContent;
@@ -679,6 +765,15 @@ public class GptBotRobotTest extends TestCase {
     @Override
     public Optional<String> search(String query) {
       return Optional.empty();
+    }
+
+    @Override
+    public Optional<BotAttachmentContext.RawAttachment> exportAttachment(String attachmentId,
+        String rpcServerUrl) {
+      exportAttachmentCalls++;
+      lastExportedAttachmentId = attachmentId;
+      lastRpcServerUrl = rpcServerUrl;
+      return Optional.ofNullable(exportedAttachment);
     }
 
     @Override

--- a/wave/src/test/java/org/waveprotocol/examples/robots/gptbot/OpenAiCodexClientTest.java
+++ b/wave/src/test/java/org/waveprotocol/examples/robots/gptbot/OpenAiCodexClientTest.java
@@ -77,6 +77,23 @@ public class OpenAiCodexClientTest extends TestCase {
     assertFalse(httpClient.lastRequestBody.contains("\"stream\":true"));
   }
 
+  public void testTranscribeAttachmentPostsMultipartAudioRequest() {
+    StringHttpClient httpClient = new StringHttpClient("{\"text\":\"hello from audio\"}");
+    OpenAiCodexClient client = new OpenAiCodexClient("test-key", "https://api.example.com",
+        "gpt-test", httpClient, false, "gpt-4o-mini-transcribe");
+
+    Optional<String> transcript = client.transcribeAttachment("voice.mp3", "audio/mpeg",
+        "audio bytes".getBytes(StandardCharsets.UTF_8));
+
+    assertEquals(Optional.of("hello from audio"), transcript);
+    assertEquals("/audio/transcriptions", httpClient.lastRequestUri.getPath());
+    assertTrue(httpClient.lastContentType.startsWith("multipart/form-data; boundary="));
+    assertTrue(httpClient.lastRequestBody.contains("name=\"model\""));
+    assertTrue(httpClient.lastRequestBody.contains("gpt-4o-mini-transcribe"));
+    assertTrue(httpClient.lastRequestBody.contains("filename=\"voice.mp3\""));
+    assertTrue(httpClient.lastRequestBody.contains("audio bytes"));
+  }
+
   private static List<Map<String, String>> exampleMessages() {
     List<Map<String, String>> messages = new ArrayList<Map<String, String>>();
     Map<String, String> system = new LinkedHashMap<String, String>();
@@ -92,6 +109,8 @@ public class OpenAiCodexClientTest extends TestCase {
 
   private abstract static class BaseHttpClient extends HttpClient {
     protected String lastRequestBody = "";
+    protected URI lastRequestUri;
+    protected String lastContentType = "";
 
     @Override
     public Optional<CookieHandler> cookieHandler() {
@@ -152,6 +171,8 @@ public class OpenAiCodexClientTest extends TestCase {
     }
 
     protected void capture(HttpRequest request) {
+      lastRequestUri = request.uri();
+      lastContentType = request.headers().firstValue("Content-Type").orElse("");
       lastRequestBody = bodyString(request);
     }
 

--- a/wave/src/test/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClientTest.java
+++ b/wave/src/test/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClientTest.java
@@ -100,6 +100,27 @@ public class SupaWaveApiClientTest extends TestCase {
     assertTrue(httpClient.lastRpcRequestBody.contains("\"blipId\":\"b+reply\""));
   }
 
+  public void testExportAttachmentPostsRobotExportAttachmentAndParsesData() {
+    GptBotConfig config = testConfig();
+    RecordingHttpClient httpClient = new RecordingHttpClient();
+    httpClient.rpcResponseBody =
+        "[{\"id\":\"gpt-bot-attachment-1\",\"data\":{\"attachmentData\":{"
+            + "\"fileName\":\"voice.mp3\","
+            + "\"creator\":\"alice@example.com\","
+            + "\"data\":\"dm9pY2UtYnl0ZXM=\"}}}]";
+    SupaWaveApiClient client = new SupaWaveApiClient(config, httpClient);
+
+    Optional<BotAttachmentContext.RawAttachment> attachment =
+        client.exportAttachment("att-voice", "https://wave.example.com/robot/dataapi/rpc");
+
+    assertTrue(attachment.isPresent());
+    assertEquals("voice.mp3", attachment.get().getFileName());
+    assertEquals("voice-bytes", new String(attachment.get().getData(), StandardCharsets.UTF_8));
+    assertEquals("https://wave.example.com/robot/dataapi/rpc", httpClient.lastRpcRequestUri.toString());
+    assertTrue(httpClient.lastRpcRequestBody.contains("\"method\":\"robot.exportAttachment\""));
+    assertTrue(httpClient.lastRpcRequestBody.contains("\"attachmentId\":\"att-voice\""));
+  }
+
   public void testCreateReplyFallsBackToTrustedRobotEndpointWhenRpcServerUrlIsUntrusted() {
     GptBotConfig config = testConfig();
     RecordingHttpClient httpClient = new RecordingHttpClient();
@@ -218,6 +239,8 @@ public class SupaWaveApiClientTest extends TestCase {
     private String lastTokenRequestBody = "";
     private URI lastRpcRequestUri;
     private String lastRpcRequestBody = "";
+    private String rpcResponseBody =
+        "[{\"id\":\"gpt-bot-reply-1\",\"data\":{\"newBlipId\":\"b+child\"}}]";
 
     @Override
     public Optional<CookieHandler> cookieHandler() {
@@ -280,8 +303,7 @@ public class SupaWaveApiClientTest extends TestCase {
       lastRpcRequestUri = request.uri();
       lastRpcRequestBody = body;
       @SuppressWarnings("unchecked")
-      HttpResponse<T> response = (HttpResponse<T>) new StringHttpResponse(
-          200, "[{\"id\":\"gpt-bot-reply-1\",\"data\":{\"newBlipId\":\"b+child\"}}]");
+      HttpResponse<T> response = (HttpResponse<T>) new StringHttpResponse(200, rpcResponseBody);
       return response;
     }
 

--- a/wave/src/test/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClientTest.java
+++ b/wave/src/test/java/org/waveprotocol/examples/robots/gptbot/SupaWaveApiClientTest.java
@@ -21,7 +21,9 @@ package org.waveprotocol.examples.robots.gptbot;
 
 import junit.framework.TestCase;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.Authenticator;
 import java.net.CookieHandler;
 import java.net.ProxySelector;
@@ -302,6 +304,12 @@ public class SupaWaveApiClientTest extends TestCase {
       }
       lastRpcRequestUri = request.uri();
       lastRpcRequestBody = body;
+      if (body.contains("\"robot.exportAttachment\"")) {
+        @SuppressWarnings("unchecked")
+        HttpResponse<T> response = (HttpResponse<T>) new InputStreamHttpResponse(200,
+            new ByteArrayInputStream(rpcResponseBody.getBytes(StandardCharsets.UTF_8)));
+        return response;
+      }
       @SuppressWarnings("unchecked")
       HttpResponse<T> response = (HttpResponse<T>) new StringHttpResponse(200, rpcResponseBody);
       return response;
@@ -397,6 +405,56 @@ public class SupaWaveApiClientTest extends TestCase {
 
     @Override
     public String body() {
+      return body;
+    }
+
+    @Override
+    public Optional<SSLSession> sslSession() {
+      return Optional.empty();
+    }
+
+    @Override
+    public URI uri() {
+      return URI.create("https://wave.example.com");
+    }
+
+    @Override
+    public HttpClient.Version version() {
+      return HttpClient.Version.HTTP_1_1;
+    }
+  }
+
+  private static final class InputStreamHttpResponse implements HttpResponse<InputStream> {
+    private final int statusCode;
+    private final InputStream body;
+
+    private InputStreamHttpResponse(int statusCode, InputStream body) {
+      this.statusCode = statusCode;
+      this.body = body;
+    }
+
+    @Override
+    public int statusCode() {
+      return statusCode;
+    }
+
+    @Override
+    public HttpRequest request() {
+      return null;
+    }
+
+    @Override
+    public Optional<HttpResponse<InputStream>> previousResponse() {
+      return Optional.empty();
+    }
+
+    @Override
+    public HttpHeaders headers() {
+      return HttpHeaders.of(java.util.Collections.emptyMap(), (a, b) -> true);
+    }
+
+    @Override
+    public InputStream body() {
       return body;
     }
 


### PR DESCRIPTION
## Summary
- export Wave attachments from the triggering GPT bot blip and include bounded text-like attachments as markdown context
- transcribe supported audio/video attachments through OpenAI before reply generation
- add focused robot, SupaWave API export, and OpenAI multipart transcription tests

Closes #1266

## Verification
- `python3 scripts/assemble-changelog.py` -> `assembled 381 entries -> wave/config/changelog.json`
- `python3 scripts/validate-changelog.py --changelog wave/config/changelog.json` -> `changelog validation passed`
- `git diff --check` -> exit 0
- `sbt "wave/testOnly org.waveprotocol.examples.robots.gptbot.GptBotRobotTest org.waveprotocol.examples.robots.gptbot.SupaWaveApiClientTest org.waveprotocol.examples.robots.gptbot.OpenAiCodexClientTest"` -> `Passed: Total 34, Failed 0, Errors 0, Passed 34`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPT Bot can include message attachments (audio, video, text) as bounded prompt context; supported audio/video are transcribed (with a default transcription model) and text files are added as formatted context, with size and budget safeguards and graceful fallbacks.

* **Documentation**
  * Added implementation plan, verification journal, and changelog detailing transcription behavior, size limits (skip threshold), prompt-budgeting, model selection, and fallback handling.

* **Tests**
  * Added tests for attachment export, multipart transcription requests, and inclusion of attachment context in prompts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->