### PR TITLE
fix(deploy): retry sanity apk dependency install

### DIFF
--- a/deploy/caddy/deploy.sh
+++ b/deploy/caddy/deploy.sh
@@ -467,9 +467,22 @@ sanity_check() {
     -e SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS \
     "$sanity_image" sh -c '
     set -e
+    install_sanity_tools_with_retry() {
+      for attempt in 1 2 3; do
+        if apk add --no-cache curl jq >/dev/null; then
+          return 0
+        fi
+        if [ "$attempt" -lt 3 ]; then
+          echo "[sanity] apk add curl/jq failed on attempt ${attempt}/3, retrying..." >&2
+          sleep "$attempt"
+        fi
+      done
+      return 1
+    }
+
     if ! command -v curl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
       if command -v apk >/dev/null 2>&1; then
-        if ! apk add --no-cache curl jq >/dev/null; then
+        if ! install_sanity_tools_with_retry; then
           echo "[sanity] FAIL: unable to install curl/jq via apk" >&2
           exit 1
         fi

--- a/deploy/contabo/deploy.sh
+++ b/deploy/contabo/deploy.sh
@@ -157,9 +157,22 @@ sanity_check() {
     -e SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS \
     "$sanity_image" sh -c '
     set -e
+    install_sanity_tools_with_retry() {
+      for attempt in 1 2 3; do
+        if apk add --no-cache curl jq >/dev/null; then
+          return 0
+        fi
+        if [ "$attempt" -lt 3 ]; then
+          echo "[sanity] apk add curl/jq failed on attempt ${attempt}/3, retrying..." >&2
+          sleep "$attempt"
+        fi
+      done
+      return 1
+    }
+
     if ! command -v curl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
       if command -v apk >/dev/null 2>&1; then
-        if ! apk add --no-cache curl jq >/dev/null; then
+        if ! install_sanity_tools_with_retry; then
           echo "[sanity] FAIL: unable to install curl/jq via apk" >&2
           exit 1
         fi

--- a/scripts/tests/deploy_harness.py
+++ b/scripts/tests/deploy_harness.py
@@ -19,6 +19,7 @@ def run_deploy_script(
     application_conf: str | None = None,
     release_files: dict[str, dict[str, str]] | None = None,
     wave_image: str = "ghcr.io/example/wave:test",
+    env_overrides: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
   bash_path = find_bash()
   if bash_path is None:
@@ -90,6 +91,8 @@ exit 1
     env["CANONICAL_HOST"] = "supawave.ai"
     env["ROOT_HOST"] = "wave.supawave.ai"
     env["WWW_HOST"] = "www.supawave.ai"
+    if env_overrides is not None:
+      env.update(env_overrides)
 
     return subprocess.run(
         [bash_path, str(temp_deploy_script), command],

--- a/scripts/tests/test_deploy_sanity_gate.py
+++ b/scripts/tests/test_deploy_sanity_gate.py
@@ -62,6 +62,10 @@ case "$cmd" in
     ;;
   *" up -d wave-green"*)
     ;;
+  *" exec -T caddy caddy reload"*)
+    ;;
+  *" stop wave-blue"*)
+    ;;
   *" stop wave-green"*)
     ;;
   *"inspect --format {{.State.StartedAt}} wave-green-id"*)
@@ -88,6 +92,194 @@ esac
     combined = f"{result.stdout}\n{result.stderr}"
     self.assertIn("SANITY_ADDRESS and SANITY_PASSWORD must both be set", combined)
     self.assertNotIn("skipping sanity check", combined.lower())
