### PR TITLE
Fix blip reply and reaction badge overlap

### DIFF
--- a/docs/superpowers/plans/2026-05-19-issue-1280-blip-footer-actions.md
+++ b/docs/superpowers/plans/2026-05-19-issue-1280-blip-footer-actions.md
@@ -1,0 +1,17 @@
+# Issue 1280: Align reply and reaction badges in blip footer
+
+## Root cause
+J2CL renders the same-level reply continuation trigger in a zero-height row after `<wavy-blip-card>`. Reactions are slotted inside that card, so once a reaction row exists the trigger's fixed negative offset is measured from after the reactions and visually lands on top of emoji badges. GWT already uses a hover-revealed continuation overlay, but its reaction row still has extra footer margin/button height that makes reactions read as a separate lower row.
+
+## Implementation plan
+1. Move the J2CL continuation row inside `<wavy-blip-card>` immediately after the blip body and before the reactions slot, preserving the existing event and zero-height behavior.
+2. Compact J2CL reaction controls to the same footer height as the reply overlay, without changing reaction event names or payloads.
+3. Compact the GWT reaction row/button CSS to match the same footer level while leaving `ContinuationIndicator.css` behavior intact.
+4. Add focused Lit regression coverage for continuation-before-reactions and compact reaction controls. Add/update source-level Java/CSS coverage where practical.
+5. Run focused J2CL and Java tests, validate changelog, push PR, and monitor until merged.
+
+## Acceptance checks
+- Reply continuation is anchored to the blip body bottom border, not to the post-reaction footer.
+- Reply continuation does not overlap reaction buttons.
+- Reply continuation does not reserve horizontal space next to reactions.
+- Reaction controls use compact footer geometry in both J2CL and GWT.

