### PR TITLE
Fix J2CL wave controls user-menu overlap

### DIFF
--- a/docs/superpowers/plans/2026-05-19-issue-1299-j2cl-wave-controls-overlap.md
+++ b/docs/superpowers/plans/2026-05-19-issue-1299-j2cl-wave-controls-overlap.md
@@ -1,0 +1,20 @@
+# Issue 1299: J2CL Wave Controls Overlap User Menu
+
+## Root Cause
+
+`wavy-wave-controls-toggle` is emitted as a fixed-position floating mount after `</shell-root>`. Its viewport `top/right` coordinates place it in the same 40px compact topbar band as the right-aligned `wavy-header` user-menu/avatar cluster. On narrow widths, those independent positioning systems overlap.
+
+## Plan
+
+- Add a Lit geometry regression for the compact header plus floating wave-controls toggle.
+- Keep the existing floating mount and `wavy-wave-controls-toggled` event behavior unchanged.
+- Move the floating toggle below the compact topbar so it cannot occupy the user-menu hitbox.
+- Add a changelog fragment because this is user-visible J2CL chrome behavior.
+- Verify with the focused Lit test, changelog validation, and `git diff --check`.
+
+## Acceptance Criteria
+
+- The regression fails on the current overlapping geometry.
+- The focused `wavy-wave-controls-toggle` test passes after the fix.
+- Existing toggle labels, pressed state, and event behavior still pass.
+- The changelog fragment validates.

--- a/j2cl/lit/src/elements/wavy-wave-controls-toggle.js
+++ b/j2cl/lit/src/elements/wavy-wave-controls-toggle.js
@@ -11,10 +11,9 @@ import { t } from "../i18n/t.js";
  *
  * Layout:
  *   - The host is fixed-position in the top-right of the viewport.
- *     In compact-topbar mode (body:has(shell-header[compact-gwt-topbar])) the
- *     top offset drops to --wavy-spacing-8 (40px) + --wavy-spacing-2 (8px) so
- *     the control clears the user-menu cluster. On non-compact routes the
- *     default top of --wavy-spacing-3 (12px) is used instead.
+ *     Top position is driven by --j2cl-compact-topbar-top (set in
+ *     shell-tokens.css via body:has(shell-header[compact-gwt-topbar]));
+ *     falls back to --wavy-spacing-3 (12px) on non-compact routes.
  *
  * A11y:
  *   - The inner native &lt;button&gt; carries the role + keyboard
