### PR TITLE
Fix J2CL root blip edit submit

### DIFF
--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -821,9 +821,27 @@ export class WaveBlip extends LitElement {
       new CustomEvent("wave-blip-edit-requested", {
         bubbles: true,
         composed: true,
-        detail: { blipId: this.blipId, waveId: this.waveId }
+        detail: {
+          blipId: this.blipId,
+          waveId: this.waveId,
+          bodySize: this.bodySize || 0,
+          bodyText: this._currentBodyText()
+        }
       })
     );
+  }
+
+  _currentBodyText() {
+    if (!this.shadowRoot) return this.textContent || "";
+    const slot = this.shadowRoot.querySelector(".body slot");
+    const roots =
+      slot && typeof slot.assignedNodes === "function"
+        ? slot.assignedNodes({ flatten: true })
+        : [];
+    if (!roots || roots.length === 0) {
+      return this.textContent || "";
+    }
+    return roots.map((node) => node.textContent || "").join("");
   }
 
   /**

--- a/j2cl/lit/src/elements/wave-blip.js
+++ b/j2cl/lit/src/elements/wave-blip.js
@@ -825,7 +825,7 @@ export class WaveBlip extends LitElement {
           blipId: this.blipId,
           waveId: this.waveId,
           bodySize: this.bodySize || 0,
-          bodyText: this._currentBodyText()
+          bodyText: this._currentBodyText().trim()
         }
       })
     );

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -425,7 +425,9 @@ describe("<wave-blip>", () => {
 
   it("re-emits wave-blip-edit-requested when toolbar Edit fires", async () => {
     const el = await fixture(html`
-      <wave-blip data-blip-id="b5" data-wave-id="w5" author-name="A"></wave-blip>
+      <wave-blip data-blip-id="b5" data-wave-id="w5" author-name="A" data-blip-doc-size="11">
+        Original root text
+      </wave-blip>
     `);
     await el.updateComplete;
     const toolbar = el.renderRoot.querySelector("wave-blip-toolbar");
@@ -434,6 +436,8 @@ describe("<wave-blip>", () => {
     setTimeout(() => editBtn.click(), 0);
     const ev = await oneEvent(el, "wave-blip-edit-requested");
     expect(ev.detail.blipId).to.equal("b5");
+    expect(ev.detail.bodySize).to.equal(11);
+    expect(ev.detail.bodyText.trim()).to.equal("Original root text");
   });
 
   // F-3.S4 (#1038, R-5.6 F.6): the Delete button on the per-blip

--- a/j2cl/lit/test/wave-blip.test.js
+++ b/j2cl/lit/test/wave-blip.test.js
@@ -437,7 +437,7 @@ describe("<wave-blip>", () => {
     const ev = await oneEvent(el, "wave-blip-edit-requested");
     expect(ev.detail.blipId).to.equal("b5");
     expect(ev.detail.bodySize).to.equal(11);
-    expect(ev.detail.bodyText.trim()).to.equal("Original root text");
+    expect(ev.detail.bodyText).to.equal("Original root text");
   });
 
   // F-3.S4 (#1038, R-5.6 F.6): the Delete button on the per-blip

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -156,6 +156,27 @@ public final class J2clComposeSurfaceController {
       onContinuationSubmitted(builder.toString(), replyTargetBlipId);
     }
 
+    default void onBlipEditSubmitted(
+        String draft, String blipId, int bodyItemCount, String originalText) {
+      onReplySubmitted(draft, blipId);
+    }
+
+    default void onBlipEditSubmittedWithComponents(
+        List<SubmittedComponent> components,
+        String blipId,
+        int bodyItemCount,
+        String originalText) {
+      StringBuilder builder = new StringBuilder();
+      if (components != null) {
+        for (SubmittedComponent component : components) {
+          if (component != null && component.getText() != null) {
+            builder.append(component.getText());
+          }
+        }
+      }
+      onBlipEditSubmitted(builder.toString(), blipId, bodyItemCount, originalText);
+    }
+
     /**
      * GWT parity (cursor-anchored inline reply): wave-blip captured the
      * caret's wave-doc item offset inside the parent body before the
@@ -466,6 +487,18 @@ public final class J2clComposeSurfaceController {
         int inlineAnchorItemOffset,
         int parentBodyItemCount) {
       return createReplyRequest(address, session, draftText, document);
+    }
+
+    default SidecarSubmitRequest createBlipEditRequest(
+        String address,
+        J2clSidecarWriteSession session,
+        String blipId,
+        String draftText,
+        J2clComposerDocument document,
+        int bodyItemCount,
+        String originalText) {
+      throw new UnsupportedOperationException(
+          "Blip edit is only available with the rich-content delta factory.");
     }
 
     /**
@@ -958,6 +991,23 @@ public final class J2clComposeSurfaceController {
           }
 
           @Override
+          public void onBlipEditSubmitted(
+              String draft, String blipId, int bodyItemCount, String originalText) {
+            J2clComposeSurfaceController.this.onBlipEditSubmitted(
+                draft, blipId, bodyItemCount, originalText);
+          }
+
+          @Override
+          public void onBlipEditSubmittedWithComponents(
+              List<SubmittedComponent> components,
+              String blipId,
+              int bodyItemCount,
+              String originalText) {
+            J2clComposeSurfaceController.this.onBlipEditSubmittedWithComponents(
+                components, blipId, bodyItemCount, originalText);
+          }
+
+          @Override
           public void onInlineReplyAnchorRequested(
               String blipId, int anchorItemOffset, int parentBodyItemCount) {
             J2clComposeSurfaceController.this.onInlineReplyAnchorRequested(
@@ -1288,6 +1338,32 @@ public final class J2clComposeSurfaceController {
   public void onContinuationSubmittedWithComponents(
       List<SubmittedComponent> components, String replyTargetBlipId) {
     submitWithComponents(components, replyTargetBlipId, true);
+  }
+
+  public void onBlipEditSubmitted(
+      String draft, String blipId, int bodyItemCount, String originalText) {
+    replyDraft = normalizeDraft(draft);
+    pendingSubmittedComponents = null;
+    submitBlipEdit(blipId, bodyItemCount, originalText);
+  }
+
+  public void onBlipEditSubmittedWithComponents(
+      List<SubmittedComponent> components, String blipId, int bodyItemCount, String originalText) {
+    if (components == null) {
+      replyDraft = normalizeDraft("");
+      pendingSubmittedComponents = null;
+      submitBlipEdit(blipId, bodyItemCount, originalText);
+      return;
+    }
+    StringBuilder plainBuilder = new StringBuilder();
+    for (SubmittedComponent component : components) {
+      if (component != null && component.getText() != null) {
+        plainBuilder.append(component.getText());
+      }
+    }
+    replyDraft = normalizeDraft(plainBuilder.toString());
+    pendingSubmittedComponents = new ArrayList<SubmittedComponent>(components);
+    submitBlipEdit(blipId, bodyItemCount, originalText);
   }
 
   private void submitWithComponents(
@@ -2503,6 +2579,83 @@ public final class J2clComposeSurfaceController {
         error -> handleReplyFailure(generation, error));
   }
 
+  private void submitBlipEdit(String blipId, int bodyItemCount, String originalText) {
+    if (signedOut || replySubmitting) {
+      render();
+      return;
+    }
+    if (writeSession == null || isEmpty(writeSession.getSelectedWaveId())) {
+      replyStatusText = "";
+      replyErrorText =
+          hasSelectedWaveContext()
+              ? WAITING_FOR_WRITE_SESSION_REPLY_MESSAGE
+              : "Open a wave before editing a blip.";
+      render();
+      return;
+    }
+    String normalizedBlipId = blipId == null ? "" : blipId.trim();
+    if (normalizedBlipId.isEmpty()) {
+      replyStatusText = "";
+      replyErrorText = "Choose a blip before editing.";
+      render();
+      return;
+    }
+    if (bodyItemCount <= 0) {
+      replyStatusText = "";
+      replyErrorText = "Cannot edit this blip until its document metadata is loaded.";
+      render();
+      return;
+    }
+    if (replyDraft.trim().isEmpty() && insertedAttachments.isEmpty()) {
+      replyStatusText = "";
+      replyErrorText = EMPTY_REPLY_VALIDATION_MESSAGE;
+      render();
+      return;
+    }
+    replySubmitting = true;
+    replyStaleBasis = false;
+    replyStaleWaveId = null;
+    replyStatusText = "Bootstrapping the root-shell edit session.";
+    replyErrorText = "";
+    final String submittedDraft = replyDraft;
+    final String submittedAnnotationCommandId = annotationCommandId;
+    final int generation = ++replyGeneration;
+    final J2clSidecarWriteSession capturedSubmitSession = writeSession;
+    final int capturedBodyItemCount = Math.max(0, bodyItemCount);
+    final String capturedOriginalText = originalText == null ? "" : originalText;
+    render();
+    gateway.fetchRootSessionBootstrap(
+        bootstrap -> {
+          if (generation != replyGeneration) {
+            return;
+          }
+          notifyCurrentUserAddress(bootstrap.getAddress());
+          SidecarSubmitRequest request;
+          try {
+            request =
+                deltaFactory.createBlipEditRequest(
+                    bootstrap.getAddress(),
+                    capturedSubmitSession,
+                    normalizedBlipId,
+                    submittedDraft,
+                    buildDocument(submittedDraft, true, submittedAnnotationCommandId, true),
+                    capturedBodyItemCount,
+                    capturedOriginalText);
+          } catch (RuntimeException e) {
+            handleReplyFailure(generation, messageOrDefault(e, "Unable to build the edit request."));
+            return;
+          }
+          replyStatusText = "Submitting the edit.";
+          render();
+          gateway.submit(
+              bootstrap,
+              request,
+              response -> handleReplyResponse(generation, capturedSubmitSession, request, response),
+              error -> handleReplyFailure(generation, error));
+        },
+        error -> handleReplyFailure(generation, error));
+  }
+
   private J2clSidecarWriteSession sessionForReplyTarget(
       String replyTargetBlipId, boolean continuation) {
     if (writeSession == null) {
@@ -2959,6 +3112,18 @@ public final class J2clComposeSurfaceController {
           int parentBodyItemCount) {
         return factory.createReplyRequest(
             address, session, document, inlineAnchorItemOffset, parentBodyItemCount);
+      }
+
+      @Override
+      public SidecarSubmitRequest createBlipEditRequest(
+          String address,
+          J2clSidecarWriteSession session,
+          String blipId,
+          String draftText,
+          J2clComposerDocument document,
+          int bodyItemCount,
+          String originalText) {
+        return factory.blipEditRequest(address, session, blipId, document, bodyItemCount, originalText);
       }
 
       @Override

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -158,7 +158,7 @@ public final class J2clComposeSurfaceController {
 
     default void onBlipEditSubmitted(
         String draft, String blipId, int bodyItemCount, String originalText) {
-      onReplySubmitted(draft, blipId);
+      throw new UnsupportedOperationException("Blip edit submit handler is not wired.");
     }
 
     default void onBlipEditSubmittedWithComponents(
@@ -166,15 +166,7 @@ public final class J2clComposeSurfaceController {
         String blipId,
         int bodyItemCount,
         String originalText) {
-      StringBuilder builder = new StringBuilder();
-      if (components != null) {
-        for (SubmittedComponent component : components) {
-          if (component != null && component.getText() != null) {
-            builder.append(component.getText());
-          }
-        }
-      }
-      onBlipEditSubmitted(builder.toString(), blipId, bodyItemCount, originalText);
+      throw new UnsupportedOperationException("Blip edit submit handler is not wired.");
     }
 
     /**
@@ -679,6 +671,10 @@ public final class J2clComposeSurfaceController {
       "Wait for attachment uploads to finish before replying.";
   static final String EMPTY_REPLY_VALIDATION_MESSAGE =
       "Enter text or attach a file before replying.";
+  static final String EMPTY_EDIT_VALIDATION_MESSAGE =
+      "Enter text or attach a file before saving this edit.";
+  static final String STRUCTURAL_BLIP_EDIT_MESSAGE =
+      "This blip contains inline structure that cannot be safely edited here yet.";
   static final String WAITING_FOR_WRITE_SESSION_REPLY_MESSAGE =
       "Wait for the selected wave to finish opening before sending a reply.";
   // Legacy constructors are not used by the root shell; production passes the root session seed.
@@ -2606,9 +2602,22 @@ public final class J2clComposeSurfaceController {
       render();
       return;
     }
+    String normalizedOriginalText = originalText == null ? "" : originalText.trim();
+    if (bodyItemCount != normalizedOriginalText.length()) {
+      replyStatusText = "";
+      replyErrorText = STRUCTURAL_BLIP_EDIT_MESSAGE;
+      render();
+      return;
+    }
+    if (hasPendingAttachmentUpload()) {
+      replyStatusText = "";
+      replyErrorText = PENDING_ATTACHMENT_REPLY_MESSAGE;
+      render();
+      return;
+    }
     if (replyDraft.trim().isEmpty() && insertedAttachments.isEmpty()) {
       replyStatusText = "";
-      replyErrorText = EMPTY_REPLY_VALIDATION_MESSAGE;
+      replyErrorText = EMPTY_EDIT_VALIDATION_MESSAGE;
       render();
       return;
     }
@@ -2622,7 +2631,7 @@ public final class J2clComposeSurfaceController {
     final int generation = ++replyGeneration;
     final J2clSidecarWriteSession capturedSubmitSession = writeSession;
     final int capturedBodyItemCount = Math.max(0, bodyItemCount);
-    final String capturedOriginalText = originalText == null ? "" : originalText;
+    final String capturedOriginalText = normalizedOriginalText;
     render();
     gateway.fetchRootSessionBootstrap(
         bootstrap -> {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -2602,7 +2602,7 @@ public final class J2clComposeSurfaceController {
       render();
       return;
     }
-    String normalizedOriginalText = originalText == null ? "" : originalText.trim();
+    String normalizedOriginalText = originalText == null ? "" : originalText;
     if (bodyItemCount != normalizedOriginalText.length()) {
       replyStatusText = "";
       replyErrorText = STRUCTURAL_BLIP_EDIT_MESSAGE;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -157,7 +157,7 @@ public final class J2clComposeSurfaceController {
     }
 
     default void onBlipEditSubmitted(
-        String draft, String blipId, int bodyItemCount, String originalText) {
+        String draft, String blipId, int bodyItemCount, String originalText, String waveId) {
       throw new UnsupportedOperationException("Blip edit submit handler is not wired.");
     }
 
@@ -165,7 +165,8 @@ public final class J2clComposeSurfaceController {
         List<SubmittedComponent> components,
         String blipId,
         int bodyItemCount,
-        String originalText) {
+        String originalText,
+        String waveId) {
       throw new UnsupportedOperationException("Blip edit submit handler is not wired.");
     }
 
@@ -988,9 +989,9 @@ public final class J2clComposeSurfaceController {
 
           @Override
           public void onBlipEditSubmitted(
-              String draft, String blipId, int bodyItemCount, String originalText) {
+              String draft, String blipId, int bodyItemCount, String originalText, String waveId) {
             J2clComposeSurfaceController.this.onBlipEditSubmitted(
-                draft, blipId, bodyItemCount, originalText);
+                draft, blipId, bodyItemCount, originalText, waveId);
           }
 
           @Override
@@ -998,9 +999,10 @@ public final class J2clComposeSurfaceController {
               List<SubmittedComponent> components,
               String blipId,
               int bodyItemCount,
-              String originalText) {
+              String originalText,
+              String waveId) {
             J2clComposeSurfaceController.this.onBlipEditSubmittedWithComponents(
-                components, blipId, bodyItemCount, originalText);
+                components, blipId, bodyItemCount, originalText, waveId);
           }
 
           @Override
@@ -1337,18 +1339,22 @@ public final class J2clComposeSurfaceController {
   }
 
   public void onBlipEditSubmitted(
-      String draft, String blipId, int bodyItemCount, String originalText) {
+      String draft, String blipId, int bodyItemCount, String originalText, String waveId) {
     replyDraft = normalizeDraft(draft);
     pendingSubmittedComponents = null;
-    submitBlipEdit(blipId, bodyItemCount, originalText);
+    submitBlipEdit(blipId, bodyItemCount, originalText, waveId);
   }
 
   public void onBlipEditSubmittedWithComponents(
-      List<SubmittedComponent> components, String blipId, int bodyItemCount, String originalText) {
+      List<SubmittedComponent> components,
+      String blipId,
+      int bodyItemCount,
+      String originalText,
+      String waveId) {
     if (components == null) {
       replyDraft = normalizeDraft("");
       pendingSubmittedComponents = null;
-      submitBlipEdit(blipId, bodyItemCount, originalText);
+      submitBlipEdit(blipId, bodyItemCount, originalText, waveId);
       return;
     }
     StringBuilder plainBuilder = new StringBuilder();
@@ -1359,7 +1365,7 @@ public final class J2clComposeSurfaceController {
     }
     replyDraft = normalizeDraft(plainBuilder.toString());
     pendingSubmittedComponents = new ArrayList<SubmittedComponent>(components);
-    submitBlipEdit(blipId, bodyItemCount, originalText);
+    submitBlipEdit(blipId, bodyItemCount, originalText, waveId);
   }
 
   private void submitWithComponents(
@@ -2575,7 +2581,8 @@ public final class J2clComposeSurfaceController {
         error -> handleReplyFailure(generation, error));
   }
 
-  private void submitBlipEdit(String blipId, int bodyItemCount, String originalText) {
+  private void submitBlipEdit(
+      String blipId, int bodyItemCount, String originalText, String waveId) {
     if (signedOut || replySubmitting) {
       render();
       return;
@@ -2586,6 +2593,14 @@ public final class J2clComposeSurfaceController {
           hasSelectedWaveContext()
               ? WAITING_FOR_WRITE_SESSION_REPLY_MESSAGE
               : "Open a wave before editing a blip.";
+      render();
+      return;
+    }
+    String sessionWaveId = writeSession.getSelectedWaveId();
+    String normalizedEditWaveId = waveId == null ? "" : waveId.trim();
+    if (!normalizedEditWaveId.isEmpty() && !normalizedEditWaveId.equals(sessionWaveId)) {
+      replyStatusText = "";
+      replyErrorText = "The wave was switched since the edit was opened. Please try again.";
       render();
       return;
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -246,7 +246,8 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
                   eventDetailString(event, "blipId"),
                   "edit",
                   eventDetailInt(event, "bodySize", 0),
-                  eventDetailString(event, "bodyText")));
+                  eventDetailString(event, "bodyText"),
+                  eventDetailString(event, "waveId")));
       DomGlobal.document.body.addEventListener(
           "wave-root-reply-requested",
           event -> openInlineComposer("", "wave-root"));
@@ -495,11 +496,11 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
 
   /** F-3.S1 entrypoint: mount a `<wavy-composer>` inline at the originating blip. */
   private void openInlineComposer(String blipId, String mode) {
-    openInlineComposer(blipId, mode, 0, "");
+    openInlineComposer(blipId, mode, 0, "", "");
   }
 
   private void openInlineComposer(
-      String blipId, String mode, int bodyItemCount, String originalText) {
+      String blipId, String mode, int bodyItemCount, String originalText, String waveId) {
     String key = blipId == null ? "" : blipId;
     if (inlineComposers.containsKey(key)) {
       HTMLElement cached = inlineComposers.get(key);
@@ -512,6 +513,7 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           cached.setAttribute(
               "data-edit-body-item-count", String.valueOf(Math.max(0, bodyItemCount)));
           cached.setAttribute("data-edit-original-text", originalText == null ? "" : originalText);
+          cached.setAttribute("data-edit-wave-id", waveId == null ? "" : waveId);
           setProperty(cached, "draft", originalText == null ? "" : originalText);
         }
         setProperty(cached, "mode", mode);
@@ -543,6 +545,7 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
       composer.setAttribute(
           "data-edit-body-item-count", String.valueOf(Math.max(0, bodyItemCount)));
       composer.setAttribute("data-edit-original-text", originalText == null ? "" : originalText);
+      composer.setAttribute("data-edit-wave-id", waveId == null ? "" : waveId);
     }
     setProperty(composer, "available", true);
     setProperty(composer, "mode", mode);