--- a/j2cl/lit/src/elements/reaction-row.js
+++ b/j2cl/lit/src/elements/reaction-row.js
@@ -21,17 +21,27 @@ export class ReactionRow extends LitElement {
     .row {
       display: flex;
       flex-wrap: wrap;
-      gap: 6px;
+      gap: 4px;
       align-items: center;
+      min-height: 23px;
+    }
+
+    .row > span {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
     }
 
     button {
       border: 1px solid var(--wavy-signal-violet-soft, var(--shell-color-divider-subtle, #d8e3ee));
       border-radius: var(--wavy-radius-pill, 999px);
-      padding: 5px 9px;
+      min-height: 23px;
+      box-sizing: border-box;
+      padding: 2px 8px;
       background: transparent;
       color: var(--wavy-text-body, inherit);
       font: inherit;
+      line-height: 1;
       cursor: pointer;
       transition: background-color 180ms ease-out, border-color 180ms ease-out,
         box-shadow 180ms ease-out;

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -1012,21 +1012,21 @@ export class WaveBlip extends LitElement {
         <div class="body">
           <slot></slot>
         </div>
+        <div class="continuation-row" data-blip-continuation-host="true">
+          <button
+            type="button"
+            class="continuation-trigger"
+            data-blip-continuation-trigger="true"
+            aria-label=${t("blip.replyOnSameLevel", "Reply on the same level as this blip")}
+            title=${t("blip.replyOnSameLevel", "Reply on the same level as this blip")}
+            @click=${this._onContinuationClick}
+          >
+            <span class="glyph" aria-hidden="true">↩</span>
+          </button>
+        </div>
         <slot name="blip-extension" slot="blip-extension"></slot>
         <slot name="reactions" slot="reactions"></slot>
       </wavy-blip-card>
-      <div class="continuation-row" data-blip-continuation-host="true">
-        <button
-          type="button"
-          class="continuation-trigger"
-          data-blip-continuation-trigger="true"
-          aria-label=${t("blip.replyOnSameLevel", "Reply on the same level as this blip")}
-          title=${t("blip.replyOnSameLevel", "Reply on the same level as this blip")}
-          @click=${this._onContinuationClick}
-        >
-          <span class="glyph" aria-hidden="true">↩</span>
-        </button>
-      </div>
     `;
   }
 }

--- a/j2cl/lit/test/reaction-row.test.js
+++ b/j2cl/lit/test/reaction-row.test.js
@@ -54,6 +54,19 @@ describe("<reaction-row>", () => {
     );
   });
 
+  it("uses compact footer-height controls", async () => {
+    const el = await fixture(html`
+      <reaction-row blip-id="b+compact" .reactions=${reactions}></reaction-row>
+    `);
+    const row = el.renderRoot.querySelector(".row");
+    const add = el.renderRoot.querySelector("[data-reaction-add]");
+    const chip = el.renderRoot.querySelector("[data-reaction-chip]");
+
+    expect(getComputedStyle(row).minHeight).to.equal("23px");
+    expect(getComputedStyle(add).minHeight).to.equal("23px");
+    expect(getComputedStyle(chip).paddingTop).to.equal("2px");
+  });
+
   it("normalizes malformed reaction counts for visible and live text", async () => {
     const el = await fixture(html`
       <reaction-row

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -1,6 +1,7 @@
 import { fixture, expect, html, oneEvent, aTimeout } from "@open-wc/testing";
 import "../src/elements/wave-blip.js";
 import "../src/elements/wave-blip-toolbar.js";
+import "../src/elements/reaction-row.js";
 import "../src/design/wavy-blip-card.js";
 
 function ensureWavyTokensLoaded() {
@@ -356,6 +357,33 @@ describe("<wave-blip>", () => {
     setTimeout(() => button.click(), 0);
     const ev = await oneEvent(el, "wave-blip-continuation-requested");
     expect(ev.detail).to.deep.equal({ blipId: "b4", waveId: "w4" });
+  });
+
+  it("anchors the continuation trigger before reactions so the reply affordance does not cover emoji badges", async () => {
+    const el = await fixture(html`
+      <wave-blip data-blip-id="b4r" data-wave-id="w4" author-name="A">
+        body
+        <reaction-row
+          slot="reactions"
+          blip-id="b4r"
+          .reactions=${[{ emoji: "👍", count: 1 }]}
+        ></reaction-row>
+      </wave-blip>
+    `);
+    await el.updateComplete;
+    const reactionRow = el.querySelector("reaction-row");
+    await reactionRow.updateComplete;
+
+    const host = el.renderRoot.querySelector("[data-blip-continuation-host]");
+    const reactionsSlot = el.renderRoot.querySelector('slot[name="reactions"]');
+    const trigger = el.renderRoot.querySelector("[data-blip-continuation-trigger]");
+    const reactionAdd = reactionRow.renderRoot.querySelector("[data-reaction-add]");
+    expect(
+      host.compareDocumentPosition(reactionsSlot) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).to.not.equal(0);
+    expect(trigger.getBoundingClientRect().bottom).to.be.at.most(
+      reactionAdd.getBoundingClientRect().top
+    );
   });
 
   it("re-emits wave-blip-edit-requested when toolbar Edit fires", async () => {

--- a/wave/config/changelog.d/2026-05-19-issue-1280-blip-footer-actions.json
+++ b/wave/config/changelog.d/2026-05-19-issue-1280-blip-footer-actions.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-19-issue-1280-blip-footer-actions",
+  "version": "J2CL parity",
+  "date": "2026-05-19",
+  "title": "Blip reply and reaction badges no longer overlap",
+  "summary": "The J2CL same-level reply affordance is anchored to the blip body before reactions, and J2CL/GWT reaction controls use compact footer geometry so emoji badges stay aligned with the blip footer.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Prevented the J2CL hover reply affordance from floating over emoji reaction badges.",
+        "Matched compact reaction badge spacing across J2CL and GWT blip footers."
+      ]
+    }
+  ]
+}

--- a/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
+++ b/wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css
@@ -237,12 +237,13 @@
 }
 
 .reactions {
-  margin: 0.35em 0 0.15em 0;
+  margin: 0;
+  padding-top: 2px;
   min-height: 0;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.35em;
+  gap: 4px;
 }
 
 @external .waveReactionChip;
@@ -255,7 +256,10 @@
 .reactions .waveReactionChip,
 .reactions .waveReactionAdd {
   display: inline-flex;
+  align-items: center;
   justify-content: center;
+  min-height: 23px;
+  box-sizing: border-box;
   padding: 2px 8px;
   border: 1px solid #d6dee8;
   border-radius: 999px;

--- a/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelCssCompatibilityTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelCssCompatibilityTest.java
@@ -59,6 +59,8 @@ public final class WavePanelCssCompatibilityTest extends TestCase {
     assertTrue(containsPropertyInBlock(css, ".reactions", "gap: 4px"));
     assertTrue(containsPropertyInBlock(css, ".reactions .waveReactionChip", "min-height: 23px"));
     assertTrue(containsPropertyInBlock(css, ".reactions .waveReactionChip", "box-sizing: border-box"));
+    assertTrue(containsPropertyInBlock(css, ".reactions .waveReactionAdd", "min-height: 23px"));
+    assertTrue(containsPropertyInBlock(css, ".reactions .waveReactionAdd", "box-sizing: border-box"));
   }
 
   public void testTagsCssAvoidsCalcForInlineEditorWidth() throws Exception {

--- a/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelCssCompatibilityTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelCssCompatibilityTest.java
@@ -54,10 +54,11 @@ public final class WavePanelCssCompatibilityTest extends TestCase {
     String css = read(
         "wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css");
 
-    assertTrue(css.contains(".reactions {\n  margin: 0;\n  padding-top: 2px;"));
-    assertTrue(css.contains("gap: 4px;"));
-    assertTrue(css.contains("min-height: 23px;"));
-    assertTrue(css.contains("box-sizing: border-box;"));
+    assertTrue(containsPropertyInBlock(css, ".reactions", "margin: 0"));
+    assertTrue(containsPropertyInBlock(css, ".reactions", "padding-top: 2px"));
+    assertTrue(containsPropertyInBlock(css, ".reactions", "gap: 4px"));
+    assertTrue(containsPropertyInBlock(css, ".reactions .waveReactionChip", "min-height: 23px"));
+    assertTrue(containsPropertyInBlock(css, ".reactions .waveReactionChip", "box-sizing: border-box"));
   }
 
   public void testTagsCssAvoidsCalcForInlineEditorWidth() throws Exception {
@@ -91,5 +92,20 @@ public final class WavePanelCssCompatibilityTest extends TestCase {
     Pattern selectorRulePattern = Pattern.compile(
         "(?m)(^|,)\\s*" + Pattern.quote(selector) + "(?=\\s*(,|\\{))");
     return selectorRulePattern.matcher(cssWithoutComments).find();
+  }
+
+  private boolean containsPropertyInBlock(String css, String selector, String property) {
+    String cssWithoutComments = CSS_COMMENT_PATTERN.matcher(css).replaceAll("");
+    Pattern selectorPattern = Pattern.compile(
+        "(?m)(^|,)\\s*" + Pattern.quote(selector) + "(?=\\s*(,|\\{))");
+    java.util.regex.Matcher m = selectorPattern.matcher(cssWithoutComments);
+    if (!m.find()) return false;
+    int braceStart = cssWithoutComments.indexOf('{', m.end());
+    if (braceStart < 0) return false;
+    int end = cssWithoutComments.indexOf('}', braceStart);
+    if (end < 0) return false;
+    String block = cssWithoutComments.substring(braceStart + 1, end);
+    String normalizedBlock = block.replaceAll("\\s+", " ").trim();
+    return normalizedBlock.contains(property.replaceAll("\\s+", " ").trim());
   }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelCssCompatibilityTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/util/WavePanelCssCompatibilityTest.java
@@ -50,6 +50,16 @@ public final class WavePanelCssCompatibilityTest extends TestCase {
     assertFalse(containsBlockedMediaQuery(css));
   }
 
+  public void testBlipReactionControlsUseCompactFooterGeometry() throws Exception {
+    String css = read(
+        "wave/src/main/resources/org/waveprotocol/wave/client/wavepanel/view/dom/full/Blip.css");
+
+    assertTrue(css.contains(".reactions {\n  margin: 0;\n  padding-top: 2px;"));
+    assertTrue(css.contains("gap: 4px;"));
+    assertTrue(css.contains("min-height: 23px;"));
+    assertTrue(css.contains("box-sizing: border-box;"));
+  }
+
   public void testTagsCssAvoidsCalcForInlineEditorWidth() throws Exception {
     String css = read(
         "wave/src/main/java/org/waveprotocol/wave/client/wavepanel/view/dom/full/Tags.css");


### PR DESCRIPTION
## Summary\n- Anchor the J2CL same-level reply continuation trigger before the reactions slot so the hover reply affordance stays on the blip body border and no longer floats over emoji badges.\n- Compact J2CL reaction controls and GWT Blip.css reaction buttons to a shared 23px footer geometry.\n- Add focused Lit geometry coverage and a Java CSS contract test for the GWT footer reaction geometry.\n\nFixes #1280\n\n## Verification\n- npm test -- --files test/wave-blip.test.js test/reaction-row.test.js (58 passed, 0 failed)\n- sbt 'Test/testOnly org.waveprotocol.box.server.util.WavePanelCssCompatibilityTest' (5 passed, 0 failed)\n- npm run build (button audit OK; esbuild completed)\n- python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json (passed)\n- git diff --check (passed)\n\n## Notes\n- Implementation lane: /Users/vega/devroot/worktrees/codex-blip-actions-overlap\n- Plan: docs/superpowers/plans/2026-05-19-issue-1280-blip-footer-actions.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented reply affordance from overlapping reaction badges by anchoring the reply trigger before reactions and tightening footer geometry; reaction chip/add control sizing and spacing updated for consistent alignment.

* **Tests**
  * Added tests to verify compact footer geometry and correct ordering/positioning of the reply trigger relative to reactions.

* **Documentation**
  * Added doc and changelog entry describing the footer alignment fix and acceptance criteria.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->