### PR TITLE
Fix GWT search initial results when OT search starts

### DIFF
--- a/docs/superpowers/plans/2026-05-19-issue-1279-gwt-search-results.md
+++ b/docs/superpowers/plans/2026-05-19-issue-1279-gwt-search-results.md
@@ -1,0 +1,36 @@
+# Issue 1279: Fix Empty GWT Search Results
+
+## Context
+
+GWT search can show `0-0 of 0` for `in:inbox` while the J2CL UI shows matching results for the same query/account. The server `/search` path is known to return usable results because J2CL renders from that sidecar path. The GWT presenter currently opens an OT search subscription and, when OT search is enabled, can skip the direct HTTP bootstrap.
+
+The reported console `content.js` error is from an injected browser extension script, not an app source path in this repository.
+
+## Root Cause Hypothesis
+
+`SearchPresenter.bootstrapOtSearch()` relies on `SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts()`. Before this fix, that helper returned `false` when OT search was enabled, so GWT could wait only for OT search data. If the OT search channel did not deliver a usable initial snapshot, or fallback was disabled, the GWT search model could render an empty result set even though `/search` had matches.
+
+## Plan
+
+- [x] Add a focused regression test in `SearchPresenterLoadingStateTest` showing GWT should issue an HTTP bootstrap even when OT search is enabled.
+- [x] Verify the test fails on the current implementation.
+- [x] Change the bootstrap policy so OT search start always performs one direct `/search` request for initial visible results.
+- [x] Keep repeating polling disabled while OT is active; this is an initial bootstrap only, not a return to constant polling. Existing `SearchPresenterTest` documents the no-repeating-poll invariant but is excluded from the SBT JVM source set because it depends on webclient/GWT classes.
+- [x] Reconciliation policy: the HTTP bootstrap may populate initial results first; a later OT snapshot for the same query can still replace results through the existing `SimpleSearch.replaceResults(queryText, ...)` path. This matches current behavior for same-query refreshes and avoids stale cross-query replacement because results are keyed with the current `queryText`.
+- [x] Trigger boundary: the direct bootstrap runs each time `bootstrapOtSearch()` starts or restarts a query subscription. It does not schedule repeating HTTP polling; only explicit fallback paths call `startPolling()`.
+- [x] Rerun focused tests for GWT search bootstrap/loading policy.
+- [x] Run local server/browser sanity for `/?view=gwt&q=in%3Ainbox` and compare the search panel against the HTTP-backed result path.
+- [ ] Self-review the diff, then commit, open a PR, and monitor until merged.
+
+## Acceptance Criteria
+
+- GWT search panel no longer depends solely on OT search for initial results.
+- Existing OT live-search behavior and no-repeating-poll behavior remain intact.
+- Regression coverage documents the new bootstrap policy.
+- Local verification evidence is recorded in issue #1279 and the PR.
+
+## Out Of Scope
+
+- Rewriting OT search wavelet delivery.
+- Changing J2CL search rendering.
+- Treating browser extension `content.js` failures as app errors unless app-owned evidence appears.

--- a/wave/config/changelog.d/2026-05-19-gwt-search-http-bootstrap.json
+++ b/wave/config/changelog.d/2026-05-19-gwt-search-http-bootstrap.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-19-gwt-search-http-bootstrap",
+  "version": "PR #1282",
+  "date": "2026-05-19",
+  "title": "Restore initial GWT search results when OT search is enabled",
+  "summary": "The GWT search panel now performs a direct search bootstrap while opening the OT search subscription, so initial results appear even when the live search channel has not delivered a snapshot yet.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Load initial GWT search results from the HTTP search path while keeping OT search available for live updates.",
+        "Keep repeating search polling disabled unless the OT search fallback path explicitly activates it."
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/box/search/SearchBootstrapUiState.java
+++ b/wave/src/main/java/org/waveprotocol/box/search/SearchBootstrapUiState.java
@@ -38,8 +38,14 @@ public final class SearchBootstrapUiState {
     return otSearchEnabled && !useOtSearch && !otSearchTimedOut;
   }
 
