### PR TITLE
Fix J2CL topbar inbox and notification controls

### DIFF
--- a/j2cl/lit/src/elements/wavy-header.js
+++ b/j2cl/lit/src/elements/wavy-header.js
@@ -9,21 +9,17 @@ import { t } from "../i18n/t.js";
  * inventory):
  * - A.1 SupaWave brand link with cyan signal-dot accent
  * - A.2 Locale picker (en/de/es/fr/ru/sl/zh_TW)
- * - A.5 Notifications bell with violet unread dot (uses
- *       --wavy-signal-violet, NOT cyan)
- * - A.6 Inbox/mail icon — jumps to inbox via /?view=j2cl-root&q=in:inbox
  * - A.7 User-menu trigger: avatar chip (initials) + visible email span;
  *       click emits wavy-user-menu-requested for the F-0 menu sheet
  *       (the menu items A.8–A.18 themselves are owned by F-0 and are
  *       NOT mounted by this slice — only the trigger is)
  *
  * Public API:
- * - signedIn          — boolean (controls visibility of A.5/A.6/A.7)
+ * - signedIn          — boolean (controls visibility of A.7)
  * - locale            — current locale code (defaults to "en")
  * - address           — user's email address (data-address; reflected so
  *                       server-side templates can pass it through)
  * - userName          — display name fallback for initials (defaults to address)
- * - unreadCount       — number; A.5 dot becomes visible when > 0
  * - compact-gwt-topbar — boolean; activates GWT-parity compact mode: hides the
  *                        full email span, shortens locale labels, and reduces
  *                        icon sizing to match the 40px GWT root topbar
