### PR TITLE
Match J2CL reply affordances to GWT

### DIFF
--- a/docs/superpowers/plans/2026-05-19-issue-1283-j2cl-reply-affordance-parity.md
+++ b/docs/superpowers/plans/2026-05-19-issue-1283-j2cl-reply-affordance-parity.md
@@ -1,0 +1,35 @@
+# Issue #1283: J2CL reply affordance parity with GWT
+
+## Goal
+
+Match the J2CL reply entry points to GWT:
+
+- The bottom-of-thread/root affordance is a full-width "Click here to reply" box that continues the current thread.
+- The per-blip hover affordance continues after that blip at the same thread level.
+- The per-blip toolbar reply icon remains the inline-reply action.
+
+## Investigation
+
+GWT renders the bottom reply box through `ReplyBoxViewBuilder` and styles it in `ReplyBox.css` as a dashed, full-width row with an avatar and the `Click here to reply` label. `ReplyIndicatorController` routes `Type.REPLY_BOX` to `actions.addContinuation(threadView)`.
+
+GWT renders per-blip continuation through `ContinuationIndicator.css`; `ReplyIndicatorController` routes `Type.CONTINUATION_INDICATOR` to the same continuation action for that thread.
+
+J2CL already has separate events:
+
+- `wave-root-reply-requested` for the bottom/root continuation trigger.
+- `wave-blip-continuation-requested` for the hover-revealed same-level continuation trigger.
+- `wave-blip-reply-requested` for toolbar inline replies.
+
+The mismatch is visual and test coverage: the J2CL bottom trigger is a compact `+` button instead of the GWT reply box.
+
+## Plan
+
+1. Replace `<wavy-wave-root-reply-trigger>`'s compact `+` button with a GWT-style dashed reply box, avatar, and `Click here to reply` label.
+2. Keep the existing `wave-root-reply-requested` event contract unchanged.
+3. Keep the per-blip continuation trigger and toolbar inline reply paths separate, and add tests that lock that distinction down.
+4. Add a changelog fragment for the user-facing J2CL parity change.
+5. Run focused Lit tests, build, changelog validation, and whitespace checks before PR.
+
+## Self-review notes
+
+The patch should not touch Java compose routing unless tests reveal a real routing bug. Changing routing would risk regressing the already-correct distinction between inline replies and same-level continuations.