+
+  def test_deploy_sanity_retries_transient_apk_failures(self):
+    bash_path = find_bash()
+    if bash_path is None:
+      self.skipTest("requires bash >= 4 to execute deploy/caddy/deploy.sh")
+
+    result = run_deploy_script(
+        REPO_ROOT,
+        DEPLOY_SCRIPT,
+        r"""#!/usr/bin/env bash
+set -euo pipefail
+cmd="$*"
+if [[ "$1" == "compose" && "$2" == "version" ]]; then
+  exit 0
+fi
+if [[ "$cmd" == *"image inspect --format"* && "$cmd" == *"ghcr.io/example/wave:test"* ]]; then
+  printf 'true\n'
+  exit 0
+fi
+if [[ "$1" == "run" && "$cmd" == *"alpine:3.20 sh -c"* ]]; then
+  script="${@: -1}"
+  container_bin=$(mktemp -d)
+  export CONTAINER_BIN="$container_bin"
+  export APK_ATTEMPTS="$container_bin/apk-attempts"
+  cat > "$container_bin/curl" <<'CURL_STUB'
+#!/bin/sh
+echo "curl should be replaced by apk install" >&2
+exit 127
+CURL_STUB
+  chmod +x "$container_bin/curl"
+  cat > "$container_bin/apk" <<'APK'
+#!/bin/bash
+set -euo pipefail
+attempt=0
+if [[ -f "$APK_ATTEMPTS" ]]; then
+  attempt=$(/bin/cat "$APK_ATTEMPTS")
+fi
+attempt=$((attempt + 1))
+printf '%s' "$attempt" > "$APK_ATTEMPTS"
+if [[ "$attempt" -lt 3 ]]; then
+  echo "temporary error (try again later)" >&2
+  exit 1
+fi
+/bin/cat > "$CONTAINER_BIN/curl" <<'CURL'
+#!/bin/bash
+set -euo pipefail
+cookie=""
+previous=""
+for arg in "$@"; do
+  if [[ "$previous" == "-c" ]]; then
+    cookie="$arg"
+  fi
+  previous="$arg"
+done
+url="${@: -1}"
+case "$url" in
+  */auth/signin)
+    if [[ -n "$cookie" ]]; then
+      printf 'localhost\tFALSE\t/\tFALSE\t0\tJSESSIONID\ttest\n' > "$cookie"
+    fi
+    printf '200'
+    ;;
+  */search/*)
+    printf '{"3":[{"3":"wave!example"}]}'
+    ;;
+  */fetch/*)
+    printf '{"1":true}\n200'
+    ;;
+  *)
+    printf '200'
+    ;;
+esac
+CURL
+/bin/chmod +x "$CONTAINER_BIN/curl"
+/bin/cat > "$CONTAINER_BIN/jq" <<'JQ'
+#!/bin/bash
+set -euo pipefail
+filter="${@: -1}"
+input=$(cat)
+case "$filter" in
+  *'["3"][0]["3"]'*)
+    printf 'wave!example\n'
+    ;;
+  'has("1")')
+    printf 'true\n'
+    ;;
+  *)
+    printf '%s\n' "$input"
+    ;;
+esac
+JQ
+/bin/chmod +x "$CONTAINER_BIN/jq"
+/bin/cat > "$CONTAINER_BIN/grep" <<'GREP'
+#!/bin/sh
+exec /usr/bin/grep "$@"
+GREP
+/bin/chmod +x "$CONTAINER_BIN/grep"
+/bin/cat > "$CONTAINER_BIN/sed" <<'SED'
+#!/bin/sh
+exec /usr/bin/sed "$@"
+SED
+/bin/chmod +x "$CONTAINER_BIN/sed"
+/bin/cat > "$CONTAINER_BIN/tail" <<'TAIL'
+#!/bin/sh
+exec /usr/bin/tail "$@"
+TAIL
+/bin/chmod +x "$CONTAINER_BIN/tail"
+/bin/cat > "$CONTAINER_BIN/cat" <<'CAT'
+#!/bin/sh
+exec /bin/cat "$@"
+CAT
+/bin/chmod +x "$CONTAINER_BIN/cat"
+APK
+  chmod +x "$container_bin/apk"
+  cat > "$container_bin/date" <<'DATE'
+#!/bin/sh
+exec /bin/date "$@"
+DATE
+  chmod +x "$container_bin/date"
+  cat > "$container_bin/sleep" <<'SLEEP'
+#!/bin/sh
+exit 0
+SLEEP
+  chmod +x "$container_bin/sleep"
+  PATH="$container_bin" \
+    INTERNAL_PORT="${INTERNAL_PORT:-9898}" \
+    SANITY_ADDR="${SANITY_ADDR:-test@example.com}" \
+    SANITY_PASS="${SANITY_PASS:-password}" \
+    SANITY_SEARCH_DEADLINE_SECONDS="${SANITY_SEARCH_DEADLINE_SECONDS:-120}" \
+    SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS="${SANITY_SEARCH_REQUEST_TIMEOUT_SECONDS:-15}" \
+    /bin/sh -c "$script"
+  attempts=$(cat "$APK_ATTEMPTS")
+  if [[ "$attempts" != "3" ]]; then
+    echo "expected apk to be attempted 3 times, got $attempts" >&2
+    exit 1
+  fi
+  exit 0
+fi
+case "$cmd" in
+  *" ps caddy --format json"*)
+    printf '{"Service":"caddy","State":"running"}\n'
+    ;;
+  *" ps -q wave-green"*)
+    printf 'wave-green-id\n'
+    ;;
+  *" up -d wave-green"*)
+    ;;
+  *" exec -T caddy caddy reload"*)
+    ;;
+  *" stop wave-blue"*)
+    ;;
+  *" stop wave-green"*)
+    ;;
+  *"inspect --format {{.State.StartedAt}} wave-green-id"*)
+    printf '2026-04-13T11:00:00Z\n'
+    ;;
+  *" logs --no-color --since 2026-04-13T11:00:00Z wave-green"*)
+    printf 'Completed Mongock Mongo schema migrations\n'
+    ;;
+  "pull ghcr.io/example/wave:test"|*" pull ghcr.io/example/wave:test"*)
+    ;;
+  *)
+    echo "unexpected docker invocation: $cmd" >&2
+    exit 1
+    ;;
+esac
+""",
+        env_overrides={
+            "SANITY_ADDRESS": "test@example.com",
+            "SANITY_PASSWORD": "password",
+        },
+    )
+
+    self.assertEqual(
+        0,
+        result.returncode,
+        msg=f"deploy should retry transient apk failures:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}",
+    )
+    combined = f"{result.stdout}\n{result.stderr}"
+    self.assertIn("ALL CHECKS PASSED", combined)
+
+  def test_deploy_sanity_scripts_retry_apk_dependency_install(self):
+    for script_path in (DEPLOY_SCRIPT, CONTABO_DEPLOY_SCRIPT):
+      deploy_script = script_path.read_text(encoding="utf-8")
+
+      self.assertIn("install_sanity_tools_with_retry()", deploy_script)
+      self.assertIn("apk add --no-cache curl jq", deploy_script)
+      self.assertIn("for attempt in 1 2 3; do", deploy_script)
 
   def test_deploy_workflow_validates_sanity_credentials_before_remote_steps(self):
     workflow = DEPLOY_WORKFLOW.read_text(encoding="utf-8")