@@ -38,14 +37,10 @@ export class WavyWaveControlsToggle extends LitElement {
   static styles = css`
     :host {
       position: fixed;
-      top: var(--wavy-spacing-3, 12px);
+      top: var(--j2cl-compact-topbar-top, var(--wavy-spacing-3, 12px));
       right: var(--wavy-spacing-5, 24px);
       z-index: 90;
       display: inline-flex;
-    }
-    /* Push below the 40px compact topbar to avoid user-menu collision. */
-    :host-context(body:has(shell-header[compact-gwt-topbar])) {
-      top: calc(var(--wavy-spacing-8, 40px) + var(--wavy-spacing-2, 8px));
     }
     /* Shift further left on mobile to clear the nav-drawer-toggle. */
     @media (max-width: 860px) {

--- a/j2cl/lit/src/elements/wavy-wave-controls-toggle.js
+++ b/j2cl/lit/src/elements/wavy-wave-controls-toggle.js
@@ -10,10 +10,11 @@ import { t } from "../i18n/t.js";
  *   - pressed: boolean — when true, controls are hidden ("compact mode").
  *
  * Layout:
- *   - The host is fixed-position in the top-right of the viewport,
- *     offset to the left of the nav-drawer-toggle on mobile (escapes
- *     the shell-root grid so it sits in the visible header band rather
- *     than below the min-height:100vh shell).
+ *   - The host is fixed-position just below the compact topbar, aligned
+ *     with the right edge of the viewport. Keeping it below the 40px
+ *     header prevents the floating control from colliding with the
+ *     right-aligned user-menu/avatar cluster while still escaping the
+ *     shell-root grid.
  *
  * A11y:
  *   - The inner native &lt;button&gt; carries the role + keyboard
@@ -37,7 +38,7 @@ export class WavyWaveControlsToggle extends LitElement {
   static styles = css`
     :host {
       position: fixed;
-      top: var(--wavy-spacing-3, 12px);
+      top: calc(40px + var(--wavy-spacing-2, 8px));
       right: var(--wavy-spacing-5, 24px);
       z-index: 90;
       display: inline-flex;

--- a/j2cl/lit/src/elements/wavy-wave-controls-toggle.js
+++ b/j2cl/lit/src/elements/wavy-wave-controls-toggle.js
@@ -11,8 +11,8 @@ import { t } from "../i18n/t.js";
  *
  * Layout:
  *   - The host is fixed-position just below the compact topbar, aligned
- *     with the right edge of the viewport. Keeping it below the 40px
- *     header prevents the floating control from colliding with the
+ *     with the right edge of the viewport. Keeping it below the topbar
+ *     (--wavy-spacing-8) prevents the floating control from colliding with the
  *     right-aligned user-menu/avatar cluster while still escaping the
  *     shell-root grid.
  *
@@ -38,7 +38,7 @@ export class WavyWaveControlsToggle extends LitElement {
   static styles = css`
     :host {
       position: fixed;
-      top: calc(40px + var(--wavy-spacing-2, 8px));
+      top: calc(var(--wavy-spacing-8, 40px) + var(--wavy-spacing-2, 8px));
       right: var(--wavy-spacing-5, 24px);
       z-index: 90;
       display: inline-flex;

--- a/j2cl/lit/src/elements/wavy-wave-controls-toggle.js
+++ b/j2cl/lit/src/elements/wavy-wave-controls-toggle.js
@@ -10,11 +10,11 @@ import { t } from "../i18n/t.js";
  *   - pressed: boolean — when true, controls are hidden ("compact mode").
  *
  * Layout:
- *   - The host is fixed-position just below the compact topbar, aligned
- *     with the right edge of the viewport. Keeping it below the topbar
- *     (--wavy-spacing-8) prevents the floating control from colliding with the
- *     right-aligned user-menu/avatar cluster while still escaping the
- *     shell-root grid.
+ *   - The host is fixed-position in the top-right of the viewport.
+ *     In compact-topbar mode (body:has(shell-header[compact-gwt-topbar])) the
+ *     top offset drops to --wavy-spacing-8 (40px) + --wavy-spacing-2 (8px) so
+ *     the control clears the user-menu cluster. On non-compact routes the
+ *     default top of --wavy-spacing-3 (12px) is used instead.
  *
  * A11y:
  *   - The inner native &lt;button&gt; carries the role + keyboard
@@ -38,10 +38,14 @@ export class WavyWaveControlsToggle extends LitElement {
   static styles = css`
     :host {
       position: fixed;
-      top: calc(var(--wavy-spacing-8, 40px) + var(--wavy-spacing-2, 8px));
+      top: var(--wavy-spacing-3, 12px);
       right: var(--wavy-spacing-5, 24px);
       z-index: 90;
       display: inline-flex;
+    }
+    /* Push below the 40px compact topbar to avoid user-menu collision. */
+    :host-context(body:has(shell-header[compact-gwt-topbar])) {
+      top: calc(var(--wavy-spacing-8, 40px) + var(--wavy-spacing-2, 8px));
     }
     /* Shift further left on mobile to clear the nav-drawer-toggle. */
     @media (max-width: 860px) {

--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -135,6 +135,14 @@ shell-root:has(> shell-header[compact-gwt-topbar]) > [slot="main"] {
   padding-top: 8px;
 }
 
+/* Top offset for fixed floating controls on compact-topbar pages.
+ * Inherits through shadow DOM via CSS custom property cascade so
+ * wavy-wave-controls-toggle (and any future floating mounts) can
+ * read it without relying on :host-context() + :has(). */
+body:has(shell-header[compact-gwt-topbar]) {
+  --j2cl-compact-topbar-top: calc(var(--wavy-spacing-8, 40px) + var(--wavy-spacing-2, 8px));
+}
+
 .j2cl-shell-splitter {
   box-sizing: border-box;
   align-self: stretch;

--- a/j2cl/lit/test/wavy-wave-controls-toggle.test.js
+++ b/j2cl/lit/test/wavy-wave-controls-toggle.test.js
@@ -3,6 +3,28 @@ import "../src/elements/shell-header.js";
 import "../src/elements/wavy-header.js";
 import "../src/elements/wavy-wave-controls-toggle.js";
 
+function ensureShellTokensLoaded() {
+  if (document.querySelector("link[data-shell-tokens-test]")) return;
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = "/src/tokens/shell-tokens.css";
+  link.dataset.shellTokensTest = "true";
+  document.head.appendChild(link);
+}
+
+async function waitForCompactTopbarToken() {
+  for (let i = 0; i < 50; i++) {
+    const probe = document.createElement("shell-header");
+    probe.setAttribute("compact-gwt-topbar", "");
+    document.body.appendChild(probe);
+    const applied = getComputedStyle(document.body).getPropertyValue("--j2cl-compact-topbar-top").trim() !== "";
+    probe.remove();
+    if (applied) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error("--j2cl-compact-topbar-top not set within 1000ms");
+}
+
 function rectsOverlap(a, b) {
   return (
     a.left < b.right &&
@@ -80,6 +102,8 @@ describe("<wavy-wave-controls-toggle>", () => {
   });
 
   it("keeps the floating toggle clear of the compact user menu", async () => {
+    ensureShellTokensLoaded();
+    await waitForCompactTopbarToken();
     const el = await fixture(html`
       <div>
         <shell-header signed-in compact-gwt-topbar style="width:100vw">

--- a/j2cl/lit/test/wavy-wave-controls-toggle.test.js
+++ b/j2cl/lit/test/wavy-wave-controls-toggle.test.js
@@ -1,5 +1,16 @@
 import { fixture, expect, html, oneEvent } from "@open-wc/testing";
+import "../src/elements/shell-header.js";
+import "../src/elements/wavy-header.js";
 import "../src/elements/wavy-wave-controls-toggle.js";
+
+function rectsOverlap(a, b) {
+  return (
+    a.left < b.right &&
+    a.right > b.left &&
+    a.top < b.bottom &&
+    a.bottom > b.top
+  );
+}
 
 describe("<wavy-wave-controls-toggle>", () => {
   it("defines the wavy-wave-controls-toggle custom element", () => {
@@ -66,5 +77,34 @@ describe("<wavy-wave-controls-toggle>", () => {
     const button = el.renderRoot.querySelector("button");
     expect(button.getAttribute("aria-pressed")).to.equal("false");
     expect(button.getAttribute("aria-label")).to.equal("Hide wave controls");
+  });
+
+  it("keeps the floating toggle clear of the compact user menu", async () => {
+    const el = await fixture(html`
+      <div>
+        <shell-header signed-in compact-gwt-topbar style="width:100vw">
+          <a slot="brand">SupaWave</a>
+          <wavy-header
+            slot="actions-signed-in"
+            signed-in
+            no-brand
+            compact-gwt-topbar
+            data-address="test@example.com"
+          ></wavy-header>
+        </shell-header>
+        <wavy-wave-controls-toggle></wavy-wave-controls-toggle>
+      </div>
+    `);
+    const header = el.querySelector("wavy-header");
+    const toggle = el.querySelector("wavy-wave-controls-toggle");
+    await header.updateComplete;
+    await toggle.updateComplete;
+
+    const userMenuRect = header.renderRoot
+      .querySelector(".user-menu")
+      .getBoundingClientRect();
+    const toggleRect = toggle.getBoundingClientRect();
+
+    expect(rectsOverlap(toggleRect, userMenuRect)).to.equal(false);
   });
 });

--- a/wave/config/changelog.d/2026-05-19-issue-1299-j2cl-wave-controls-overlap.json
+++ b/wave/config/changelog.d/2026-05-19-issue-1299-j2cl-wave-controls-overlap.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-19-issue-1299-j2cl-wave-controls-overlap",
+  "version": "Unreleased",
+  "date": "2026-05-19",
+  "title": "J2CL wave controls menu spacing",
+  "summary": "The J2CL wave-controls toggle no longer overlaps the compact topbar user menu.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Moved the floating wave-controls toggle below the compact J2CL topbar so it stays clear of the user menu and avatar controls."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #1299

## Summary
- Move the floating J2CL wave-controls toggle below the compact 40px topbar so it no longer overlaps the user-menu/avatar cluster.
- Add a Lit geometry regression for the compact header + floating toggle collision.
- Add a plan and changelog fragment for the user-visible J2CL chrome fix.

## Verification
- RED: `npm test -- --files test/wavy-wave-controls-toggle.test.js` failed after adding the regression with `expected true to equal false` for the overlap assertion.
- GREEN: `npm test -- --files test/wavy-wave-controls-toggle.test.js` passed: 7 passed, 0 failed.
- `npm test -- --files test/shell-header.test.js test/wavy-header.test.js test/wavy-wave-controls-toggle.test.js` passed: 38 passed, 0 failed.
- `npm run build` passed.
- `python3 scripts/assemble-changelog.py && python3 scripts/validate-changelog.py` passed.
- `git diff --check` passed.

## Self-review
- Scope is limited to the wave-controls toggle position and regression coverage.
- Existing toggle aria labels, pressed state, and event behavior remain covered.
- No renderer, route-sync, or data behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed visual overlap issue between the wave-controls toggle and the compact topbar user menu by repositioning the toggle below the header.

* **Tests**
  * Added regression test to ensure the toggle does not overlap with the user menu area.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->