--- a/j2cl/lit/src/elements/wavy-wave-root-reply-trigger.js
+++ b/j2cl/lit/src/elements/wavy-wave-root-reply-trigger.js
@@ -116,6 +116,7 @@ export class WavyWaveRootReplyTrigger extends LitElement {
         class="reply-box"
         data-wave-root-reply-trigger
         data-wave-root-reply-box
+        aria-label=${label}
         title=${label}
         @click=${this._onClick}
       >

--- a/j2cl/lit/src/elements/wavy-wave-root-reply-trigger.js
+++ b/j2cl/lit/src/elements/wavy-wave-root-reply-trigger.js
@@ -1,8 +1,9 @@
 import { LitElement, css, html } from "lit";
+import { subscribe } from "../i18n/locale.js";
 import { t } from "../i18n/t.js";
 
 /**
- * <wavy-wave-root-reply-trigger> — F-3.S1 (#1038, R-5.1 step 5) compact
+ * <wavy-wave-root-reply-trigger> — F-3.S1 (#1038, R-5.1 step 5)
  * bottom-of-wave reply affordance (J.1 from the GWT inventory).
  *
  * Mounted at the bottom of the read surface. Clicking dispatches a
@@ -23,34 +24,56 @@ export class WavyWaveRootReplyTrigger extends LitElement {
 
   static styles = css`
     :host {
-      display: inline-flex;
-      padding: var(--wavy-spacing-1, 4px) 0;
+      box-sizing: border-box;
+      display: block;
+      padding: 4px 8px 8px;
     }
     :host([hidden]) {
       display: none;
     }
-    button {
+    .reply-box {
+      align-items: center;
+      box-sizing: border-box;
+      display: flex;
+      gap: 5px;
+      min-height: 38px;
+      width: 100%;
+      margin: 0;
+      overflow: hidden;
+      padding: 6px 10px;
+      border: 1.5px dashed #e2e8f0;
+      border-radius: var(--wavy-radius-md, 8px);
+      background: #f0f4f8;
+      color: #718096;
+      cursor: pointer;
+      font: var(--wavy-type-body, 13px / 1.35 Arial, sans-serif);
+      font-style: italic;
+      text-align: left;
+      transition: border-color 160ms ease, background 160ms ease, color 160ms ease;
+    }
+    .reply-box:hover {
+      border-color: var(--wavy-signal-cyan, #00b4d8);
+      background: rgba(0, 180, 216, 0.04);
+      color: var(--wavy-signal-blue, #0077b6);
+    }
+    .reply-box:focus-visible {
+      outline: none;
+      border-color: var(--wavy-signal-cyan, #00b4d8);
+      box-shadow: var(--wavy-focus-ring, 0 0 0 2px rgba(0, 119, 182, 0.16));
+      color: var(--wavy-signal-blue, #0077b6);
+    }
+    .avatar {
+      flex: 0 0 auto;
       width: 24px;
       height: 24px;
       padding: 0;
-      border-radius: var(--wavy-radius-pill, 999px);
-      border: 1px solid var(--wavy-border-hairline, rgba(34, 211, 238, 0.24));
-      background: var(--wavy-surface-raised, rgba(255, 255, 255, 0.92));
-      color: var(--wavy-signal-cyan, #0077b6);
-      font: var(--wavy-type-label, 0.875rem / 1 sans-serif);
-      font-weight: 700;
-      cursor: pointer;
-      text-align: center;
-    }
-    button:hover {
-      border-color: var(--wavy-signal-cyan, #22d3ee);
-      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
-    }
-    button:focus-visible {
-      outline: none;
-      border-color: var(--wavy-signal-cyan, #22d3ee);
-      box-shadow: var(--wavy-focus-ring, 0 0 0 2px #22d3ee);
-      color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
+      border: 1.5px solid #e2e8f0;
+      border-radius: 50%;
+      background:
+        radial-gradient(circle at 50% 35%, #b7c3d0 0 22%, transparent 23%),
+        radial-gradient(circle at 50% 82%, #b7c3d0 0 36%, transparent 37%),
+        #f8fafc;
+      opacity: 0.5;
     }
   `;
 
@@ -58,6 +81,20 @@ export class WavyWaveRootReplyTrigger extends LitElement {
     super();
     this.waveId = "";
     this.hidden = false;
+    this._unsubscribeLocale = null;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._unsubscribeLocale = subscribe(() => this.requestUpdate());
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._unsubscribeLocale) {
+      this._unsubscribeLocale();
+      this._unsubscribeLocale = null;
+    }
   }
 
   _onClick(event) {
@@ -72,15 +109,19 @@ export class WavyWaveRootReplyTrigger extends LitElement {
   }
 
   render() {
+    const label = t("rootReply.label", "Click here to reply");
     return html`
       <button
         type="button"
+        class="reply-box"
         data-wave-root-reply-trigger
+        data-wave-root-reply-box
         aria-label=${t("rootReply.aria", "Reply to the wave")}
-        title=${t("rootReply.aria", "Reply to the wave")}
+        title=${label}
         @click=${this._onClick}
       >
-        +
+        <span class="avatar" data-wave-root-reply-avatar aria-hidden="true"></span>
+        <span>${label}</span>
       </button>
     `;
   }

--- a/j2cl/lit/src/elements/wavy-wave-root-reply-trigger.js
+++ b/j2cl/lit/src/elements/wavy-wave-root-reply-trigger.js
@@ -116,7 +116,6 @@ export class WavyWaveRootReplyTrigger extends LitElement {
         class="reply-box"
         data-wave-root-reply-trigger
         data-wave-root-reply-box
-        aria-label=${t("rootReply.aria", "Reply to the wave")}
         title=${label}
         @click=${this._onClick}
       >

--- a/j2cl/lit/src/i18n/catalogs/de.js
+++ b/j2cl/lit/src/i18n/catalogs/de.js
@@ -205,7 +205,7 @@ export const de = {
   "waveNav.unpin": "Lösen",
   "waveNav.versionHistory": "Versionsverlauf anzeigen",
 
-  "rootReply.label": "Oben antworten",
+  "rootReply.label": "Hier antworten",
   "rootReply.aria": "Auf die Wave antworten",
 
   "skipLink.label": "Zum Hauptinhalt springen",

--- a/j2cl/lit/src/i18n/catalogs/de.js
+++ b/j2cl/lit/src/i18n/catalogs/de.js
@@ -206,7 +206,6 @@ export const de = {
   "waveNav.versionHistory": "Versionsverlauf anzeigen",
 
   "rootReply.label": "Hier antworten",
-  "rootReply.aria": "Auf die Wave antworten",
 
   "skipLink.label": "Zum Hauptinhalt springen",
 

--- a/j2cl/lit/src/i18n/catalogs/en.js
+++ b/j2cl/lit/src/i18n/catalogs/en.js
@@ -223,7 +223,6 @@ export const en = {
 
   // wavy-wave-root-reply-trigger.js
   "rootReply.label": "Click here to reply",
-  "rootReply.aria": "Reply to the wave",
 
   // shell-skip-link.js
   "skipLink.label": "Skip to main content",

--- a/j2cl/lit/src/i18n/catalogs/en.js
+++ b/j2cl/lit/src/i18n/catalogs/en.js
@@ -222,7 +222,7 @@ export const en = {
   "waveNav.versionHistory": "Show version history",
 
   // wavy-wave-root-reply-trigger.js
-  "rootReply.label": "Reply at top",
+  "rootReply.label": "Click here to reply",
   "rootReply.aria": "Reply to the wave",
 
   // shell-skip-link.js

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -359,6 +359,43 @@ describe("<wave-blip>", () => {
     expect(ev.detail).to.deep.equal({ blipId: "b4", waveId: "w4" });
   });
 
+  it("keeps toolbar reply inline while the hover affordance continues the blip thread", async () => {
+    const el = await fixture(html`
+      <wave-blip
+        data-blip-id="b4split"
+        data-wave-id="w4"
+        author-name="A"
+        data-blip-doc-size="11"
+      ></wave-blip>
+    `);
+    await el.updateComplete;
+    const toolbar = el.renderRoot.querySelector("wave-blip-toolbar");
+    await toolbar.updateComplete;
+    const replyBtn = toolbar.renderRoot.querySelector("[data-toolbar-action='reply']");
+    const continuationBtn = el.renderRoot.querySelector("[data-blip-continuation-trigger]");
+    expect(replyBtn).to.exist;
+    expect(continuationBtn).to.exist;
+
+    const eventTypes = [];
+    el.addEventListener("wave-blip-reply-requested", (event) => {
+      eventTypes.push(event.type);
+      expect(event.detail.blipId).to.equal("b4split");
+      expect(event.detail.parentBodyItemCount).to.equal(11);
+    });
+    el.addEventListener("wave-blip-continuation-requested", (event) => {
+      eventTypes.push(event.type);
+      expect(event.detail).to.deep.equal({ blipId: "b4split", waveId: "w4" });
+    });
+
+    replyBtn.click();
+    continuationBtn.click();
+    await el.updateComplete;
+    expect(eventTypes).to.deep.equal([
+      "wave-blip-reply-requested",
+      "wave-blip-continuation-requested"
+    ]);
+  });
+
   it("anchors the continuation trigger before reactions so the reply affordance does not cover emoji badges", async () => {
     const el = await fixture(html`
       <wave-blip data-blip-id="b4r" data-wave-id="w4" author-name="A">

--- a/j2cl/lit/test/wavy-wave-root-reply-trigger.test.js
+++ b/j2cl/lit/test/wavy-wave-root-reply-trigger.test.js
@@ -29,7 +29,7 @@ describe("<wavy-wave-root-reply-trigger>", () => {
     expect(button.textContent.trim()).to.equal("Click here to reply");
     expect(button.matches("[data-wave-root-reply-box]")).to.be.true;
     expect(button.querySelector("[data-wave-root-reply-avatar]")).to.exist;
-    expect(button.getAttribute("aria-label")).to.equal("Reply to the wave");
+    expect(button.getAttribute("aria-label")).to.be.null;
     expect(button.getAttribute("title")).to.equal("Click here to reply");
     const hostStyle = getComputedStyle(el);
     const buttonStyle = getComputedStyle(button);
@@ -49,7 +49,7 @@ describe("<wavy-wave-root-reply-trigger>", () => {
     await el.updateComplete;
     expect(button.textContent.trim()).to.equal("Hier antworten");
     expect(button.getAttribute("title")).to.equal("Hier antworten");
-    expect(button.getAttribute("aria-label")).to.equal("Auf die Wave antworten");
+    expect(button.getAttribute("aria-label")).to.be.null;
   });
 
   it("emits wave-root-reply-requested with the wave id on click", async () => {

--- a/j2cl/lit/test/wavy-wave-root-reply-trigger.test.js
+++ b/j2cl/lit/test/wavy-wave-root-reply-trigger.test.js
@@ -1,4 +1,5 @@
 import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import { setLocale, _resetLocaleForTesting } from "../src/i18n/locale.js";
 import "../src/elements/wavy-wave-root-reply-trigger.js";
 
 function ensureWavyTokensLoaded() {
@@ -13,15 +14,42 @@ function ensureWavyTokensLoaded() {
 before(() => ensureWavyTokensLoaded());
 
 describe("<wavy-wave-root-reply-trigger>", () => {
-  it("renders the J.1 compact reply button", async () => {
+  beforeEach(() => _resetLocaleForTesting());
+  afterEach(() => _resetLocaleForTesting());
+
+  it("renders the GWT-style bottom reply box", async () => {
+    const wrapper = await fixture(html`
+      <div style="width: 320px">
+        <wavy-wave-root-reply-trigger wave-id="w1"></wavy-wave-root-reply-trigger>
+      </div>
+    `);
+    const el = wrapper.querySelector("wavy-wave-root-reply-trigger");
+    const button = el.renderRoot.querySelector("[data-wave-root-reply-trigger]");
+    expect(button).to.exist;
+    expect(button.textContent.trim()).to.equal("Click here to reply");
+    expect(button.matches("[data-wave-root-reply-box]")).to.be.true;
+    expect(button.querySelector("[data-wave-root-reply-avatar]")).to.exist;
+    expect(button.getAttribute("aria-label")).to.equal("Reply to the wave");
+    expect(button.getAttribute("title")).to.equal("Click here to reply");
+    const hostStyle = getComputedStyle(el);
+    const buttonStyle = getComputedStyle(button);
+    expect(hostStyle.display).to.equal("block");
+    expect(button.getBoundingClientRect().width).to.be.greaterThan(280);
+    expect(buttonStyle.borderStyle).to.equal("dashed");
+    expect(buttonStyle.fontStyle).to.equal("italic");
+  });
+
+  it("rerenders the visible label when the locale changes", async () => {
     const el = await fixture(html`
       <wavy-wave-root-reply-trigger wave-id="w1"></wavy-wave-root-reply-trigger>
     `);
     const button = el.renderRoot.querySelector("[data-wave-root-reply-trigger]");
-    expect(button).to.exist;
-    expect(button.textContent.trim()).to.equal("+");
-    expect(button.getAttribute("aria-label")).to.equal("Reply to the wave");
-    expect(button.getAttribute("title")).to.equal("Reply to the wave");
+    expect(button.textContent.trim()).to.equal("Click here to reply");
+    setLocale("de");
+    await el.updateComplete;
+    expect(button.textContent.trim()).to.equal("Hier antworten");
+    expect(button.getAttribute("title")).to.equal("Hier antworten");
+    expect(button.getAttribute("aria-label")).to.equal("Auf die Wave antworten");
   });
 
   it("emits wave-root-reply-requested with the wave id on click", async () => {

--- a/j2cl/lit/test/wavy-wave-root-reply-trigger.test.js
+++ b/j2cl/lit/test/wavy-wave-root-reply-trigger.test.js
@@ -29,7 +29,7 @@ describe("<wavy-wave-root-reply-trigger>", () => {
     expect(button.textContent.trim()).to.equal("Click here to reply");
     expect(button.matches("[data-wave-root-reply-box]")).to.be.true;
     expect(button.querySelector("[data-wave-root-reply-avatar]")).to.exist;
-    expect(button.getAttribute("aria-label")).to.be.null;
+    expect(button.getAttribute("aria-label")).to.equal("Click here to reply");
     expect(button.getAttribute("title")).to.equal("Click here to reply");
     const hostStyle = getComputedStyle(el);
     const buttonStyle = getComputedStyle(button);
@@ -49,7 +49,7 @@ describe("<wavy-wave-root-reply-trigger>", () => {
     await el.updateComplete;
     expect(button.textContent.trim()).to.equal("Hier antworten");
     expect(button.getAttribute("title")).to.equal("Hier antworten");
-    expect(button.getAttribute("aria-label")).to.be.null;
+    expect(button.getAttribute("aria-label")).to.equal("Hier antworten");
   });
 
   it("emits wave-root-reply-requested with the wave id on click", async () => {

--- a/wave/config/changelog.d/2026-05-19-issue-1283-j2cl-reply-affordance-parity.json
+++ b/wave/config/changelog.d/2026-05-19-issue-1283-j2cl-reply-affordance-parity.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-19-issue-1283-j2cl-reply-affordance-parity",
+  "version": "J2CL parity",
+  "date": "2026-05-19",
+  "title": "J2CL bottom reply control now matches GWT",
+  "summary": "The J2CL bottom reply affordance now appears as the GWT-style \"Click here to reply\" row while the per-blip toolbar reply icon remains dedicated to inline replies.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Changed the J2CL bottom-of-thread reply trigger from a compact plus button to a full-width dashed reply row.",
+        "Added regression coverage that keeps bottom continuation, per-blip continuation, and inline reply actions distinct."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #1283

## Summary
- replace the J2CL bottom/root `+` reply button with a GWT-style full-width `Click here to reply` row
- keep the root continuation, per-blip same-level continuation, and toolbar inline-reply event paths separate
- add regression coverage for the bottom reply box, locale rerendering, label-in-name accessibility, and the inline-vs-continuation split

## Plan
- `docs/superpowers/plans/2026-05-19-issue-1283-j2cl-reply-affordance-parity.md`

## Commits
- `77c6be24f` Match J2CL reply affordances to GWT
- `63a02c70c` fix(a11y): satisfy WCAG 2.5.3 label-in-name for root reply button
- `31990e558` fix(a11y): restore aria-label to satisfy audit-buttons and WCAG 2.5.3

## Verification
- `cd j2cl/lit && test -d node_modules || npm ci`
- `cd j2cl/lit && npm test -- --files test/wavy-wave-root-reply-trigger.test.js test/wavy-composer-inline-mount.test.js test/wave-blip.test.js` — 57 passed, 0 failed
- `cd j2cl/lit && npm run build` — OK, including `audit-buttons: OK`
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json && git diff --check` — OK

## Self-review
- No Java compose routing was changed; J2CL already has distinct events for root continuation, per-blip continuation, and inline reply.
- Removed the initial avatar image URL approach after tests exposed a new 404, replacing it with a CSS-only avatar placeholder.
- Addressed review feedback by subscribing the root reply trigger to locale updates and setting the button aria-label to the same localized visible label.
