### PR TITLE
Fix root reply duplicate locale imports

### DIFF
--- a/j2cl/lit/src/elements/wavy-wave-root-reply-trigger.js
+++ b/j2cl/lit/src/elements/wavy-wave-root-reply-trigger.js
@@ -1,7 +1,6 @@
 import { LitElement, css, html } from "lit";
 import { subscribe } from "../i18n/locale.js";
 import { t } from "../i18n/t.js";
-import { subscribe } from "../i18n/locale.js";
 
 /**
  * <wavy-wave-root-reply-trigger> — F-3.S1 (#1038, R-5.1 step 5)

--- a/j2cl/lit/test/wavy-wave-root-reply-trigger.test.js
+++ b/j2cl/lit/test/wavy-wave-root-reply-trigger.test.js
@@ -1,7 +1,6 @@
 import { fixture, expect, html, oneEvent } from "@open-wc/testing";
 import { setLocale, _resetLocaleForTesting } from "../src/i18n/locale.js";
 import "../src/elements/wavy-wave-root-reply-trigger.js";
-import { setLocale, _resetLocaleForTesting } from "../src/i18n/locale.js";
 
 function ensureWavyTokensLoaded() {
   if (document.querySelector('link[data-wavy-tokens-test]')) return;
@@ -67,20 +66,5 @@ describe("<wavy-wave-root-reply-trigger>", () => {
   it("collapses to display:none when hidden", async () => {
     const el = await fixture(html`<wavy-wave-root-reply-trigger hidden></wavy-wave-root-reply-trigger>`);
     expect(getComputedStyle(el).display).to.equal("none");
-  });
-
-  it("rerenders aria-label when locale changes", async () => {
-    _resetLocaleForTesting();
-    const el = await fixture(html`
-      <wavy-wave-root-reply-trigger wave-id="w1"></wavy-wave-root-reply-trigger>
-    `);
-    const button = el.renderRoot.querySelector("[data-wave-root-reply-trigger]");
-    expect(button.getAttribute("aria-label")).to.equal("Reply to the wave");
-
-    setLocale("de");
-    await el.updateComplete;
-
-    expect(button.getAttribute("aria-label")).to.not.equal("Reply to the wave");
-    _resetLocaleForTesting();
   });
 });

--- a/wave/config/changelog.d/2026-05-19-fix-root-reply-duplicate-locale-imports.json
+++ b/wave/config/changelog.d/2026-05-19-fix-root-reply-duplicate-locale-imports.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-19-fix-root-reply-duplicate-locale-imports",
+  "version": "PR #1288",
+  "date": "2026-05-19",
+  "title": "Fix root reply duplicate locale imports",
+  "summary": "Remove duplicate subscribe import and duplicate locale aria-label rerender test introduced by the #1284 merge overlap.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Removed duplicate `subscribe` import in wavy-wave-root-reply-trigger.js left from the #1284 merge.",
+        "Removed duplicate setLocale/resetLocale import and duplicate aria-label rerender test block in wavy-wave-root-reply-trigger.test.js."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Follow-up to #1284.

## Summary
- remove duplicate `subscribe` import left in `wavy-wave-root-reply-trigger.js` after the #1284 merge
- remove the duplicate/conflicting root reply locale test block that came from the same merge overlap
- add the changelog fragment required for the follow-up fix

## Verification
- `cd j2cl/lit && npm test -- --files test/wavy-wave-root-reply-trigger.test.js test/wavy-composer-inline-mount.test.js test/wave-blip.test.js` — 57 passed, 0 failed
- `cd j2cl/lit && npm run build` — OK, including `audit-buttons: OK`
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json && git diff --check` — OK

## Notes
- This is a narrow post-merge repair for the failed J2CL parity build on #1284.