@@ -39,7 +35,6 @@ export class WavyHeader extends LitElement {
     address: { type: String, attribute: "data-address", reflect: true },
     userName: { type: String, attribute: "user-name" },
     userRole: { type: String, attribute: "user-role" },
-    unreadCount: { type: Number, attribute: "unread-count" },
     basePath: { type: String, attribute: "base-path" },
     returnTarget: { type: String, attribute: "return-target" },
     compactGwtTopbar: { type: Boolean, attribute: "compact-gwt-topbar", reflect: true },
@@ -128,8 +123,6 @@ export class WavyHeader extends LitElement {
       font-weight: 700;
       text-transform: uppercase;
     }
-    .bell,
-    .mail,
     .user-menu {
       background: transparent;
       color: var(--wavy-text-muted, rgba(232, 240, 255, 0.62));
@@ -141,17 +134,6 @@ export class WavyHeader extends LitElement {
       padding: var(--wavy-spacing-1, 4px) var(--wavy-spacing-2, 8px);
       border-radius: var(--wavy-radius-pill, 9999px);
       text-decoration: none;
-    }
-    :host([compact-gwt-topbar]) .bell,
-    :host([compact-gwt-topbar]) .mail {
-      width: 32px;
-      height: 32px;
-      min-width: 32px;
-      padding: 0;
-      justify-content: center;
-      color: #fff;
-      background: rgba(255, 255, 255, 0.10);
-      border-radius: 6px;
     }
     :host([compact-gwt-topbar]) .user-menu {
       width: auto;
@@ -235,42 +217,22 @@ export class WavyHeader extends LitElement {
       background: rgba(255, 255, 255, 0.18);
       transform: scale(1.05);
     }
-    :host([compact-gwt-topbar]) .bell:focus-visible,
-    :host([compact-gwt-topbar]) .mail:focus-visible,
     :host([compact-gwt-topbar]) .user-menu:focus-visible {
       outline: 2px solid rgba(255, 255, 255, 0.95);
       outline-offset: 2px;
       background: rgba(255, 255, 255, 0.18);
     }
-    :host([compact-gwt-topbar]) .bell:hover,
-    :host([compact-gwt-topbar]) .mail:hover,
     :host([compact-gwt-topbar]) .user-menu:hover {
       color: #fff;
       outline: none;
       background: rgba(255, 255, 255, 0.18);
       transform: scale(1.05);
     }
-    .bell:hover,
-    .bell:focus-visible,
-    .mail:hover,
-    .mail:focus-visible,
     .user-menu:hover,
     .user-menu:focus-visible {
       color: var(--wavy-text-body, rgba(232, 240, 255, 0.92));
       outline: none;
       background: rgba(34, 211, 238, 0.06);
-    }
-    .bell {
-      position: relative;
-    }
-    .dot.violet {
-      position: absolute;
-      top: 4px;
-      right: 4px;
-      width: 8px;
-      height: 8px;
-      border-radius: 50%;
-      background: var(--wavy-signal-violet, #7c3aed);
     }
     .avatar {
       display: inline-flex;
@@ -414,7 +376,6 @@ export class WavyHeader extends LitElement {
     this.address = "";
     this.userName = "";
     this.userRole = "user";
-    this.unreadCount = 0;
     this.basePath = "/";
     this.returnTarget = "/";
     this.compactGwtTopbar = false;
@@ -551,7 +512,6 @@ export class WavyHeader extends LitElement {
 
   render() {
     const initials = this._initials();
-    const hasUnread = (this.unreadCount || 0) > 0;
     const base = this._normalizedBasePath();
     const compact = this.compactGwtTopbar;
     const isAdminOrOwner = this.userRole === "admin" || this.userRole === "owner";
@@ -627,26 +587,6 @@ export class WavyHeader extends LitElement {
 
       ${this.signedIn
         ? html`
-            <button
-              type="button"
-              class="bell"
-              aria-label=${t("header.notifications", "Notifications")}
-              title=${t("header.notifications", "Notifications")}
-            >
-              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true">
-                <path d="M3 12h10l-1.4-1.4A2 2 0 0 1 11 9.2V7a3 3 0 0 0-6 0v2.2a2 2 0 0 1-.6 1.4L3 12z" stroke-linecap="round" stroke-linejoin="round"/>
-                <path d="M6.5 13.5a1.5 1.5 0 0 0 3 0" stroke-linecap="round"/>
-              </svg>
-              <span class="dot violet" ?hidden=${!hasUnread} aria-hidden="true"></span>
-            </button>
-
-            <a class="mail" href=${`${base}?view=j2cl-root&q=in:inbox`} aria-label=${t("header.inbox", "Inbox")} title=${t("header.inbox", "Inbox")}>
-              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" aria-hidden="true">
-                <rect x="2" y="3.5" width="12" height="9" rx="1.4"/>
-                <path d="M2.5 4.5l5.5 4 5.5-4" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-            </a>
-
             <span class="user-menu-wrap">
               <button
                 id="wavyHeaderUserMenuToggle"

--- a/j2cl/lit/src/i18n/catalogs/de.js
+++ b/j2cl/lit/src/i18n/catalogs/de.js
@@ -45,8 +45,6 @@ export const de = {
   // wavy-header.js — reused from SavedStateMessages_de + WebClientMessages_de
   "header.brand": "SupaWave Startseite",
   "header.localePicker": "Sprache",
-  "header.notifications": "Benachrichtigungen",
-  "header.inbox": "Postfach", // GWT SearchWidgetMessages_de.properties: inbox
   "header.userMenu": "Benutzermenü öffnen",
   "header.saveSaving": "Änderungen werden gespeichert",
   // GWT SavedStateMessages_de.properties: unsaved

--- a/j2cl/lit/src/i18n/catalogs/de.js
+++ b/j2cl/lit/src/i18n/catalogs/de.js
@@ -45,6 +45,7 @@ export const de = {
   // wavy-header.js — reused from SavedStateMessages_de + WebClientMessages_de
   "header.brand": "SupaWave Startseite",
   "header.localePicker": "Sprache",
+  "header.inbox": "Postfach", // GWT SearchWidgetMessages_de.properties: inbox — used by wavy-back-to-inbox
   "header.userMenu": "Benutzermenü öffnen",
   "header.saveSaving": "Änderungen werden gespeichert",
   // GWT SavedStateMessages_de.properties: unsaved

--- a/j2cl/lit/src/i18n/catalogs/en.js
+++ b/j2cl/lit/src/i18n/catalogs/en.js
@@ -43,8 +43,6 @@ export const en = {
   // wavy-header.js
   "header.brand": "SupaWave home",
   "header.localePicker": "Language",
-  "header.notifications": "Notifications",
-  "header.inbox": "Inbox",
   "header.userMenu": "Open user menu",
   "header.saveSaving": "Saving changes",
   "header.saveUnsaved": "Unsaved changes",

--- a/j2cl/lit/src/i18n/catalogs/en.js
+++ b/j2cl/lit/src/i18n/catalogs/en.js
@@ -43,6 +43,7 @@ export const en = {
   // wavy-header.js
   "header.brand": "SupaWave home",
   "header.localePicker": "Language",
+  "header.inbox": "Inbox", // used by wavy-back-to-inbox
   "header.userMenu": "Open user menu",
   "header.saveSaving": "Saving changes",
   "header.saveUnsaved": "Unsaved changes",

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -307,7 +307,7 @@ shell-header[compact-gwt-topbar] wavy-header .user-email {
 /* Mirror wavy-header compact shadow-DOM styles onto SSR light-DOM children
  * before shell.js upgrades the element.  Without these, browser-default
  * form/link controls appear on the 40px compact bar until upgrade — the
- * shadow rules (:host([compact-gwt-topbar]) .locale / .bell / …) only
+ * shadow rules (:host([compact-gwt-topbar]) .locale / .user-menu / …) only
  * fire after customElements.define() runs. */
 shell-header[compact-gwt-topbar] wavy-header .locale {
   box-sizing: border-box;
@@ -325,24 +325,6 @@ shell-header[compact-gwt-topbar] wavy-header .locale {
   text-transform: uppercase;
   cursor: pointer;
   appearance: none;
-}
-
-shell-header[compact-gwt-topbar] wavy-header .bell,
-shell-header[compact-gwt-topbar] wavy-header .mail {
-  box-sizing: border-box;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  min-width: 32px;
-  padding: 0;
-  border: 0;
-  border-radius: 6px;
-  color: #fff;
-  background: rgba(255, 255, 255, 0.10);
-  cursor: pointer;
-  text-decoration: none;
 }
 
 shell-header[compact-gwt-topbar] wavy-header .user-menu-wrap {
@@ -367,13 +349,6 @@ shell-header[compact-gwt-topbar] wavy-header .user-menu {
   background: rgba(255, 255, 255, 0.10);
   cursor: pointer;
   text-decoration: none;
-}
-
-shell-header[compact-gwt-topbar] wavy-header .bell svg,
-shell-header[compact-gwt-topbar] wavy-header .mail svg {
-  width: 16px;
-  height: 16px;
-  flex: 0 0 auto;
 }
 
 shell-header[compact-gwt-topbar] wavy-header .avatar {

--- a/j2cl/lit/test/wavy-header.test.js
+++ b/j2cl/lit/test/wavy-header.test.js
@@ -62,10 +62,13 @@ describe("<wavy-header>", () => {
   it("compact GWT topbar mode uses compact action controls", async () => {
     const el = await fixture(html`<wavy-header compact-gwt-topbar signed-in></wavy-header>`);
     await el.updateComplete;
-    const bell = el.renderRoot.querySelector("button.bell");
+    const saveStatus = el.renderRoot.querySelector(".savestatus");
+    const netStatus = el.renderRoot.querySelector(".netstatus");
 
-    expect(getComputedStyle(bell).width).to.equal("32px");
-    expect(getComputedStyle(bell).height).to.equal("32px");
+    expect(getComputedStyle(saveStatus).width).to.equal("32px");
+    expect(getComputedStyle(saveStatus).height).to.equal("32px");
+    expect(getComputedStyle(netStatus).width).to.equal("32px");
+    expect(getComputedStyle(netStatus).height).to.equal("32px");
   });
 
   it("compact GWT topbar mode uses the GWT user-menu pill geometry", async () => {
@@ -91,49 +94,14 @@ describe("<wavy-header>", () => {
     expect(el.locale).to.equal("de");
   });
 
-  it("notifications bell renders only when signed-in (A.5)", async () => {
-    const elOut = await fixture(html`<wavy-header></wavy-header>`);
-    await elOut.updateComplete;
-    expect(elOut.renderRoot.querySelector(".bell")).to.be.null;
-
-    const elIn = await fixture(
-      html`<wavy-header signed-in data-address="alice@example.com"></wavy-header>`
-    );
-    await elIn.updateComplete;
-    expect(elIn.renderRoot.querySelector(".bell")).to.exist;
-  });
-
-  it("bell unread dot toggles on unread-count > 0 (A.5)", async () => {
+  it("omits topbar notifications and inbox controls", async () => {
     const el = await fixture(
       html`<wavy-header signed-in data-address="alice@example.com"></wavy-header>`
     );
     await el.updateComplete;
-    const dot = el.renderRoot.querySelector(".bell .dot.violet");
-    expect(dot).to.exist;
-    expect(dot.hasAttribute("hidden")).to.be.true;
-    el.unreadCount = 4;
-    await el.updateComplete;
-    expect(dot.hasAttribute("hidden")).to.be.false;
-  });
 
-  it("bell unread dot uses --wavy-signal-violet, NOT cyan (A.5)", () => {
-    const cssText = WavyHeader_styleText();
-    expect(cssText).to.match(/\.dot\.violet\s*\{[^}]*var\(--wavy-signal-violet/);
-  });
-
-  it("mail icon links to /?view=j2cl-root&q=in:inbox (A.6)", async () => {
-    const el = await fixture(
-      html`<wavy-header signed-in data-address="alice@example.com"></wavy-header>`
-    );
-    await el.updateComplete;
-    const mail = el.renderRoot.querySelector("a.mail");
-    expect(mail).to.exist;
-    // F-2 slice 6 (#1058): the mail icon must keep the J2CL view selector
-    // so signed-in users stay on the wavy chrome rather than being kicked
-    // back to the legacy GWT route. The source-of-truth href is
-    // `${base}?view=j2cl-root&q=in:inbox` in wavy-header.js.
-    expect(mail.getAttribute("href")).to.equal("/?view=j2cl-root&q=in:inbox");
-    expect(mail.getAttribute("aria-label")).to.equal("Inbox");
+    expect(el.renderRoot.querySelector(".bell")).to.be.null;
+    expect(el.renderRoot.querySelector(".mail")).to.be.null;
   });
 
   it("user-menu trigger renders avatar with initials AND visible email span (A.7)", async () => {

--- a/wave/config/changelog.d/2026-05-19-j2cl-header-inbox-notifications.json
+++ b/wave/config/changelog.d/2026-05-19-j2cl-header-inbox-notifications.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-19-j2cl-header-inbox-notifications",
+  "version": "Unreleased",
+  "date": "2026-05-19",
+  "title": "J2CL topbar removes inert notification and duplicate inbox controls",
+  "summary": "The J2CL root topbar now keeps only working status, locale, and user-menu controls while Inbox remains in the left search rail like GWT.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Removed the unwired J2CL notification bell and duplicate topbar Inbox shortcut; the GWT-style Inbox filter remains available in the left search rail."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/HtmlRenderer.java
@@ -3580,11 +3580,11 @@ public final class HtmlRenderer {
           .append("<span class=\"j2cl-brand-name\">SupaWave</span>")
           .append("</span>\n");
       sb.append("    </a>\n");
-      // F-2 slice 3 (#1047): wavy header chrome (A.1, A.2, A.5, A.6,
+      // F-2 slice 3 (#1047): wavy header chrome (A.1, A.2,
       // A.7) is mounted as a <wavy-header> custom element inside the
       // signed-in actions slot. Server-side we emit the FULL inner
-      // light DOM (brand link, locale select with seven options, bell
-      // button, mail icon, user-menu trigger). The Lit upgrade
+      // light DOM (brand link, locale select with seven options,
+      // user-menu trigger). The Lit upgrade
       // re-renders the same content into the shadow DOM and wires
       // event handlers; the server-rendered light DOM is what
       // J2clSearchRailParityTest asserts on (mirrors the F-2 S1
@@ -4228,8 +4228,7 @@ public final class HtmlRenderer {
    * server-rendered HTML directly.
    *
    * <p>Affordances: A.1 brand link, A.2 locale picker (seven
-   * options), A.5 notifications bell, A.6 inbox/mail icon,
-   * A.7 user-menu trigger (avatar + email).
+   * options), A.7 user-menu trigger (avatar + email).
    */
   private static void appendWavyHeaderActionsSlot(
       StringBuilder sb, String rawAddress, String safeAddress,
@@ -4263,7 +4262,7 @@ public final class HtmlRenderer {
         .append(escapeHtml(userRole == null ? HumanAccountData.ROLE_USER : userRole))
         .append("\" return-target=\"")
         .append(safeResolvedReturnTarget)
-        .append("\" unread-count=\"0\" data-connection-state=\"online\""
+        .append("\" data-connection-state=\"online\""
             + " data-save-state=\"saved\" base-path=\"")
         .append(safeBasePath)
         .append("\">\n");
@@ -4297,20 +4296,6 @@ public final class HtmlRenderer {
           .append(ICON_WIFI)
           .append("</span>\n");
     }
-    // A.5 notifications bell — server-renders the same SVG glyph the
-    // Lit element renders so the icon does not appear empty pre-upgrade.
-    sb.append("      <button type=\"button\" class=\"bell\" aria-label=\"Notifications\">")
-        .append("<svg viewBox=\"0 0 16 16\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.4\" aria-hidden=\"true\">")
-        .append("<path d=\"M3 12h10l-1.4-1.4A2 2 0 0 1 11 9.2V7a3 3 0 0 0-6 0v2.2a2 2 0 0 1-.6 1.4L3 12z\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/>")
-        .append("<path d=\"M6.5 13.5a1.5 1.5 0 0 0 3 0\" stroke-linecap=\"round\"/></svg>")
-        .append("<span class=\"dot violet\" hidden aria-hidden=\"true\"></span></button>\n");
-    // A.6 inbox/mail icon — server-renders the envelope SVG.
-    sb.append("      <a class=\"mail\" href=\"")
-        .append(safeBasePath)
-        .append("?view=j2cl-root&amp;q=in%3Ainbox\" aria-label=\"Inbox\">")
-        .append("<svg viewBox=\"0 0 16 16\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.4\" aria-hidden=\"true\">")
-        .append("<rect x=\"2\" y=\"3.5\" width=\"12\" height=\"9\" rx=\"1.4\"/>")
-        .append("<path d=\"M2.5 4.5l5.5 4 5.5-4\" stroke-linecap=\"round\" stroke-linejoin=\"round\"/></svg></a>\n");
     sb.append("      <span class=\"user-menu-wrap\">\n");
     sb.append("        <button id=\"wavyHeaderUserMenuToggle\" type=\"button\" class=\"user-menu\" aria-haspopup=\"true\" aria-expanded=\"false\" aria-controls=\"wavyHeaderUserMenu\" aria-label=\"Open user menu\" title=\"")
         .append(escapedAddress)

--- a/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clSearchRailParityTest.java
+++ b/wave/src/jakarta-test/java/org/waveprotocol/box/server/rpc/J2clSearchRailParityTest.java
@@ -68,13 +68,12 @@ import org.waveprotocol.wave.model.wave.data.ObservableWaveletData;
  * NEW search rail + search-help modal + wavy header chrome that
  * slice 3 mounts inside {@code renderJ2clRootShellPage}.
  *
- * <p>Inventory affordances asserted (45 total, organised below):
+ * <p>Inventory affordances asserted (organised below):
  *
  * <ul>
- *   <li><b>A.1 / A.2 / A.5 / A.6 / A.7</b> — wavy header chrome:
+ *   <li><b>A.1 / A.2 / A.7</b> — wavy header chrome:
  *       brand link with cyan signal-dot, locale picker (seven
- *       options), notifications bell with violet unread dot,
- *       inbox/mail icon, user-menu trigger (avatar + visible email).
+ *       options), user-menu trigger (avatar + visible email).
  *   <li><b>B.1–B.12</b> — search rail: query box (default
  *       {@code in:inbox}) + waveform glyph; help-trigger; New Wave
  *       button with {@code aria-keyshortcuts}; Manage saved searches;
@@ -139,9 +138,9 @@ public final class J2clSearchRailParityTest {
     }
   }
 
-  /** A.1, A.2, A.5, A.6, A.7 — every chrome class marker present in light DOM. */
+  /** A.1, A.2, A.7 — header chrome stays focused on working topbar controls. */
   @Test
-  public void wavyHeaderInnerLightDomEmitsBrandLocaleBellMailUserMenuChrome()
+  public void wavyHeaderInnerLightDomEmitsBrandLocaleUserMenuChrome()
       throws Exception {
     String html = renderJ2clRootShell();
     assertTrue("A.1 brand link class", html.contains("class=\"brand\""));
@@ -149,18 +148,16 @@ public final class J2clSearchRailParityTest {
         "A.1 cyan signal-dot accent (uses --wavy-signal-cyan in the element CSS)",
         html.contains("class=\"brand-dot\""));
     assertTrue("A.2 locale picker class", html.contains("class=\"locale\""));
-    assertTrue("A.5 notifications bell class", html.contains("class=\"bell\""));
-    assertTrue(
-        "A.5 violet unread dot (initially hidden)",
-        html.contains("class=\"dot violet\" hidden"));
-    assertTrue("A.6 mail icon class", html.contains("class=\"mail\""));
-    assertTrue(
-        "A.6 mail icon links to inbox query with J2CL root routing",
-        html.contains("href=\"/?view=j2cl-root&amp;q=in%3Ainbox\""));
+    assertFalse(
+        "Notifications are not wired in J2CL and must not render",
+        html.contains("class=\"bell\""));
+    assertFalse(
+        "Topbar Inbox is duplicate of the left search rail",
+        html.contains("class=\"mail\""));
     assertTrue("A.7 user-menu trigger class", html.contains("class=\"user-menu\""));
     assertTrue(
         "A.7 user-menu trigger advertises menu popup semantics",
-        html.contains("aria-haspopup=\"menu\""));
+        html.contains("aria-haspopup=\"true\""));
     assertTrue("A.7 avatar chip class", html.contains("class=\"avatar\""));
     assertTrue(
         "A.7 visible user-email span (matches GWT inventory \"avatar + email\")",
@@ -168,15 +165,6 @@ public final class J2clSearchRailParityTest {
     assertTrue(
         "A.7 user-email content matches viewer address",
         html.contains(">alice@example.com</span>"));
-    // A.5 / A.6 SVG glyphs must SSR so the icons are visible
-    // pre-upgrade (matches the no-flicker contract used by the help
-    // modal's hidden attribute and the avatar initials parity).
-    assertTrue(
-        "A.5 bell button server-renders an SVG glyph (no empty pre-upgrade icon)",
-        html.contains("<button type=\"button\" class=\"bell\" aria-label=\"Notifications\"><svg"));
-    assertTrue(
-        "A.6 mail icon server-renders an SVG glyph (no empty pre-upgrade icon)",
-        html.contains("class=\"mail\" href=\"/?view=j2cl-root&amp;q=in%3Ainbox\" aria-label=\"Inbox\"><svg"));
   }
 
   // ---------- B.* search rail ----------

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellTest.java
@@ -83,6 +83,12 @@ public final class HtmlRendererJ2clRootShellTest extends TestCase {
     assertTrue(
         "compact wavy-header must SSR a netstatus chip",
         html.contains("class=\"netstatus\""));
+    assertFalse(
+        "compact wavy-header must not SSR inert notifications",
+        html.contains("class=\"bell\""));
+    assertFalse(
+        "compact wavy-header must not SSR duplicate Inbox shortcut",
+        html.contains("class=\"mail\""));
     assertTrue(
         "compact wavy-header must SSR the GWT-style user menu toggle",
         html.contains("id=\"wavyHeaderUserMenuToggle\""));


### PR DESCRIPTION
Closes #1294.\n\n## Summary\n- Remove the unwired J2CL topbar notification bell from Lit and server-first SSR.\n- Remove the duplicate topbar Inbox shortcut so Inbox stays in the left search rail like GWT.\n- Update focused Lit/Jakarta/SSR coverage and add a changelog fragment.\n\n## Verification\n- `npm test -- --files test/wavy-header.test.js` in `j2cl/lit`: 23 passed, 0 failed.\n- `npm run build` in `j2cl/lit`: passed.\n- `sbt --batch 'Test/testOnly org.waveprotocol.box.server.rpc.HtmlRendererJ2clRootShellTest' 'JakartaTest/testOnly org.waveprotocol.box.server.rpc.J2clSearchRailParityTest'`: 34 + 17 tests passed, 0 failed.\n- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py --changelog wave/config/changelog.json`: passed.\n- `git diff --check`: passed.\n- Staged server: `WAVE_STAGE_INCLUDE_J2CL_ASSETS=1 bash scripts/worktree-boot.sh --port 9952` passed; `PORT=9952 bash scripts/wave-smoke.sh check` passed while the staged server was kept in foreground. Detached `wave-smoke.sh start` reported READY but exited before follow-up check, so foreground mode was used for smoke evidence.