@@ -577,12 +580,13 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           boolean edit = "edit".equals(currentMode);
           int editBodyItemCount = parseInt(composer.getAttribute("data-edit-body-item-count"), 0);
           String editOriginalText = composer.getAttribute("data-edit-original-text");
+          String editWaveId = composer.getAttribute("data-edit-wave-id");
           List<J2clComposeSurfaceController.SubmittedComponent> components =
               decodeSubmittedComponents(event);
           if (components.isEmpty()) {
             String draft = propertyString(composer, "draft");
             if (edit) {
-              listener.onBlipEditSubmitted(draft, key, editBodyItemCount, editOriginalText);
+              listener.onBlipEditSubmitted(draft, key, editBodyItemCount, editOriginalText, editWaveId);
             } else if (continuation) {
               listener.onContinuationSubmitted(draft, key);
             } else {
@@ -591,7 +595,7 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           } else {
             if (edit) {
               listener.onBlipEditSubmittedWithComponents(
-                  components, key, editBodyItemCount, editOriginalText);
+                  components, key, editBodyItemCount, editOriginalText, editWaveId);
             } else if (continuation) {
               listener.onContinuationSubmittedWithComponents(components, key);
             } else {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -241,7 +241,12 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           event -> openInlineComposer(eventDetailString(event, "blipId"), "continuation"));
       DomGlobal.document.body.addEventListener(
           "wave-blip-edit-requested",
-          event -> openInlineComposer(eventDetailString(event, "blipId"), "edit"));
+          event ->
+              openInlineComposer(
+                  eventDetailString(event, "blipId"),
+                  "edit",
+                  eventDetailInt(event, "bodySize", 0),
+                  eventDetailString(event, "bodyText")));
       DomGlobal.document.body.addEventListener(
           "wave-root-reply-requested",
           event -> openInlineComposer("", "wave-root"));
