### PR TITLE
Fix duplicate J2CL topbar sign out

### DIFF
--- a/docs/superpowers/plans/2026-05-19-issue-1293-j2cl-duplicate-signout.md
+++ b/docs/superpowers/plans/2026-05-19-issue-1293-j2cl-duplicate-signout.md
@@ -1,0 +1,22 @@
+# Issue 1293: Remove Duplicate J2CL Sign Out
+
+## Investigation
+
+- The Lit `<wavy-header>` renders signed-in compact controls as locale, save status, network status, notifications, inbox, and the user-menu pill.
+- The user-menu dropdown already contains the sign-out link and uses the `return-target` attribute to preserve the J2CL return route.
+- The Jakarta SSR root shell emits that same `<wavy-header>` light DOM, including the user-menu sign-out link, then appends a second top-level `slot="actions-signed-in"` sign-out anchor after the header actions.
+- That second top-level anchor is stale from before the user-menu dropdown shipped and can crowd the compact topbar next to the Admin action.
+
+## Plan
+
+1. Add a focused SSR regression test proving signed-in J2CL root markup has no top-level sign-out anchor in the shell-header actions slot.
+2. Keep the user-menu sign-out link and route-sync contract intact.
+3. Remove the stale top-level sign-out anchor from the signed-in J2CL root shell SSR path.
+4. Update the changelog because this changes visible J2CL topbar behavior.
+5. Run focused Lit/Java tests, changelog validation, diff checks, and a browser-level sanity check for visible controls.
+
+## Self-Review Of Plan
+
+- Scope stays on J2CL compact root topbar markup; it does not alter sign-out servlet behavior or GWT topbar behavior.
+- The Admin menu item remains available inside the user menu and the existing top-level Admin link is left alone so the hidden-button symptom is addressed without removing unrelated affordances.
+- Verification needs both SSR coverage and Lit coverage because the duplicate exists pre-upgrade while the working user-menu behavior lives in the upgraded element.

--- a/wave/config/changelog.d/2026-05-19-j2cl-duplicate-signout.json
+++ b/wave/config/changelog.d/2026-05-19-j2cl-duplicate-signout.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-19-j2cl-duplicate-signout",
+  "version": "J2CL parity",
+  "date": "2026-05-19",
+  "title": "J2CL no longer shows a duplicate sign-out button in the compact topbar.",
+  "summary": "The compact J2CL topbar now relies on the user-menu sign-out action only, leaving the visible topbar controls uncluttered.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Removed the duplicate top-level J2CL sign-out link while keeping sign-out available in the user menu."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3594,16 +3594,9 @@ public final class HtmlRenderer {
       appendWavyHeaderActionsSlot(
           sb, address, safeAddress, resolvedReturnTarget, safeResolvedReturnTarget,
           safeResolvedBasePath, safeHtmlLang, role, true);
-      // The legacy inline Admin and Sign out links are PRESERVED until
-      // the F-0 user-menu sheet ships (A.7 only mounts the trigger;
-      // A.8–A.18 are F-0). Removing them now would orphan affordances
-      // A.15 and A.17 on the J2CL route.
       if (isAdminOrOwner) {
         sb.append("    <a slot=\"actions-signed-in\" data-j2cl-root-admin-link=\"true\" href=\"/admin\">Admin</a>\n");
       }
-      sb.append("    <a slot=\"actions-signed-in\" data-j2cl-root-signout=\"true\" href=\"/auth/signout?r=")
-          .append(safeEncodedReturnTarget)
-          .append("\">Sign out</a>\n");
       sb.append("  </shell-header>\n");
       // F-2 slice 3 (#1047): replace the Inbox-link placeholder with a
       // full wavy-search-rail SSR'd into the existing nav slot. The

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
@@ -102,6 +102,9 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
     assertTrue(
         "compact wavy-header user menu must preserve the J2CL return target on sign out",
         html.contains("href=\"/auth/signout?r=/%3Fview%3Dj2cl-root\""));
+    assertFalse(
+        "signed-in J2CL topbar must not emit a duplicate top-level sign-out link",
+        html.contains("slot=\"actions-signed-in\" data-j2cl-root-signout=\"true\""));
     assertTrue(
         "J2CL route sync must update wavy-header return-target for the dropdown signout link",
         html.contains("document.querySelectorAll('wavy-header[return-target]').forEach(function(header){header.setAttribute('return-target', target);});"));


### PR DESCRIPTION
## Summary
- remove the stale top-level J2CL sign-out anchor from the signed-in compact root topbar
- keep sign-out available through the wavy-header user menu and preserve the route-sync data attribute
- add SSR regression coverage and a J2CL parity changelog fragment

Fixes #1293

## Verification
- RED before fix: `sbt --batch 'testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellTest'` failed on the duplicate top-level sign-out assertion\n- GREEN after fix: `sbt --batch 'testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellTest'` -> 34 passed, 0 failed\n- `npm ci` in `j2cl/lit`\n- `npm test -- --files test/wavy-header.test.js` -> 26 passed, 0 failed\n- `npm run build` -> button audit OK and Lit assets built\n- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py` -> validation passed\n- `git diff --check` -> clean\n- `bash scripts/worktree-boot.sh --port 9923` -> boot assets ready\n- Same-shell smoke start/check/probe/stop on port 9923 -> rc 0; J2CL root shell present; duplicate top-level sign-out absent in runtime probe