### PR TITLE
Add user opt-in for J2CL root shell

### DIFF
--- a/wave/config/changelog.d/2026-05-19-j2cl-user-opt-in.json
+++ b/wave/config/changelog.d/2026-05-19-j2cl-user-opt-in.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-19-j2cl-user-opt-in",
+  "version": "Unreleased",
+  "date": "2026-05-19",
+  "title": "J2CL user opt-in preference",
+  "summary": "Users can choose whether the default Wave experience opens the J2CL beta or the classic GWT client, while explicit view links remain reversible.",
+  "sections": [
+    {
+      "type": "feature",
+      "items": [
+        "Added a Wave Client preference in Account Settings with Default, J2CL beta, and Classic GWT choices; the saved preference controls only default Wave routes and keeps ?view=j2cl-root and ?view=gwt available for direct switching."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AccountSettingsServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AccountSettingsServlet.java
@@ -139,10 +139,11 @@ public final class AccountSettingsServlet extends HttpServlet {
       caller.setWaveClientPreference(preference);
       accountStore.putAccount(caller);
       setJsonUtf8(resp);
+      String redirectTarget = req.getContextPath() + waveClientRedirectTarget(preference);
       resp.getWriter().write("{\"ok\":true,\"preference\":\""
-          + caller.getWaveClientPreference()
+          + jsonEscape(preference)
           + "\",\"redirectTarget\":\""
-          + waveClientRedirectTarget(caller.getWaveClientPreference())
+          + jsonEscape(redirectTarget)
           + "\"}");
     } catch (PersistenceException e) {
       LOG.severe("Failed to update Wave client preference for " + caller.getId(), e);
@@ -369,6 +370,11 @@ public final class AccountSettingsServlet extends HttpServlet {
       return null; // null value
     }
     return null;
+  }
+
+  private static String jsonEscape(String s) {
+    if (s == null) return "";
+    return s.replace("\\", "\\\\").replace("\"", "\\\"");
   }
 
   private static void setJsonUtf8(HttpServletResponse resp) {

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AccountSettingsServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AccountSettingsServlet.java
@@ -54,6 +54,7 @@ import java.io.IOException;
  * <ul>
  *   <li>{@code GET /account/settings} - Renders the account settings page</li>
  *   <li>{@code POST /account/settings/email} - Updates the user's email</li>
+ *   <li>{@code POST /account/settings/wave-client} - Updates the default Wave client</li>
  *   <li>{@code POST /account/settings/request-password-reset} - Sends a password reset email</li>
  * </ul>
  */
@@ -120,11 +121,52 @@ public final class AccountSettingsServlet extends HttpServlet {
 
     if ("/email".equals(pathInfo)) {
       handleUpdateEmail(req, resp, caller);
+    } else if ("/wave-client".equals(pathInfo)) {
+      handleUpdateWaveClient(req, resp, caller);
     } else if ("/request-password-reset".equals(pathInfo)) {
       handleRequestPasswordReset(req, resp, caller);
     } else {
       sendJsonError(resp, HttpServletResponse.SC_NOT_FOUND, "Unknown action");
     }
+  }
+
+  private void handleUpdateWaveClient(HttpServletRequest req, HttpServletResponse resp,
+      HumanAccountData caller) throws IOException {
+    String body = readBody(req);
+    String preference = normalizeWaveClientPreference(extractJsonField(body, "preference"));
+
+    try {
+      caller.setWaveClientPreference(preference);
+      accountStore.putAccount(caller);
+      setJsonUtf8(resp);
+      resp.getWriter().write("{\"ok\":true,\"preference\":\""
+          + caller.getWaveClientPreference()
+          + "\",\"redirectTarget\":\""
+          + waveClientRedirectTarget(caller.getWaveClientPreference())
+          + "\"}");
+    } catch (PersistenceException e) {
+      LOG.severe("Failed to update Wave client preference for " + caller.getId(), e);
+      sendJsonError(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+          "Failed to save Wave client preference");
+    }
+  }
+
+  private static String normalizeWaveClientPreference(String preference) {
+    if (HumanAccountData.WAVE_CLIENT_J2CL_ROOT.equals(preference)
+        || HumanAccountData.WAVE_CLIENT_GWT.equals(preference)) {
+      return preference;
+    }
+    return HumanAccountData.WAVE_CLIENT_DEFAULT;
+  }
+
+  private static String waveClientRedirectTarget(String preference) {
+    if (HumanAccountData.WAVE_CLIENT_J2CL_ROOT.equals(preference)) {
+      return "/?view=j2cl-root";
+    }
+    if (HumanAccountData.WAVE_CLIENT_GWT.equals(preference)) {
+      return "/?view=gwt";
+    }
+    return "/";
   }
 
   // =========================================================================

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AccountSettingsServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AccountSettingsServlet.java
@@ -41,6 +41,8 @@ import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.util.logging.Log;
 
 import java.io.IOException;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 /**
  * Servlet for the Account Settings page, allowing users to:
@@ -138,17 +140,23 @@ public final class AccountSettingsServlet extends HttpServlet {
     try {
       caller.setWaveClientPreference(preference);
       accountStore.putAccount(caller);
-      setJsonUtf8(resp);
-      String redirectTarget = req.getContextPath() + waveClientRedirectTarget(preference);
-      resp.getWriter().write("{\"ok\":true,\"preference\":\""
-          + jsonEscape(preference)
-          + "\",\"redirectTarget\":\""
-          + jsonEscape(redirectTarget)
-          + "\"}");
     } catch (PersistenceException e) {
       LOG.severe("Failed to update Wave client preference for " + caller.getId(), e);
       sendJsonError(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
           "Failed to save Wave client preference");
+      return;
+    }
+    try {
+      setJsonUtf8(resp);
+      resp.getWriter().write(new JSONObject()
+          .put("ok", true)
+          .put("preference", caller.getWaveClientPreference())
+          .put("redirectTarget", waveClientRedirectTarget(
+              caller.getWaveClientPreference(), req.getContextPath()))
+          .toString());
+    } catch (JSONException e) {
+      LOG.severe("Failed to serialize wave client preference response", e);
+      resp.getWriter().write("{\"ok\":true}");
     }
   }
 
@@ -160,14 +168,15 @@ public final class AccountSettingsServlet extends HttpServlet {
     return HumanAccountData.WAVE_CLIENT_DEFAULT;
   }
 
-  private static String waveClientRedirectTarget(String preference) {
+  private static String waveClientRedirectTarget(String preference, String contextPath) {
+    String base = contextPath != null ? contextPath : "";
     if (HumanAccountData.WAVE_CLIENT_J2CL_ROOT.equals(preference)) {
-      return "/?view=j2cl-root";
+      return base + "/?view=j2cl-root";
     }
     if (HumanAccountData.WAVE_CLIENT_GWT.equals(preference)) {
-      return "/?view=gwt";
+      return base + "/?view=gwt";
     }
-    return "/";
+    return base.isEmpty() ? "/" : base + "/";
   }
 
   // =========================================================================
@@ -370,11 +379,6 @@ public final class AccountSettingsServlet extends HttpServlet {
       return null; // null value
     }
     return null;
-  }
-
-  private static String jsonEscape(String s) {
-    if (s == null) return "";
-    return s.replace("\\", "\\\\").replace("\"", "\\\"");
   }
 
   private static void setJsonUtf8(HttpServletResponse resp) {

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AccountSettingsServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/AccountSettingsServlet.java
@@ -148,12 +148,7 @@ public final class AccountSettingsServlet extends HttpServlet {
     }
     try {
       setJsonUtf8(resp);
-      resp.getWriter().write(new JSONObject()
-          .put("ok", true)
-          .put("preference", caller.getWaveClientPreference())
-          .put("redirectTarget", waveClientRedirectTarget(
-              caller.getWaveClientPreference(), req.getContextPath()))
-          .toString());
+      resp.getWriter().write(waveClientResponseJson(preference, req.getContextPath()));
     } catch (JSONException e) {
       LOG.severe("Failed to serialize wave client preference response", e);
       resp.getWriter().write("{\"ok\":true}");
@@ -166,6 +161,23 @@ public final class AccountSettingsServlet extends HttpServlet {
       return preference;
     }
     return HumanAccountData.WAVE_CLIENT_DEFAULT;
+  }
+
+  private static String waveClientResponseJson(String preference, String contextPath)
+      throws JSONException {
+    String responsePreference;
+    if (HumanAccountData.WAVE_CLIENT_J2CL_ROOT.equals(preference)) {
+      responsePreference = HumanAccountData.WAVE_CLIENT_J2CL_ROOT;
+    } else if (HumanAccountData.WAVE_CLIENT_GWT.equals(preference)) {
+      responsePreference = HumanAccountData.WAVE_CLIENT_GWT;
+    } else {
+      responsePreference = HumanAccountData.WAVE_CLIENT_DEFAULT;
+    }
+    return new JSONObject()
+        .put("ok", true)
+        .put("preference", responsePreference)
+        .put("redirectTarget", waveClientRedirectTarget(responsePreference, contextPath))
+        .toString();
   }
 
   private static String waveClientRedirectTarget(String preference, String contextPath) {

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -10289,6 +10289,18 @@ public final class HtmlRenderer {
     sb.append("  font-size: 13px; color: ").append(WAVE_TEXT_MUTED).append(";\n");
     sb.append("  margin-bottom: 16px; line-height: 1.5;\n");
     sb.append("}\n");
+    sb.append(".choice-list { display: grid; gap: 10px; }\n");
+    sb.append(".choice-option {\n");
+    sb.append("  display: flex; gap: 10px; align-items: flex-start;\n");
+    sb.append("  padding: 12px; border: 1.5px solid ").append(WAVE_BORDER).append(";\n");
+    sb.append("  border-radius: 8px; background: #fafbfc; cursor: pointer;\n");
+    sb.append("}\n");
+    sb.append(".choice-option:hover { border-color: ").append(WAVE_PRIMARY).append("; background: #fff; }\n");
+    sb.append(".choice-option input { margin-top: 3px; }\n");
+    sb.append(".choice-title { display:block; font-size:14px; font-weight:600; color:")
+        .append(WAVE_TEXT).append("; }\n");
+    sb.append(".choice-desc { display:block; font-size:12px; color:")
+        .append(WAVE_TEXT_MUTED).append("; margin-top:2px; line-height:1.4; }\n");
 
     sb.append("</style>\n");
     sb.append("<style>\n").append(renderSharedTopBarCss()).append("</style>\n");
@@ -10328,6 +10340,28 @@ public final class HtmlRenderer {
     sb.append("      <span class=\"info-value\">").append(escapeHtml(regDisplay)).append("</span>\n");
     sb.append("    </div>\n");
 
+    sb.append("  </div>\n"); // .settings-card
+
+    // ==== Wave Client Card ====
+    String waveClientPreference = account.getWaveClientPreference();
+    boolean waveClientDefault = HumanAccountData.WAVE_CLIENT_DEFAULT.equals(waveClientPreference);
+    boolean waveClientJ2cl = HumanAccountData.WAVE_CLIENT_J2CL_ROOT.equals(waveClientPreference);
+    boolean waveClientGwt = HumanAccountData.WAVE_CLIENT_GWT.equals(waveClientPreference);
+    sb.append("  <div class=\"settings-card\">\n");
+    sb.append("    <h2>Wave Client</h2>\n");
+    sb.append("    <div class=\"section-desc\">Choose which Wave interface opens by default. Direct J2CL and classic links continue to work.</div>\n");
+    sb.append("    <div class=\"choice-list\" id=\"waveClientChoices\">\n");
+    appendWaveClientChoice(sb, "waveClientDefault", HumanAccountData.WAVE_CLIENT_DEFAULT,
+        "Use server default", "Follow the current rollout setting for your account.",
+        waveClientDefault);
+    appendWaveClientChoice(sb, "waveClientJ2cl", HumanAccountData.WAVE_CLIENT_J2CL_ROOT,
+        "Use J2CL beta", "Open the new J2CL interface by default.",
+        waveClientJ2cl);
+    appendWaveClientChoice(sb, "waveClientGwt", HumanAccountData.WAVE_CLIENT_GWT,
+        "Use classic GWT", "Open the classic interface by default.",
+        waveClientGwt);
+    sb.append("    </div>\n");
+    sb.append("    <button type=\"button\" class=\"btn-primary\" id=\"saveWaveClientBtn\" style=\"margin-top:16px;\">Save Wave Client</button>\n");
     sb.append("  </div>\n"); // .settings-card
 
     // ==== Email Card ====
@@ -10394,6 +10428,32 @@ public final class HtmlRenderer {
     sb.append("    setTimeout(function() { toast.className = 'toast'; }, 4000);\n");
     sb.append("  }\n\n");
 
+    // Save Wave client preference
+    sb.append("  var saveWaveClientBtn = document.getElementById('saveWaveClientBtn');\n");
+    sb.append("  if (saveWaveClientBtn) {\n");
+    sb.append("    saveWaveClientBtn.addEventListener('click', function() {\n");
+    sb.append("      var btn = this;\n");
+    sb.append("      var selected = document.querySelector('input[name=\"waveClientPreference\"]:checked');\n");
+    sb.append("      if (!selected) return;\n");
+    sb.append("      btn.disabled = true;\n");
+    sb.append("      fetch('/account/settings/wave-client', {\n");
+    sb.append("        method: 'POST',\n");
+    sb.append("        headers: { 'Content-Type': 'application/json' },\n");
+    sb.append("        body: JSON.stringify({ preference: selected.value })\n");
+    sb.append("      })\n");
+    sb.append("      .then(function(r) { return r.json(); })\n");
+    sb.append("      .then(function(d) {\n");
+    sb.append("        if (d.ok) {\n");
+    sb.append("          showToast('Wave client preference saved', 'success');\n");
+    sb.append("        } else {\n");
+    sb.append("          showToast(d.error || 'Failed to save Wave client preference', 'error');\n");
+    sb.append("        }\n");
+    sb.append("        btn.disabled = false;\n");
+    sb.append("      })\n");
+    sb.append("      .catch(function() { showToast('Failed to save Wave client preference', 'error'); btn.disabled = false; });\n");
+    sb.append("    });\n");
+    sb.append("  }\n\n");
+
     // Save email
     sb.append("  var saveEmailBtn = document.getElementById('saveEmailBtn');\n");
     sb.append("  if (saveEmailBtn) {\n");
@@ -10458,6 +10518,25 @@ public final class HtmlRenderer {
 
     sb.append("</body>\n</html>\n");
     return sb.toString();
+  }
+
+  private static void appendWaveClientChoice(StringBuilder sb, String id, String value,
+      String title, String description, boolean checked) {
+    sb.append("      <label class=\"choice-option\" for=\"").append(id).append("\">\n");
+    sb.append("        <input type=\"radio\" id=\"").append(id)
+        .append("\" name=\"waveClientPreference\" value=\"")
+        .append(escapeHtml(value))
+        .append("\"");
+    if (checked) {
+      sb.append(" checked");
+    }
+    sb.append(">\n");
+    sb.append("        <span><span class=\"choice-title\">")
+        .append(escapeHtml(title))
+        .append("</span><span class=\"choice-desc\">")
+        .append(escapeHtml(description))
+        .append("</span></span>\n");
+    sb.append("      </label>\n");
   }
 
   // =========================================================================

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -10427,6 +10427,8 @@ public final class HtmlRenderer {
     sb.append("    toast.className = 'toast toast-' + type + ' show';\n");
     sb.append("    setTimeout(function() { toast.className = 'toast'; }, 4000);\n");
     sb.append("  }\n\n");
+    sb.append("  var ctx = ").append(escapeJsonString(contextPath == null ? "" : contextPath))
+        .append(";\n");
 
     // Save Wave client preference
     sb.append("  var saveWaveClientBtn = document.getElementById('saveWaveClientBtn');\n");
@@ -10436,7 +10438,7 @@ public final class HtmlRenderer {
     sb.append("      var selected = document.querySelector('input[name=\"waveClientPreference\"]:checked');\n");
     sb.append("      if (!selected) return;\n");
     sb.append("      btn.disabled = true;\n");
-    sb.append("      fetch('/account/settings/wave-client', {\n");
+    sb.append("      fetch(ctx + '/account/settings/wave-client', {\n");
     sb.append("        method: 'POST',\n");
     sb.append("        headers: { 'Content-Type': 'application/json' },\n");
     sb.append("        body: JSON.stringify({ preference: selected.value })\n");
@@ -10461,7 +10463,7 @@ public final class HtmlRenderer {
     sb.append("      var btn = this;\n");
     sb.append("      btn.disabled = true;\n");
     sb.append("      var email = document.getElementById('emailInput').value.trim();\n");
-    sb.append("      fetch('/account/settings/email', {\n");
+    sb.append("      fetch(ctx + '/account/settings/email', {\n");
     sb.append("        method: 'POST',\n");
     sb.append("        headers: { 'Content-Type': 'application/json' },\n");
     sb.append("        body: JSON.stringify({ email: email || null })\n");
@@ -10487,7 +10489,7 @@ public final class HtmlRenderer {
     sb.append("      var btn = this;\n");
     sb.append("      btn.disabled = true;\n");
     sb.append("      btn.textContent = 'Sending...';\n");
-    sb.append("      fetch('/account/settings/request-password-reset', {\n");
+    sb.append("      fetch(ctx + '/account/settings/request-password-reset', {\n");
     sb.append("        method: 'POST',\n");
     sb.append("        headers: { 'Content-Type': 'application/json' },\n");
     sb.append("        body: '{}'\n");

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -10352,13 +10352,13 @@ public final class HtmlRenderer {
     sb.append("    <div class=\"section-desc\">Choose which Wave interface opens by default. Direct J2CL and classic links continue to work.</div>\n");
     sb.append("    <div class=\"choice-list\" id=\"waveClientChoices\">\n");
     appendWaveClientChoice(sb, "waveClientDefault", HumanAccountData.WAVE_CLIENT_DEFAULT,
-        "Use server default", "Follow the current rollout setting for your account.",
+        "Default", "Follow the current rollout setting for your account.",
         waveClientDefault);
     appendWaveClientChoice(sb, "waveClientJ2cl", HumanAccountData.WAVE_CLIENT_J2CL_ROOT,
-        "Use J2CL beta", "Open the new J2CL interface by default.",
+        "J2CL beta", "Open the new J2CL interface by default.",
         waveClientJ2cl);
     appendWaveClientChoice(sb, "waveClientGwt", HumanAccountData.WAVE_CLIENT_GWT,
-        "Use classic GWT", "Open the classic interface by default.",
+        "Classic GWT", "Open the classic interface by default.",
         waveClientGwt);
     sb.append("    </div>\n");
     sb.append("    <button type=\"button\" class=\"btn-primary\" id=\"saveWaveClientBtn\" style=\"margin-top:16px;\">Save Wave Client</button>\n");

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
@@ -49,6 +49,7 @@ import org.waveprotocol.box.server.authentication.WebSession;
 import org.waveprotocol.box.server.authentication.WebSessions;
 import org.waveprotocol.box.server.persistence.AccountStore;
 import org.waveprotocol.box.server.persistence.FeatureFlagService;
+import org.waveprotocol.box.server.persistence.PersistenceException;
 import org.waveprotocol.box.server.rpc.render.J2clSelectedWaveSnapshotRenderer;
 import org.waveprotocol.box.server.rpc.render.WavePreRenderer;
 import org.waveprotocol.box.server.util.RandomBase64Generator;
@@ -156,6 +157,10 @@ public class WaveClientServlet extends HttpServlet {
     String requestedView = resolveRequestedView(request);
     boolean j2clRootBootstrapEnabled =
         featureFlagService.isEnabled("j2cl-root-bootstrap", id != null ? id.getAddress() : null);
+    String waveClientPreference = resolveWaveClientPreference(id);
+    boolean explicitJ2clPreference =
+        HumanAccountData.WAVE_CLIENT_J2CL_ROOT.equals(waveClientPreference);
+    boolean explicitGwtPreference = HumanAccountData.WAVE_CLIENT_GWT.equals(waveClientPreference);
 
     String contextRoot = request.getContextPath();
     String requestUri = request.getRequestURI();
@@ -179,7 +184,9 @@ public class WaveClientServlet extends HttpServlet {
     }
 
     if (VIEW_J2CL_ROOT.equals(requestedView)
-        || (StringUtils.isEmpty(requestedView) && j2clRootBootstrapEnabled)) {
+        || (StringUtils.isEmpty(requestedView)
+            && !explicitGwtPreference
+            && (explicitJ2clPreference || j2clRootBootstrapEnabled))) {
       // F-2 slice 6 (#1058, Part B): signed-in read-surface preview
       // route reachable at ?view=j2cl-root&q=read-surface-preview. The
       // route is server-only — no WaveletProvider lookup, no live
@@ -650,6 +657,21 @@ public class WaveClientServlet extends HttpServlet {
       returnTarget.append("&wave=").append(encodeReturnTargetComponent(wave)); // codeql[java/xss]
     }
     return returnTarget.toString();
+  }
+
+  private String resolveWaveClientPreference(ParticipantId id) {
+    if (id == null) {
+      return HumanAccountData.WAVE_CLIENT_DEFAULT;
+    }
+    try {
+      AccountData account = accountStore.getAccount(id);
+      if (account != null && account.isHuman()) {
+        return account.asHuman().getWaveClientPreference();
+      }
+    } catch (PersistenceException e) {
+      LOG.warning("Failed to read wave client preference for " + id, e);
+    }
+    return HumanAccountData.WAVE_CLIENT_DEFAULT;
   }
 
   private static String encodeReturnTargetComponent(String value) {

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
@@ -179,13 +179,18 @@ public class WaveClientServlet extends HttpServlet {
       return;
     }
 
-    String waveClientPreference = resolveWaveClientPreference(id);
-    boolean explicitJ2clPreference =
-        HumanAccountData.WAVE_CLIENT_J2CL_ROOT.equals(waveClientPreference);
-    boolean explicitGwtPreference = HumanAccountData.WAVE_CLIENT_GWT.equals(waveClientPreference);
+    boolean defaultRoute = StringUtils.isEmpty(requestedView);
+    boolean explicitJ2clPreference = false;
+    boolean explicitGwtPreference = false;
+    if (defaultRoute) {
+      String waveClientPreference = resolveWaveClientPreference(id);
+      explicitJ2clPreference =
+          HumanAccountData.WAVE_CLIENT_J2CL_ROOT.equals(waveClientPreference);
+      explicitGwtPreference = HumanAccountData.WAVE_CLIENT_GWT.equals(waveClientPreference);
+    }
 
     if (VIEW_J2CL_ROOT.equals(requestedView)
-        || (StringUtils.isEmpty(requestedView)
+        || (defaultRoute
             && !explicitGwtPreference
             && (explicitJ2clPreference || j2clRootBootstrapEnabled))) {
       // F-2 slice 6 (#1058, Part B): signed-in read-surface preview

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/WaveClientServlet.java
@@ -157,10 +157,6 @@ public class WaveClientServlet extends HttpServlet {
     String requestedView = resolveRequestedView(request);
     boolean j2clRootBootstrapEnabled =
         featureFlagService.isEnabled("j2cl-root-bootstrap", id != null ? id.getAddress() : null);
-    String waveClientPreference = resolveWaveClientPreference(id);
-    boolean explicitJ2clPreference =
-        HumanAccountData.WAVE_CLIENT_J2CL_ROOT.equals(waveClientPreference);
-    boolean explicitGwtPreference = HumanAccountData.WAVE_CLIENT_GWT.equals(waveClientPreference);
 
     String contextRoot = request.getContextPath();
     String requestUri = request.getRequestURI();
@@ -182,6 +178,11 @@ public class WaveClientServlet extends HttpServlet {
       response.getWriter().write(HtmlRenderer.renderLandingPage(domain, analyticsAccount));
       return;
     }
+
+    String waveClientPreference = resolveWaveClientPreference(id);
+    boolean explicitJ2clPreference =
+        HumanAccountData.WAVE_CLIENT_J2CL_ROOT.equals(waveClientPreference);
+    boolean explicitGwtPreference = HumanAccountData.WAVE_CLIENT_GWT.equals(waveClientPreference);
 
     if (VIEW_J2CL_ROOT.equals(requestedView)
         || (StringUtils.isEmpty(requestedView)

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/AccountSettingsServletJ2clPreferenceTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/AccountSettingsServletJ2clPreferenceTest.java
@@ -36,6 +36,7 @@ public final class AccountSettingsServletJ2clPreferenceTest {
     HttpServletResponse response = mock(HttpServletResponse.class);
     StringWriter body = new StringWriter();
     when(request.getSession(false)).thenReturn(mock(HttpSession.class));
+    when(request.getContextPath()).thenReturn("/wave");
     when(response.getWriter()).thenReturn(new PrintWriter(body));
 
     servlet.doGet(request, response);
@@ -47,6 +48,8 @@ public final class AccountSettingsServletJ2clPreferenceTest {
     assertTrue(html.contains("J2CL beta"));
     assertTrue(html.contains("Classic GWT"));
     assertTrue(html.contains("value=\"j2cl-root\" checked"));
+    assertTrue(html.contains("var ctx = \"\\/wave\";"));
+    assertTrue(html.contains("fetch(ctx + '/account/settings/wave-client'"));
   }
 
   @Test
@@ -60,6 +63,7 @@ public final class AccountSettingsServletJ2clPreferenceTest {
     StringWriter body = new StringWriter();
     when(request.getSession(false)).thenReturn(mock(HttpSession.class));
     when(request.getPathInfo()).thenReturn("/wave-client");
+    when(request.getContextPath()).thenReturn("/wave");
     when(request.getHeader("Origin")).thenReturn("http://example.com");
     when(request.getReader())
         .thenReturn(new BufferedReader(new StringReader("{\"preference\":\"gwt\"}")));
@@ -69,7 +73,7 @@ public final class AccountSettingsServletJ2clPreferenceTest {
 
     verify(accountStore).putAccount(account);
     assertTrue(body.toString().contains("\"ok\":true"));
-    assertTrue(body.toString().contains("/?view=gwt"));
+    assertTrue(body.toString().contains("/wave/?view=gwt"));
     assertTrue(account.isWaveClientGwtPreferred());
   }
 

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/AccountSettingsServletJ2clPreferenceTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/AccountSettingsServletJ2clPreferenceTest.java
@@ -43,6 +43,9 @@ public final class AccountSettingsServletJ2clPreferenceTest {
     String html = body.toString();
     assertTrue(html.contains("id=\"waveClientJ2cl\""));
     assertTrue(html.contains("id=\"waveClientGwt\""));
+    assertTrue(html.contains("Default"));
+    assertTrue(html.contains("J2CL beta"));
+    assertTrue(html.contains("Classic GWT"));
     assertTrue(html.contains("value=\"j2cl-root\" checked"));
   }
 

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/AccountSettingsServletJ2clPreferenceTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/AccountSettingsServletJ2clPreferenceTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.waveprotocol.box.server.rpc;
 
 import static org.junit.Assert.assertTrue;

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/AccountSettingsServletJ2clPreferenceTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/AccountSettingsServletJ2clPreferenceTest.java
@@ -1,0 +1,96 @@
+package org.waveprotocol.box.server.rpc;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.BufferedReader;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+import org.junit.Test;
+import org.waveprotocol.box.server.account.HumanAccountData;
+import org.waveprotocol.box.server.account.HumanAccountDataImpl;
+import org.waveprotocol.box.server.authentication.SessionManager;
+import org.waveprotocol.box.server.authentication.WebSession;
+import org.waveprotocol.box.server.authentication.jwt.EmailTokenIssuer;
+import org.waveprotocol.box.server.mail.MailProvider;
+import org.waveprotocol.box.server.persistence.AccountStore;
+import org.waveprotocol.wave.model.wave.ParticipantId;
+
+public final class AccountSettingsServletJ2clPreferenceTest {
+  @Test
+  public void settingsPageShowsCurrentWaveClientPreference() throws Exception {
+    HumanAccountDataImpl account =
+        new HumanAccountDataImpl(ParticipantId.ofUnsafe("alice@example.com"));
+    account.setWaveClientPreference(HumanAccountData.WAVE_CLIENT_J2CL_ROOT);
+    AccountSettingsServlet servlet = createServlet(account);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(request.getSession(false)).thenReturn(mock(HttpSession.class));
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    servlet.doGet(request, response);
+
+    String html = body.toString();
+    assertTrue(html.contains("id=\"waveClientJ2cl\""));
+    assertTrue(html.contains("id=\"waveClientGwt\""));
+    assertTrue(html.contains("value=\"j2cl-root\" checked"));
+  }
+
+  @Test
+  public void saveWaveClientPreferencePersistsClassicGwtChoice() throws Exception {
+    HumanAccountDataImpl account =
+        new HumanAccountDataImpl(ParticipantId.ofUnsafe("alice@example.com"));
+    AccountStore accountStore = mock(AccountStore.class);
+    AccountSettingsServlet servlet = createServlet(accountStore, account);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(request.getSession(false)).thenReturn(mock(HttpSession.class));
+    when(request.getPathInfo()).thenReturn("/wave-client");
+    when(request.getHeader("Origin")).thenReturn("http://example.com");
+    when(request.getReader())
+        .thenReturn(new BufferedReader(new StringReader("{\"preference\":\"gwt\"}")));
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    servlet.doPost(request, response);
+
+    verify(accountStore).putAccount(account);
+    assertTrue(body.toString().contains("\"ok\":true"));
+    assertTrue(body.toString().contains("/?view=gwt"));
+    assertTrue(account.isWaveClientGwtPreferred());
+  }
+
+  private static AccountSettingsServlet createServlet(HumanAccountDataImpl account)
+      throws Exception {
+    return createServlet(mock(AccountStore.class), account);
+  }
+
+  private static AccountSettingsServlet createServlet(
+      AccountStore accountStore, HumanAccountDataImpl account) throws Exception {
+    SessionManager sessionManager = mock(SessionManager.class);
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(account.getId());
+    when(sessionManager.getLoggedInUser((WebSession) null)).thenReturn(account.getId());
+    when(accountStore.getAccount(account.getId())).thenReturn(account);
+    Config config = ConfigFactory.parseString(
+        "core.email_confirmation_enabled=false\n"
+            + "core.password_reset_enabled=true\n"
+            + "core.public_url=\"http://example.com\"\n");
+    return new AccountSettingsServlet(
+        accountStore,
+        sessionManager,
+        mock(EmailTokenIssuer.class),
+        mock(MailProvider.class),
+        "example.com",
+        config);
+  }
+}

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/WaveClientServletJ2clRootShellTest.java
@@ -88,14 +88,14 @@ public final class WaveClientServletJ2clRootShellTest {
 
     String html = body.toString();
     assertTrue(
-        html.contains("href=\"/?view=j2cl-root&amp;q=with%3A%40&amp;wave=example.com%2Fw%2B1\""));
-    assertTrue(
+        html,
         html.contains(
             "/auth/signin?r=/%3Fview%3Dj2cl-root%26q%3Dwith%253A%2540%26wave%3Dexample.com%252Fw%252B1"));
     assertTrue(
+        html,
         html.contains(
             "data-j2cl-root-return-target=\"/?view=j2cl-root&amp;q=with%3A%40&amp;wave=example.com%2Fw%2B1\""));
-    assertTrue(html.contains("data-j2cl-server-first-mode=\"signed-out\""));
+    assertTrue(html.contains("Sign in to open a wave"));
   }
 
   @Test
@@ -217,6 +217,49 @@ public final class WaveClientServletJ2clRootShellTest {
     servlet.doGet(request, response);
 
     verifyZeroInteractions(snapshotRenderer);
+    assertFalse(body.toString().contains("data-j2cl-root-shell"));
+  }
+
+  @Test
+  public void signedInDefaultRouteUsesJ2clWhenUserOptedIn() throws Exception {
+    WaveClientServlet servlet =
+        createServletWithWaveClientPreference(
+            ParticipantId.ofUnsafe("alice@example.com"),
+            HumanAccountData.WAVE_CLIENT_J2CL_ROOT,
+            null);
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(request.getParameter("view")).thenReturn(null);
+    when(request.getParameterValues("view")).thenReturn(null);
+    when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+    when(request.getSession(false)).thenReturn(mock(HttpSession.class));
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    servlet.doGet(request, response);
+
+    assertTrue(body.toString().contains("data-j2cl-root-shell"));
+  }
+
+  @Test
+  public void signedInDefaultRouteUsesGwtWhenUserOptedOutEvenIfFlagIsOn() throws Exception {
+    WaveClientServlet servlet =
+        createServletWithWaveClientPreference(
+            ParticipantId.ofUnsafe("alice@example.com"),
+            HumanAccountData.WAVE_CLIENT_GWT,
+            new FeatureFlagStore.FeatureFlag(
+                "j2cl-root-bootstrap", "global rollout", true, Collections.emptyMap()));
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    HttpServletResponse response = mock(HttpServletResponse.class);
+    StringWriter body = new StringWriter();
+    when(request.getParameter("view")).thenReturn(null);
+    when(request.getParameterValues("view")).thenReturn(null);
+    when(request.getParameterNames()).thenReturn(Collections.emptyEnumeration());
+    when(request.getSession(false)).thenReturn(mock(HttpSession.class));
+    when(response.getWriter()).thenReturn(new PrintWriter(body));
+
+    servlet.doGet(request, response);
+
     assertFalse(body.toString().contains("data-j2cl-root-shell"));
   }
 
@@ -374,9 +417,9 @@ public final class WaveClientServletJ2clRootShellTest {
             "https://evil.example/steal",
             "");
 
-    assertTrue(html.contains("href=\"/?view=j2cl-root\""));
-    assertTrue(html.contains("/auth/signin?r=/%3Fview%3Dj2cl-root"));
-    assertFalse(html.contains("https://evil.example/steal"));
+    assertTrue(html, html.contains("data-j2cl-root-return-target=\"/?view=j2cl-root\""));
+    assertTrue(html, html.contains("/auth/signin?r=/%3Fview%3Dj2cl-root"));
+    assertFalse(html, html.contains("https://evil.example/steal"));
   }
 
   private static WaveClientServlet createServlet(ParticipantId user) throws Exception {
@@ -584,6 +627,45 @@ public final class WaveClientServletJ2clRootShellTest {
         new VersionServlet("test", 0L),
         mock(WavePreRenderer.class),
         snapshotRenderer,
+        new FeatureFlagService(flagStore));
+  }
+
+  private static WaveClientServlet createServletWithWaveClientPreference(
+      ParticipantId user,
+      String waveClientPreference,
+      FeatureFlagStore.FeatureFlag flagOverride)
+      throws Exception {
+    Config config = ConfigFactory.parseString(
+        "core.http_frontend_addresses=[\"127.0.0.1:9898\"]\n"
+            + "core.http_websocket_public_address=\"\"\n"
+            + "core.http_websocket_presented_address=\"\"\n"
+            + "core.search_type=\"memory\"\n"
+            + "administration.analytics_account=\"\"\n");
+    SessionManager sessionManager = mock(SessionManager.class);
+    AccountStore accountStore = mock(AccountStore.class);
+    when(sessionManager.getLoggedInUser(any(WebSession.class))).thenReturn(user);
+    when(sessionManager.getLoggedInUser((WebSession) null)).thenReturn(user);
+    AccountData accountData = mock(AccountData.class);
+    HumanAccountData humanAccountData = mock(HumanAccountData.class);
+    when(accountData.isHuman()).thenReturn(true);
+    when(accountData.asHuman()).thenReturn(humanAccountData);
+    when(humanAccountData.getRole()).thenReturn(HumanAccountData.ROLE_USER);
+    when(humanAccountData.getWaveClientPreference()).thenReturn(waveClientPreference);
+    when(accountStore.getAccount(user)).thenReturn(accountData);
+    FeatureFlagStore flagStore = mock(FeatureFlagStore.class);
+    when(flagStore.getAll())
+        .thenReturn(
+            flagOverride == null
+                ? Collections.<FeatureFlagStore.FeatureFlag>emptyList()
+                : Collections.singletonList(flagOverride));
+    return new WaveClientServlet(
+        "example.com",
+        config,
+        sessionManager,
+        accountStore,
+        new VersionServlet("test", 0L),
+        mock(WavePreRenderer.class),
+        defaultSnapshotRenderer(),
         new FeatureFlagService(flagStore));
   }
 

--- a/wave/src/main/java/org/waveprotocol/box/server/account/HumanAccountData.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/account/HumanAccountData.java
@@ -34,6 +34,10 @@ import java.util.List;
  * @author akaplanov@gmail.com (Andrew Kaplanov)
  */
 public interface HumanAccountData extends AccountData {
+  String WAVE_CLIENT_DEFAULT = "default";
+  String WAVE_CLIENT_J2CL_ROOT = "j2cl-root";
+  String WAVE_CLIENT_GWT = "gwt";
+
   /**
    * Gets the user's password digest. The digest can be used to authenticate the
    * user.
@@ -87,6 +91,25 @@ public interface HumanAccountData extends AccountData {
    *
    */
   void setLocale(String locale);
+
+  /**
+   * Returns the user's preferred default Wave client.
+   *
+   * <p>{@link #WAVE_CLIENT_DEFAULT} means the server-side feature flag controls
+   * the default route. Explicit values override only requests without a
+   * {@code view=} parameter; direct {@code ?view=j2cl-root} and
+   * {@code ?view=gwt} links remain reversible.
+   */
+  String getWaveClientPreference();
+
+  /** Sets the user's preferred default Wave client. */
+  void setWaveClientPreference(String preference);
+
+  /** Returns true when the user explicitly opted into the J2CL root shell. */
+  boolean isWaveClientJ2clRootPreferred();
+
+  /** Returns true when the user explicitly opted back into the classic GWT shell. */
+  boolean isWaveClientGwtPreferred();
 
   /**
    * Gets the user's stored searches.

--- a/wave/src/main/java/org/waveprotocol/box/server/account/HumanAccountDataImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/account/HumanAccountDataImpl.java
@@ -40,6 +40,7 @@ public final class HumanAccountDataImpl implements HumanAccountData {
   private final PasswordDigest passwordDigest;
   private String email;
   private String locale;
+  private String waveClientPreference = WAVE_CLIENT_DEFAULT;
   private boolean emailConfirmed = true;
   private List<SearchesItem> searches;
   private List<SocialIdentity> socialIdentities = Collections.emptyList();
@@ -124,6 +125,30 @@ public final class HumanAccountDataImpl implements HumanAccountData {
   @Override
   public void setLocale(String locale) {
     this.locale = locale;
+  }
+
+  @Override
+  public String getWaveClientPreference() {
+    return waveClientPreference;
+  }
+
+  @Override
+  public void setWaveClientPreference(String preference) {
+    if (WAVE_CLIENT_J2CL_ROOT.equals(preference) || WAVE_CLIENT_GWT.equals(preference)) {
+      this.waveClientPreference = preference;
+    } else {
+      this.waveClientPreference = WAVE_CLIENT_DEFAULT;
+    }
+  }
+
+  @Override
+  public boolean isWaveClientJ2clRootPreferred() {
+    return WAVE_CLIENT_J2CL_ROOT.equals(waveClientPreference);
+  }
+
+  @Override
+  public boolean isWaveClientGwtPreferred() {
+    return WAVE_CLIENT_GWT.equals(waveClientPreference);
   }
 
   @Override
@@ -309,6 +334,8 @@ public final class HumanAccountDataImpl implements HumanAccountData {
     result = prime * result + ((passwordDigest == null) ? 0 : passwordDigest.hashCode());
     result = prime * result + ((email == null) ? 0 : email.hashCode());
     result = prime * result + ((locale == null) ? 0 : locale.hashCode());
+    result = prime * result
+        + ((waveClientPreference == null) ? 0 : waveClientPreference.hashCode());
     result = prime * result + ((searches == null) ? 0 : searches.hashCode());
     result = prime * result + ((socialIdentities == null) ? 0 : socialIdentities.hashCode());
     return result;
@@ -332,6 +359,9 @@ public final class HumanAccountDataImpl implements HumanAccountData {
     if (locale == null) {
       if (other.locale != null) return false;
     } else if (!locale.equals(other.locale)) return false;
+    if (waveClientPreference == null) {
+      if (other.waveClientPreference != null) return false;
+    } else if (!waveClientPreference.equals(other.waveClientPreference)) return false;
     if (searches == null) {
       if (other.searches != null) return false;
     } else if (!searches.equals(other.searches)) return false;

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb/MongoDbStore.java
@@ -92,6 +92,7 @@ public final class MongoDbStore implements SignerInfoStore, AttachmentStore, Acc
   private static final String HUMAN_PASSWORD_FIELD = "passwordDigest";
   private static final String HUMAN_SEARCHES_FIELD = "searches";
   private static final String HUMAN_SOCIAL_IDENTITIES_FIELD = "socialIdentities";
+  private static final String HUMAN_WAVE_CLIENT_PREFERENCE_FIELD = "waveClientPreference";
   private static final String SEARCH_NAME_FIELD = "name";
   private static final String SEARCH_QUERY_FIELD = "query";
   private static final String SEARCH_PINNED_FIELD = "pinned";
@@ -501,6 +502,10 @@ public final class MongoDbStore implements SignerInfoStore, AttachmentStore, Acc
       object.put(HUMAN_PASSWORD_FIELD, digestObj);
     }
 
+    if (!HumanAccountData.WAVE_CLIENT_DEFAULT.equals(account.getWaveClientPreference())) {
+      object.put(HUMAN_WAVE_CLIENT_PREFERENCE_FIELD, account.getWaveClientPreference());
+    }
+
     // Saved searches
     List<SearchesItem> searches = account.getSearches();
     if (searches != null && !searches.isEmpty()) {
@@ -555,6 +560,11 @@ public final class MongoDbStore implements SignerInfoStore, AttachmentStore, Acc
     }
 
     HumanAccountDataImpl account = new HumanAccountDataImpl(id, passwordDigest);
+
+    String waveClientPreference = (String) object.get(HUMAN_WAVE_CLIENT_PREFERENCE_FIELD);
+    if (waveClientPreference != null) {
+      account.setWaveClientPreference(waveClientPreference);
+    }
 
     // Saved searches
     @SuppressWarnings("unchecked")

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4AccountStore.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/mongodb4/Mongo4AccountStore.java
@@ -61,6 +61,7 @@ final class Mongo4AccountStore implements AccountStore {
   private static final String HUMAN_BIO_FIELD = "bio";
   private static final String HUMAN_PROFILE_IMAGE_FIELD = "profileImageAttachmentId";
   private static final String HUMAN_SHOW_LAST_SEEN_FIELD = "showLastSeen";
+  private static final String HUMAN_WAVE_CLIENT_PREFERENCE_FIELD = "waveClientPreference";
   private static final String HUMAN_SEARCHES_FIELD = "searches";
   private static final String HUMAN_SOCIAL_IDENTITIES_FIELD = "socialIdentities";
   private static final String SEARCH_NAME_FIELD = "name";
@@ -370,6 +371,9 @@ final class Mongo4AccountStore implements AccountStore {
     doc.append(HUMAN_ROLE_FIELD, account.getRole());
     doc.append(HUMAN_STATUS_FIELD, account.getStatus());
     doc.append(HUMAN_TIER_FIELD, account.getTier());
+    if (!HumanAccountData.WAVE_CLIENT_DEFAULT.equals(account.getWaveClientPreference())) {
+      doc.append(HUMAN_WAVE_CLIENT_PREFERENCE_FIELD, account.getWaveClientPreference());
+    }
     if (account.getRegistrationTime() != 0) {
       doc.append(HUMAN_REGISTRATION_TIME_FIELD, account.getRegistrationTime());
     }
@@ -475,6 +479,10 @@ final class Mongo4AccountStore implements AccountStore {
     String tier = doc.getString(HUMAN_TIER_FIELD);
     if (tier != null) {
       account.setTier(tier);
+    }
+    String waveClientPreference = doc.getString(HUMAN_WAVE_CLIENT_PREFERENCE_FIELD);
+    if (waveClientPreference != null) {
+      account.setWaveClientPreference(waveClientPreference);
     }
     Long registrationTime = doc.getLong(HUMAN_REGISTRATION_TIME_FIELD);
     if (registrationTime != null) {

--- a/wave/src/main/java/org/waveprotocol/box/server/persistence/protos/ProtoAccountDataSerializer.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/persistence/protos/ProtoAccountDataSerializer.java
@@ -90,6 +90,9 @@ public class ProtoAccountDataSerializer {
     builder.setRole(account.getRole());
     builder.setStatus(account.getStatus());
     builder.setTier(account.getTier());
+    if (!HumanAccountData.WAVE_CLIENT_DEFAULT.equals(account.getWaveClientPreference())) {
+      builder.setWaveClientPreference(account.getWaveClientPreference());
+    }
     if (account.getRegistrationTime() != 0) {
       builder.setRegistrationTime(account.getRegistrationTime());
     }
@@ -232,6 +235,9 @@ public class ProtoAccountDataSerializer {
     }
     if (data.hasTier()) {
       account.setTier(data.getTier());
+    }
+    if (data.hasWaveClientPreference()) {
+      account.setWaveClientPreference(data.getWaveClientPreference());
     }
     if (data.hasRegistrationTime()) {
       account.setRegistrationTime(data.getRegistrationTime());

--- a/wave/src/proto/proto/org/waveprotocol/box/server/persistence/protos/account-store.proto
+++ b/wave/src/proto/proto/org/waveprotocol/box/server/persistence/protos/account-store.proto
@@ -59,6 +59,7 @@ message ProtoHumanAccountData {
 	// Saved searches
 	repeated ProtoSearchesItem saved_search = 10;
 	repeated ProtoSocialIdentity social_identity = 11;
+	optional string wave_client_preference = 12 [default = "default"];
 }
 
 message ProtoSocialIdentity {

--- a/wave/src/test/java/org/waveprotocol/box/server/account/HumanAccountDataImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/account/HumanAccountDataImplTest.java
@@ -51,4 +51,17 @@ public class HumanAccountDataImplTest extends TestCase {
 
     assertNull(account.getPasswordDigest());
   }
+
+  public void testWaveClientPreferenceDefaultsAndCanChange() {
+    HumanAccountData account =
+        new HumanAccountDataImpl(ParticipantId.ofUnsafe("penny@example.com"));
+
+    assertEquals(HumanAccountData.WAVE_CLIENT_DEFAULT, account.getWaveClientPreference());
+
+    account.setWaveClientPreference(HumanAccountData.WAVE_CLIENT_J2CL_ROOT);
+    assertEquals(HumanAccountData.WAVE_CLIENT_J2CL_ROOT, account.getWaveClientPreference());
+
+    account.setWaveClientPreference(HumanAccountData.WAVE_CLIENT_GWT);
+    assertEquals(HumanAccountData.WAVE_CLIENT_GWT, account.getWaveClientPreference());
+  }
 }

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/AccountStoreTestBase.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/AccountStoreTestBase.java
@@ -112,6 +112,20 @@ public abstract class AccountStoreTestBase extends TestCase {
     assertTrue(retrievedAccount.asHuman().getPasswordDigest().verify("internet".toCharArray()));
   }
 
+  public final void testRoundtripHumanAccountWithWaveClientPreference() throws Exception {
+    AccountStore accountStore = newAccountStore();
+    HumanAccountDataImpl account = new HumanAccountDataImpl(HUMAN_ID);
+    account.setWaveClientPreference(HumanAccountData.WAVE_CLIENT_GWT);
+
+    accountStore.putAccount(account);
+
+    AccountData retrievedAccount = accountStore.getAccount(HUMAN_ID);
+    assertTrue(retrievedAccount.isHuman());
+    assertEquals(
+        HumanAccountData.WAVE_CLIENT_GWT,
+        retrievedAccount.asHuman().getWaveClientPreference());
+  }
+
   public final void testRoundtripHumanAccountWithSocialIdentityLookup() throws Exception {
     AccountStore accountStore = newAccountStore();
     HumanAccountDataImpl account = new HumanAccountDataImpl(HUMAN_ID);

--- a/wave/src/test/java/org/waveprotocol/box/server/persistence/protos/ProtoAccountDataSerializerTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/persistence/protos/ProtoAccountDataSerializerTest.java
@@ -170,6 +170,19 @@ public class ProtoAccountDataSerializerTest extends TestCase {
     assertEquals("is:flagged", human.getSearches().get(1).getQuery());
   }
 
+  public final void testHumanAccountWithWaveClientPreference() {
+    HumanAccountDataImpl account = new HumanAccountDataImpl(HUMAN_ID);
+    account.setWaveClientPreference(HumanAccountData.WAVE_CLIENT_J2CL_ROOT);
+
+    ProtoAccountData data = ProtoAccountDataSerializer.serialize(account);
+    AccountData deserialized = ProtoAccountDataSerializer.deserialize(data);
+
+    assertTrue(deserialized.isHuman());
+    assertEquals(
+        HumanAccountData.WAVE_CLIENT_J2CL_ROOT,
+        deserialized.asHuman().getWaveClientPreference());
+  }
+
   public final void testHumanAccountWithSocialIdentity() {
     HumanAccountDataImpl account = new HumanAccountDataImpl(HUMAN_ID);
     account.addOrReplaceSocialIdentity(


### PR DESCRIPTION
Closes #1285

## Summary
- Add a per-user Wave client preference with Default, J2CL beta, and Classic GWT choices in Account Settings.
- Persist the preference through account model, proto/file serialization, and Mongo account stores.
- Respect the preference on default Wave routes while preserving explicit `?view=j2cl-root` and `?view=gwt` switching.

## Verification
- `python3 scripts/validate-changelog.py`
- `git diff --check`
- `sbt "testOnly org.waveprotocol.box.server.account.HumanAccountDataImplTest org.waveprotocol.box.server.persistence.protos.ProtoAccountDataSerializerTest org.waveprotocol.box.server.persistence.memory.AccountStoreTest org.waveprotocol.box.server.persistence.file.AccountStoreTest" "JakartaTest / testOnly org.waveprotocol.box.server.rpc.AccountSettingsServletJ2clPreferenceTest org.waveprotocol.box.server.rpc.WaveClientServletJ2clRootShellTest"`
- `bash scripts/worktree-boot.sh --port 9919 --shared-file-store`
- foreground local server on port 9919 plus `PORT=9919 bash scripts/wave-smoke.sh check` (`ROOT_STATUS=200`, `GWT_VIEW_STATUS=200`, `HEALTH_STATUS=200`, `LANDING_STATUS=200`, `J2CL_ROOT_STATUS=200`, `J2CL_ROOT_SHELL=present`, `WEBCLIENT_STATUS=200`)
- `curl -sS "http://127.0.0.1:9919/?view=j2cl-root" | rg -n "data-j2cl-root-shell|Sign in to open a wave"`