-  public static boolean shouldBootstrapViaHttpWhenOtStarts(boolean otSearchEnabled) {
-    return !otSearchEnabled;
+  /**
+   * GWT search must issue a one-shot HTTP search request whenever it opens an
+   * OT search subscription. Keeping this as a shared policy helper gives the
+   * SBT JVM test suite coverage for the bootstrap decision even though the
+   * full GWT {@code SearchPresenter} test is excluded from that source set.
+   */
+  public static boolean shouldBootstrapViaHttpWhenOtStarts() {
+    return true;
   }
 
   public static boolean shouldUseHttpSearchForWindowRequest(

--- a/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
+++ b/wave/src/main/java/org/waveprotocol/box/webclient/search/SearchPresenter.java
@@ -447,7 +447,7 @@ public final class SearchPresenter
       return;
     }
     subscribeToSearchWavelet(queryText);
-    if (SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts(otSearchEnabled)) {
+    if (SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts()) {
       doSearch();
     }
     // Do NOT start the repeating poll here. OT handles live updates. If fallback is enabled,

--- a/wave/src/test/java/org/waveprotocol/box/search/SearchPresenterLoadingStateTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/search/SearchPresenterLoadingStateTest.java
@@ -39,9 +39,8 @@ public final class SearchPresenterLoadingStateTest extends TestCase {
     assertFalse(SearchBootstrapUiState.shouldRetryOtSubscriptionOnReconnect(false, false, false));
   }
 
-  public void testOtBootstrapUsesOtChannelWhenEnabled() {
-    assertFalse(SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts(true));
-    assertTrue(SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts(false));
+  public void testHttpBootstrapAlwaysRunsWhenOtStarts() {
+    assertTrue(SearchBootstrapUiState.shouldBootstrapViaHttpWhenOtStarts());
   }
 
   public void testShowMoreHttpFallbackRequiresExplicitFlagWhenOtNotReady() {


### PR DESCRIPTION
Fixes #1279.

## Summary
- Always run the one-shot HTTP search bootstrap when GWT starts an OT search subscription.
- Keep OT live-search subscription behavior intact; this does not start repeating HTTP polling.
- Add a focused bootstrap-policy regression test and changelog fragment.

## Verification
- Red check first: `sbt "testOnly org.waveprotocol.box.search.SearchPresenterLoadingStateTest"` failed before the production change in `testHttpBootstrapAlwaysRunsWhenOtStarts`.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py`
- `sbt "testOnly org.waveprotocol.box.search.SearchPresenterLoadingStateTest"` -> `Passed: Total 4, Failed 0, Errors 0, Passed 4`
- `bash scripts/worktree-boot.sh --port 9901`
- `PORT=9901 bash scripts/wave-smoke.sh check` -> passed root, `/?view=gwt`, `/healthz`, landing, J2CL root shell, and webclient checks
- Browser sanity: authenticated local user `codex1279@local.net` on `http://127.0.0.1:9901/?view=gwt&q=in%3Ainbox` showed `in:inbox (0-1 of of 1)` and included `/search/?query=in%3Ainbox&index=0&numResults=30` in resource timing.

## Review
- Plan review: approve-with-changes; addressed by documenting trigger boundary and HTTP-vs-OT reconciliation semantics in the plan.
- Implementation review: pass-with-concerns; addressed the concrete helper readability concern by removing the ignored `otSearchEnabled` parameter. Remaining concern is broader integration/race coverage; current JVM source set excludes `SearchPresenterTest` because it depends on webclient/GWT classes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GWT search panel now displays initial results immediately when OT search is enabled (no longer shows "0-0 of 0" while matches exist).

* **Documentation**
  * Added detailed notes describing the observed behavior, acceptance criteria, and the implemented approach.

* **Tests**
  * Updated tests to assert the HTTP bootstrap runs when OT search starts.

* **Chores**
  * Added a changelog entry documenting the bootstrap behavior for initial search results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->