@@ -490,6 +495,11 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
 
   /** F-3.S1 entrypoint: mount a `<wavy-composer>` inline at the originating blip. */
   private void openInlineComposer(String blipId, String mode) {
+    openInlineComposer(blipId, mode, 0, "");
+  }
+
+  private void openInlineComposer(
+      String blipId, String mode, int bodyItemCount, String originalText) {
     String key = blipId == null ? "" : blipId;
     if (inlineComposers.containsKey(key)) {
       HTMLElement cached = inlineComposers.get(key);
@@ -498,6 +508,12 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
         // the same blip must surface the new verb in the host chip and in
         // emitted event details) and re-focus.
         cached.setAttribute("mode", mode);
+        if ("edit".equals(mode)) {
+          cached.setAttribute(
+              "data-edit-body-item-count", String.valueOf(Math.max(0, bodyItemCount)));
+          cached.setAttribute("data-edit-original-text", originalText == null ? "" : originalText);
+          setProperty(cached, "draft", originalText == null ? "" : originalText);
+        }
         setProperty(cached, "mode", mode);
         cached.dispatchEvent(new Event("composer-focus-request"));
         activeInlineComposerKey = key;
@@ -523,6 +539,11 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     composer.setAttribute("data-inline-composer", "true");
     composer.setAttribute("reply-target-blip-id", key);
     composer.setAttribute("mode", mode);
+    if ("edit".equals(mode)) {
+      composer.setAttribute(
+          "data-edit-body-item-count", String.valueOf(Math.max(0, bodyItemCount)));
+      composer.setAttribute("data-edit-original-text", originalText == null ? "" : originalText);
+    }
     setProperty(composer, "available", true);
     setProperty(composer, "mode", mode);
     composer.addEventListener(
@@ -553,17 +574,25 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
             currentMode = composer.getAttribute("mode");
           }
           boolean continuation = "continuation".equals(currentMode);
+          boolean edit = "edit".equals(currentMode);
+          int editBodyItemCount = parseInt(composer.getAttribute("data-edit-body-item-count"), 0);
+          String editOriginalText = composer.getAttribute("data-edit-original-text");
           List<J2clComposeSurfaceController.SubmittedComponent> components =
               decodeSubmittedComponents(event);
           if (components.isEmpty()) {
             String draft = propertyString(composer, "draft");
-            if (continuation) {
+            if (edit) {
+              listener.onBlipEditSubmitted(draft, key, editBodyItemCount, editOriginalText);
+            } else if (continuation) {
               listener.onContinuationSubmitted(draft, key);
             } else {
               listener.onReplySubmitted(draft, key);
             }
           } else {
-            if (continuation) {
+            if (edit) {
+              listener.onBlipEditSubmittedWithComponents(
+                  components, key, editBodyItemCount, editOriginalText);
+            } else if (continuation) {
               listener.onContinuationSubmittedWithComponents(components, key);
             } else {
               listener.onReplySubmittedWithComponents(components, key);
@@ -602,6 +631,9 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     activeInlineComposerKey = key;
     // Project current model state onto the new composer.
     mirrorComposerStateFromReplyElement(composer);
+    if ("edit".equals(mode)) {
+      setProperty(composer, "draft", originalText == null ? "" : originalText);
+    }
     composer.dispatchEvent(new Event("composer-focus-request"));
     if (scrollAnchor != null) {
       scrollAnchor.scrollTop = scrollTopBeforeMount;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -714,7 +714,14 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
   private void mirrorComposerState(HTMLElement composer, J2clComposeSurfaceModel model) {
     setProperty(composer, "available", model.isReplyAvailable());
     setProperty(composer, "targetLabel", model.getReplyTargetLabel());
-    setProperty(composer, "draft", model.getReplyDraft());
+    // Edit-mode composers seed their draft from the blip body in openInlineComposer
+    // and the user's own changes flow back via draft-change → replyDraft. Overwriting
+    // with model.getReplyDraft() on each render would clear the seeded originalText
+    // before the user starts typing (replyDraft is empty or carries a stale reply).
+    String composerMode = composer.getAttribute("mode");
+    if (!"edit".equals(composerMode)) {
+      setProperty(composer, "draft", model.getReplyDraft());
+    }
     setProperty(composer, "submitting", model.isReplySubmitting());
     setProperty(composer, "staleBasis", model.isReplyStaleBasis());
     setProperty(composer, "status", model.getReplyStatusText());

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -500,6 +500,11 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
   }
 
   private void openInlineComposer(
+      String blipId, String mode, int bodyItemCount, String originalText) {
+    openInlineComposer(blipId, mode, bodyItemCount, originalText, "");
+  }
+
+  private void openInlineComposer(
       String blipId, String mode, int bodyItemCount, String originalText, String waveId) {
     String key = blipId == null ? "" : blipId;
     if (inlineComposers.containsKey(key)) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -311,7 +311,7 @@ public final class J2clRichContentDeltaFactory {
       throw new IllegalArgumentException("Invalid write-session base version.");
     }
     StringBuilder components = new StringBuilder();
-    String existingText = originalText == null ? "" : originalText.trim();
+    String existingText = originalText == null ? "" : originalText;
     if (bodyItemCount != existingText.length()) {
       throw new IllegalArgumentException(
           "Blip edit currently supports text-only bodies; structural body items were detected.");

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -311,7 +311,11 @@ public final class J2clRichContentDeltaFactory {
       throw new IllegalArgumentException("Invalid write-session base version.");
     }
     StringBuilder components = new StringBuilder();
-    String existingText = originalText == null ? "" : originalText;
+    String existingText = originalText == null ? "" : originalText.trim();
+    if (bodyItemCount != existingText.length()) {
+      throw new IllegalArgumentException(
+          "Blip edit currently supports text-only bodies; structural body items were detected.");
+    }
     if (!existingText.isEmpty()) {
       appendDeleteCharacters(components, existingText);
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -288,6 +288,43 @@ public final class J2clRichContentDeltaFactory {
         bodyItemCount);
   }
 
+  public SidecarSubmitRequest blipEditRequest(
+      String address,
+      J2clSidecarWriteSession session,
+      String blipId,
+      J2clComposerDocument document,
+      int bodyItemCount,
+      String originalText) {
+    requirePresent(session, "Missing write session.");
+    requirePresent(document, "Missing composer document.");
+    String normalizedAddress = normalizeAddress(address);
+    extractDomain(normalizedAddress);
+    String selectedWaveId =
+        requireNonEmpty(session.getSelectedWaveId(), "Missing selected wave id.");
+    String historyHash =
+        requireNonEmpty(session.getHistoryHash(), "Missing write-session history hash.");
+    String channelId = requireNonEmpty(session.getChannelId(), "Missing write-session channel id.");
+    String documentId = requireNonEmpty(blipId, "Missing blip id.");
+    requirePositiveBodyItemCount(bodyItemCount);
+    long baseVersion = session.getBaseVersion();
+    if (baseVersion < 0) {
+      throw new IllegalArgumentException("Invalid write-session base version.");
+    }
+    StringBuilder components = new StringBuilder();
+    String existingText = originalText == null ? "" : originalText;
+    if (!existingText.isEmpty()) {
+      appendDeleteCharacters(components, existingText);
+    }
+    appendDocumentComponents(components, document);
+    String deltaJson =
+        buildDeltaJson(
+            baseVersion,
+            historyHash,
+            normalizedAddress,
+            buildRawDocumentOperation(documentId, components.toString()));
+    return new SidecarSubmitRequest(buildWaveletName(selectedWaveId), deltaJson, channelId);
+  }
+
   public SidecarSubmitRequest addParticipantRequest(
       String address, J2clSidecarWriteSession session, List<String> participantsToAdd) {
     WriteContext context = requireWriteContext(address, session);
@@ -1172,6 +1209,12 @@ public final class J2clRichContentDeltaFactory {
 
   private String buildDocumentOperation(String documentId, J2clComposerDocument document) {
     StringBuilder components = new StringBuilder();
+    appendDocumentComponents(components, document);
+    return buildRawDocumentOperation(documentId, components.toString());
+  }
+
+  private static void appendDocumentComponents(
+      StringBuilder components, J2clComposerDocument document) {
     for (J2clComposerDocument.Component component : document.getComponents()) {
       switch (component.type) {
         case TEXT:
@@ -1232,7 +1275,6 @@ public final class J2clRichContentDeltaFactory {
           break;
       }
     }
-    return buildRawDocumentOperation(documentId, components.toString());
   }
 
   private String buildRawDocumentOperation(String documentId, String componentsJson) {
@@ -1247,7 +1289,7 @@ public final class J2clRichContentDeltaFactory {
     return operation.toString();
   }
 
-  private void appendImageAttachment(
+  private static void appendImageAttachment(
       StringBuilder components, J2clComposerDocument.Component component) {
     components
         .append("{\"3\":{\"1\":\"image\",\"2\":[{\"1\":\"attachment\",\"2\":\"")
@@ -1295,6 +1337,11 @@ public final class J2clRichContentDeltaFactory {
 
   private static void appendCharacters(StringBuilder builder, String text) {
     builder.append("{\"2\":\"").append(escapeJson(text)).append("\"}");
+  }
+
+  private static void appendDeleteCharacters(StringBuilder builder, String text) {
+    appendComponentSeparator(builder);
+    builder.append("{\"6\":\"").append(escapeJson(text)).append("\"}");
   }
 
   private static void appendAnnotationStart(StringBuilder builder, String key, String value) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -125,7 +125,7 @@ public class J2clComposeSurfaceControllerTest {
     controller.start();
     controller.onWriteSessionChanged(writeSessionWithReplyTargets());
     controller.onBlipEditSubmitted(
-        "edited root text", "b+root", originalText.length(), originalText, "");
+        "edited root text", "b+root", originalText.length(), originalText, "example.com/w+1");
 
     Assert.assertNull("Edit submit must not build a reply session.", factory.lastReplySession);
     Assert.assertEquals("b+root", factory.lastEditBlipId);
@@ -149,7 +149,7 @@ public class J2clComposeSurfaceControllerTest {
 
     controller.start();
     controller.onWriteSessionChanged(writeSessionWithReplyTargets());
-    controller.onBlipEditSubmitted("edited root text", "b+root", 19, "original root text", "");
+    controller.onBlipEditSubmitted("edited root text", "b+root", 19, "original root text", "example.com/w+1");
 
     Assert.assertNull(factory.lastEditBlipId);
     Assert.assertFalse(view.model.isReplySubmitting());
@@ -180,7 +180,7 @@ public class J2clComposeSurfaceControllerTest {
         Arrays.asList(
             new J2clComposeSurfaceController.AttachmentFileSelection(new Object(), "late.png")));
 
-    controller.onBlipEditSubmitted("edited root text", "b+root", originalText.length(), originalText, "");
+    controller.onBlipEditSubmitted("edited root text", "b+root", originalText.length(), originalText, "example.com/w+1");
 
     Assert.assertNull(factory.lastEditBlipId);
     Assert.assertFalse(view.model.isReplySubmitting());
@@ -205,12 +205,39 @@ public class J2clComposeSurfaceControllerTest {
 
     controller.start();
     controller.onWriteSessionChanged(writeSessionWithReplyTargets());
-    controller.onBlipEditSubmitted("", "b+root", originalText.length(), originalText, "");
+    controller.onBlipEditSubmitted("", "b+root", originalText.length(), originalText, "example.com/w+1");
 
     Assert.assertNull(factory.lastEditBlipId);
     Assert.assertFalse(view.model.isReplySubmitting());
     Assert.assertEquals(
         J2clComposeSurfaceController.EMPTY_EDIT_VALIDATION_MESSAGE,
+        view.model.getReplyErrorText());
+  }
+
+  @Test
+  public void editSubmitRejectsStaleWaveIdAfterWaveChange() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    CapturingDeltaFactory factory = new CapturingDeltaFactory();
+    String originalText = "original root text";
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            factory,
+            waveId -> { },
+            waveId -> { });
+
+    controller.start();
+    controller.onWriteSessionChanged(writeSessionWithReplyTargets());
+    // Submit with a waveId that no longer matches the selected wave.
+    controller.onBlipEditSubmitted(
+        "edited root text", "b+root", originalText.length(), originalText, "example.com/w+stale");
+
+    Assert.assertNull(factory.lastEditBlipId);
+    Assert.assertFalse(view.model.isReplySubmitting());
+    Assert.assertEquals(
+        "The wave was switched since the edit was opened. Please try again.",
         view.model.getReplyErrorText());
   }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -125,7 +125,7 @@ public class J2clComposeSurfaceControllerTest {
     controller.start();
     controller.onWriteSessionChanged(writeSessionWithReplyTargets());
     controller.onBlipEditSubmitted(
-        "edited root text", "b+root", originalText.length(), originalText);
+        "edited root text", "b+root", originalText.length(), originalText, "");
 
     Assert.assertNull("Edit submit must not build a reply session.", factory.lastReplySession);
     Assert.assertEquals("b+root", factory.lastEditBlipId);
@@ -149,7 +149,7 @@ public class J2clComposeSurfaceControllerTest {
 
     controller.start();
     controller.onWriteSessionChanged(writeSessionWithReplyTargets());
-    controller.onBlipEditSubmitted("edited root text", "b+root", 19, "original root text");
+    controller.onBlipEditSubmitted("edited root text", "b+root", 19, "original root text", "");
 
     Assert.assertNull(factory.lastEditBlipId);
     Assert.assertFalse(view.model.isReplySubmitting());
@@ -180,7 +180,7 @@ public class J2clComposeSurfaceControllerTest {
         Arrays.asList(
             new J2clComposeSurfaceController.AttachmentFileSelection(new Object(), "late.png")));
 
-    controller.onBlipEditSubmitted("edited root text", "b+root", originalText.length(), originalText);
+    controller.onBlipEditSubmitted("edited root text", "b+root", originalText.length(), originalText, "");
 
     Assert.assertNull(factory.lastEditBlipId);
     Assert.assertFalse(view.model.isReplySubmitting());
@@ -205,7 +205,7 @@ public class J2clComposeSurfaceControllerTest {
 
     controller.start();
     controller.onWriteSessionChanged(writeSessionWithReplyTargets());
-    controller.onBlipEditSubmitted("", "b+root", originalText.length(), originalText);
+    controller.onBlipEditSubmitted("", "b+root", originalText.length(), originalText, "");
 
     Assert.assertNull(factory.lastEditBlipId);
     Assert.assertFalse(view.model.isReplySubmitting());

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -109,6 +109,31 @@ public class J2clComposeSurfaceControllerTest {
   }
 
   @Test
+  public void editSubmitUsesExistingBlipInsteadOfReplySession() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    CapturingDeltaFactory factory = new CapturingDeltaFactory();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            factory,
+            waveId -> { },
+            waveId -> { });
+
+    controller.start();
+    controller.onWriteSessionChanged(writeSessionWithReplyTargets());
+    controller.onBlipEditSubmitted(
+        "edited root text", "b+root", TEST_BODY_ITEM_COUNT, "original root text");
+
+    Assert.assertNull("Edit submit must not build a reply session.", factory.lastReplySession);
+    Assert.assertEquals("b+root", factory.lastEditBlipId);
+    Assert.assertEquals(TEST_BODY_ITEM_COUNT, factory.lastEditBodyItemCount);
+    Assert.assertEquals("original root text", factory.lastEditOriginalText);
+    Assert.assertEquals("edited root text", factory.lastDraftText);
+  }
+
+  @Test
   public void inlineReplyWithoutCapturedCaretFallsBackToParentBodyEndLikeGwt() {
     FakeGateway gateway = new FakeGateway();
     FakeView view = new FakeView();
@@ -4952,6 +4977,9 @@ public class J2clComposeSurfaceControllerTest {
     private J2clSidecarWriteSession lastReplySession = null;
     private int lastInlineAnchorItemOffset = Integer.MIN_VALUE;
     private int lastInlineAnchorParentBodyItemCount = Integer.MIN_VALUE;
+    private String lastEditBlipId = null;
+    private int lastEditBodyItemCount = Integer.MIN_VALUE;
+    private String lastEditOriginalText = null;
 
     @Override
     public J2clComposeSurfaceController.CreateWaveRequest createWaveRequest(
@@ -4998,6 +5026,24 @@ public class J2clComposeSurfaceControllerTest {
       lastInlineAnchorItemOffset = inlineAnchorItemOffset;
       lastInlineAnchorParentBodyItemCount = parentBodyItemCount;
       return createReplyRequest(address, session, draftText, document);
+    }
+
+    @Override
+    public SidecarSubmitRequest createBlipEditRequest(
+        String address,
+        J2clSidecarWriteSession session,
+        String blipId,
+        String draftText,
+        org.waveprotocol.box.j2cl.richtext.J2clComposerDocument document,
+        int bodyItemCount,
+        String originalText) {
+      lastEditBlipId = blipId;
+      lastDraftText = draftText;
+      lastDocumentComponentCount = componentCount(document);
+      lastEditBodyItemCount = bodyItemCount;
+      lastEditOriginalText = originalText;
+      return new SidecarSubmitRequest(
+          session.getSelectedWaveId() + "/~/conv+root", "{\"edit\":true}", session.getChannelId());
     }
 
     private static int componentCount(org.waveprotocol.box.j2cl.richtext.J2clComposerDocument document) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -113,6 +113,7 @@ public class J2clComposeSurfaceControllerTest {
     FakeGateway gateway = new FakeGateway();
     FakeView view = new FakeView();
     CapturingDeltaFactory factory = new CapturingDeltaFactory();
+    String originalText = "original root text";
     J2clComposeSurfaceController controller =
         new J2clComposeSurfaceController(
             gateway,
@@ -124,13 +125,93 @@ public class J2clComposeSurfaceControllerTest {
     controller.start();
     controller.onWriteSessionChanged(writeSessionWithReplyTargets());
     controller.onBlipEditSubmitted(
-        "edited root text", "b+root", TEST_BODY_ITEM_COUNT, "original root text");
+        "edited root text", "b+root", originalText.length(), originalText);
 
     Assert.assertNull("Edit submit must not build a reply session.", factory.lastReplySession);
     Assert.assertEquals("b+root", factory.lastEditBlipId);
-    Assert.assertEquals(TEST_BODY_ITEM_COUNT, factory.lastEditBodyItemCount);
-    Assert.assertEquals("original root text", factory.lastEditOriginalText);
+    Assert.assertEquals(originalText.length(), factory.lastEditBodyItemCount);
+    Assert.assertEquals(originalText, factory.lastEditOriginalText);
     Assert.assertEquals("edited root text", factory.lastDraftText);
+  }
+
+  @Test
+  public void editSubmitRejectsStructuralBodyBeforeBuildingRequest() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    CapturingDeltaFactory factory = new CapturingDeltaFactory();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            factory,
+            waveId -> { },
+            waveId -> { });
+
+    controller.start();
+    controller.onWriteSessionChanged(writeSessionWithReplyTargets());
+    controller.onBlipEditSubmitted("edited root text", "b+root", 19, "original root text");
+
+    Assert.assertNull(factory.lastEditBlipId);
+    Assert.assertFalse(view.model.isReplySubmitting());
+    Assert.assertEquals(
+        J2clComposeSurfaceController.STRUCTURAL_BLIP_EDIT_MESSAGE,
+        view.model.getReplyErrorText());
+  }
+
+  @Test
+  public void editSubmitWaitsForInFlightAttachmentUploadBeforeBuildingRequest() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    FakeAttachmentTransport transport = new FakeAttachmentTransport();
+    CapturingDeltaFactory factory = new CapturingDeltaFactory();
+    String originalText = "original root text";
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            factory,
+            testAttachmentControllerFactory(transport),
+            waveId -> { },
+            waveId -> { });
+
+    controller.start();
+    controller.onWriteSessionChanged(writeSessionWithReplyTargets());
+    controller.onAttachmentFilesSelected(
+        Arrays.asList(
+            new J2clComposeSurfaceController.AttachmentFileSelection(new Object(), "late.png")));
+
+    controller.onBlipEditSubmitted("edited root text", "b+root", originalText.length(), originalText);
+
+    Assert.assertNull(factory.lastEditBlipId);
+    Assert.assertFalse(view.model.isReplySubmitting());
+    Assert.assertEquals(
+        J2clComposeSurfaceController.PENDING_ATTACHMENT_REPLY_MESSAGE,
+        view.model.getReplyErrorText());
+  }
+
+  @Test
+  public void emptyEditUsesEditSpecificValidationMessage() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    CapturingDeltaFactory factory = new CapturingDeltaFactory();
+    String originalText = "original root text";
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            factory,
+            waveId -> { },
+            waveId -> { });
+
+    controller.start();
+    controller.onWriteSessionChanged(writeSessionWithReplyTargets());
+    controller.onBlipEditSubmitted("", "b+root", originalText.length(), originalText);
+
+    Assert.assertNull(factory.lastEditBlipId);
+    Assert.assertFalse(view.model.isReplySubmitting());
+    Assert.assertEquals(
+        J2clComposeSurfaceController.EMPTY_EDIT_VALIDATION_MESSAGE,
+        view.model.getReplyErrorText());
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
@@ -320,7 +320,7 @@ public class J2clRichContentDeltaFactoryTest {
             session,
             "b+root",
             document,
-            /* bodyItemCount= */ 17,
+            /* bodyItemCount= */ "Original root text".length(),
             "Original root text");
     String deltaJson = request.getDeltaJson();
 
@@ -334,6 +334,26 @@ public class J2clRichContentDeltaFactoryTest {
     Assert.assertFalse("Edit must not create a new reply blip.", deltaJson.contains("b+seed"));
     Assert.assertFalse(
         "Edit must not mutate the conversation manifest.", deltaJson.contains("\"thread\""));
+  }
+
+  @Test
+  public void blipEditRequestRejectsStructuralBodyItemCount() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession(
+            "example.com/w+edit", "chan-7", 44L, "ABCD", "b+root", 5, 9);
+    J2clComposerDocument document =
+        J2clComposerDocument.builder().text("Edited root text").build();
+
+    assertThrows(
+        () ->
+            factory.blipEditRequest(
+                "user@example.com",
+                session,
+                "b+root",
+                document,
+                /* bodyItemCount= */ "Original root text".length() + 1,
+                "Original root text"));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
@@ -306,6 +306,37 @@ public class J2clRichContentDeltaFactoryTest {
   }
 
   @Test
+  public void blipEditRequestTargetsExistingBlipWithoutManifestReplyInsert() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession(
+            "example.com/w+edit", "chan-7", 44L, "ABCD", "b+root", 5, 9);
+    J2clComposerDocument document =
+        J2clComposerDocument.builder().text("Edited root text").build();
+
+    SidecarSubmitRequest request =
+        factory.blipEditRequest(
+            "user@example.com",
+            session,
+            "b+root",
+            document,
+            /* bodyItemCount= */ 17,
+            "Original root text");
+    String deltaJson = request.getDeltaJson();
+
+    Assert.assertEquals("example.com/w+edit/~/conv+root", request.getWaveletName());
+    Assert.assertEquals("chan-7", request.getChannelId());
+    assertContains(
+        deltaJson,
+        "\"1\":\"b+root\"",
+        "{\"6\":\"Original root text\"}",
+        "{\"2\":\"Edited root text\"}");
+    Assert.assertFalse("Edit must not create a new reply blip.", deltaJson.contains("b+seed"));
+    Assert.assertFalse(
+        "Edit must not mutate the conversation manifest.", deltaJson.contains("\"thread\""));
+  }
+
+  @Test
   public void replyRequestAtInlineDepthLimitFallsBackToRegularSiblingReply() {
     J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
     J2clSidecarWriteSession session =

--- a/wave/config/changelog.d/2026-05-19-j2cl-root-blip-edit-submit.json
+++ b/wave/config/changelog.d/2026-05-19-j2cl-root-blip-edit-submit.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-19-j2cl-root-blip-edit-submit",
+  "version": "Unreleased",
+  "date": "2026-05-19",
+  "title": "Fix J2CL blip edit submit routing",
+  "summary": "J2CL edit mode now submits changes to the selected blip instead of creating a new reply blip.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "The J2CL Edit action captures the existing blip text and document metadata, prefills the edit composer, and routes Done through a blip-edit submit path.",
+        "Edit-mode submits now target the existing blip document and no longer mutate the conversation manifest as a reply."
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.d/2026-05-19-j2cl-root-blip-edit-submit.json
+++ b/wave/config/changelog.d/2026-05-19-j2cl-root-blip-edit-submit.json
@@ -8,8 +8,8 @@
     {
       "type": "fix",
       "items": [
-        "The J2CL Edit action captures the existing blip text and document metadata, prefills the edit composer, and routes Done through a blip-edit submit path.",
-        "Edit-mode submits now target the existing blip document and no longer mutate the conversation manifest as a reply."
+        "The J2CL edit action captures the existing blip text and document metadata, prefills the edit composer, and routes Done through a blip-edit submit path.",
+        "Edit-mode submissions now target the existing blip document and no longer mutate the conversation manifest as a reply."
       ]
     }
   ]


### PR DESCRIPTION
Fixes #1297

## Summary

- route J2CL blip edit composer submissions through a dedicated edit path instead of the reply path
- generate an edit delta against the existing blip document without inserting a reply blip or manifest thread entry
- carry root blip body metadata/current text into edit mode and prefill the inline composer
- add focused Lit and Java regression tests plus changelog fragment

## Verification

- `git diff --check`
- `cd j2cl/lit && npm test -- --files test/wave-blip.test.js` — passed, 47 tests
- `cd j2cl && ./mvnw -Dtest=J2clComposeSurfaceControllerTest,J2clRichContentDeltaFactoryTest test` — passed, 243 tests
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`
- `bash scripts/worktree-boot.sh --port 9927` — staged successfully and wrote `journal/local-verification/2026-05-19-branch-codex-j2cl-root-blip-edit-submit-20260519.md`; `wave-smoke.sh start` reached READY, but the staged wrapper exited before `wave-smoke.sh check` could probe endpoints. Startup logs showed Jetty listening on `127.0.0.1:9927` with no application error before exit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to edit existing blip messages directly within conversations.
  * Edit submissions now preserve original message structure while updating content.

* **Bug Fixes**
  * Fixed submission routing to target the existing blip for edits instead of creating new reply threads.
  * Improved validation to prevent structural body edits and detect incomplete uploads before submission.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->