### PR TITLE
Fix J2CL compact topbar control alignment

### DIFF
--- a/j2cl/lit/src/elements/shell-header.js
+++ b/j2cl/lit/src/elements/shell-header.js
@@ -43,6 +43,8 @@ export class ShellHeader extends LitElement {
     header.gwt-topbar-panel .actions {
       flex-wrap: nowrap;
       gap: 6px;
+      margin-left: auto;
+      justify-content: flex-end;
     }
   `;
 

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -202,6 +202,11 @@ shell-header {
   box-sizing: border-box;
 }
 
+shell-header:defined {
+  display: block;
+  width: 100%;
+}
+
 shell-header[compact-gwt-topbar] {
   padding: 0 12px;
   min-height: 40px;

--- a/j2cl/lit/test/shell-header.test.js
+++ b/j2cl/lit/test/shell-header.test.js
@@ -1,6 +1,29 @@
 import { fixture, expect, html } from "@open-wc/testing";
 import "../src/elements/shell-header.js";
 
+function ensureShellTokensLoaded() {
+  if (document.querySelector("link[data-shell-tokens-test]")) return;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "/src/tokens/shell-tokens.css";
+  link.dataset.shellTokensTest = "true";
+  document.head.appendChild(link);
+}
+
+async function waitForShellTokens() {
+  for (let i = 0; i < 50; i++) {
+    const probe = document.createElement("shell-header");
+    probe.setAttribute("compact-gwt-topbar", "");
+    probe.style.width = "640px";
+    document.body.appendChild(probe);
+    const applied = getComputedStyle(probe).display === "block";
+    probe.remove();
+    if (applied) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error("shell-tokens.css did not apply within 1000ms");
+}
+
 describe("<shell-header>", () => {
   it("uses the banner landmark", async () => {
     const el = await fixture(html`<shell-header></shell-header>`);
@@ -26,5 +49,31 @@ describe("<shell-header>", () => {
     expect(header.classList.contains("gwt-topbar-panel")).to.be.true;
     expect(header.classList.contains("is-signed-in")).to.be.true;
     expect(getComputedStyle(header).minHeight).to.equal("40px");
+  });
+
+  it("right-aligns compact signed-in actions like the GWT topbar info cluster", async () => {
+    ensureShellTokensLoaded();
+    await waitForShellTokens();
+    const el = await fixture(html`
+      <shell-header signed-in compact-gwt-topbar style="width:640px">
+        <a slot="brand">SupaWave</a>
+        <span slot="actions-signed-in">EN</span>
+        <button slot="actions-signed-in">Save</button>
+        <button slot="actions-signed-in">User</button>
+      </shell-header>
+    `);
+    const header = el.renderRoot.querySelector("header");
+    const actions = el.renderRoot.querySelector(".actions");
+    const brand = el.renderRoot.querySelector(".brand");
+
+    expect(getComputedStyle(el).display).to.equal("block");
+    expect(Math.round(el.getBoundingClientRect().width)).to.equal(640);
+    expect(getComputedStyle(actions).justifyContent).to.equal("flex-end");
+    expect(actions.getBoundingClientRect().left).to.be.greaterThan(
+      brand.getBoundingClientRect().right
+    );
+    expect(Math.round(actions.getBoundingClientRect().right)).to.equal(
+      Math.round(header.getBoundingClientRect().right)
+    );
   });
 });

--- a/wave/config/changelog.d/2026-05-19-j2cl-topbar-controls-alignment.json
+++ b/wave/config/changelog.d/2026-05-19-j2cl-topbar-controls-alignment.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-19-j2cl-topbar-controls-alignment",
+  "version": "Unreleased",
+  "date": "2026-05-19",
+  "title": "J2CL topbar control alignment",
+  "summary": "The J2CL root topbar now aligns its signed-in controls like the classic GWT topbar while preserving the existing control behavior.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Right-aligned the compact J2CL topbar control cluster so language, save state, network state, notifications, inbox, user menu, admin, and sign-out controls match the GWT layout."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary\n- align the compact J2CL topbar action cluster to the right like the GWT topbar\n- let the upgraded shell-header host span the full bar while preserving pre-upgrade fallback styling\n- add a Lit geometry regression and changelog fragment\n\nFixes #1290\n\n## Verification\n- npm test -- --files test/shell-header.test.js\n- npm test\n- npm run build\n- python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py\n- git diff --check\n- WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 bash scripts/worktree-boot.sh --port 9930\n- PORT=9930 bash scripts/wave-smoke.sh check\n- Browser fixture against local staged assets: compact shell-header host width 1280, actions right edge equals header right edge, rightGap=0, language/save/network/bell/mail/user-menu/admin/sign-out controls present, user menu opens