--- a/wave/config/changelog.d/2026-05-19-deploy-sanity-apk-retry.json
+++ b/wave/config/changelog.d/2026-05-19-deploy-sanity-apk-retry.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-19-deploy-sanity-apk-retry",
+  "version": "PR #TBD",
+  "date": "2026-05-19",
+  "title": "Retry transient Alpine package failures in deploy sanity checks",
+  "summary": "Production deploy sanity checks now retry the temporary Alpine package install used for curl and jq, so a brief package mirror outage no longer aborts an otherwise healthy blue-green deploy.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Wrapped the sanity container's apk install of curl and jq in a bounded three-attempt retry loop for both current and legacy Contabo deploy scripts."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- retry transient `apk add --no-cache curl jq` failures inside the deploy sanity container
- apply the same bounded retry to both current caddy and legacy Contabo deploy scripts
- add regression coverage that fails when a temporary Alpine package error aborts sanity before retrying

Fixes #1289

## Verification
- `python3 -m unittest scripts.tests.test_deploy_sanity_gate -v`
- `bash -n scripts/deployment/bootstrap-linux-host.sh deploy/caddy/deploy.sh deploy/contabo/deploy.sh && bash scripts/ci-validate-deploy-healthcheck.sh`
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment resilience with automatic retry logic (up to 3 attempts) for transient Alpine package manager failures when installing sanity-check dependencies.

* **Tests**
  * Added tests covering transient package-install failures and validating retry behavior; updated test harness to allow environment overrides for deploy script runs.

* **Documentation**
  * Added changelog entry documenting the deploy sanity APK retry behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->