### PR TITLE
Fix J2CL empty root blip edits

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -2618,7 +2618,7 @@ public final class J2clComposeSurfaceController {
       return;
     }
     String normalizedOriginalText = originalText == null ? "" : originalText;
-    if (bodyItemCount != normalizedOriginalText.length()) {
+    if (bodyItemCount != normalizedOriginalText.length() && !normalizedOriginalText.isEmpty()) {
       replyStatusText = "";
       replyErrorText = STRUCTURAL_BLIP_EDIT_MESSAGE;
       render();

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactory.java
@@ -313,13 +313,19 @@ public final class J2clRichContentDeltaFactory {
     StringBuilder components = new StringBuilder();
     String existingText = originalText == null ? "" : originalText;
     if (bodyItemCount != existingText.length()) {
-      throw new IllegalArgumentException(
-          "Blip edit currently supports text-only bodies; structural body items were detected.");
+      if (!existingText.isEmpty()) {
+        throw new IllegalArgumentException(
+            "Blip edit currently supports text-only bodies; structural body items were detected.");
+      }
+      appendDocumentComponents(components, document);
+      appendComponentSeparator(components);
+      appendRetain(components, bodyItemCount);
+    } else {
+      if (!existingText.isEmpty()) {
+        appendDeleteCharacters(components, existingText);
+      }
+      appendDocumentComponents(components, document);
     }
-    if (!existingText.isEmpty()) {
-      appendDeleteCharacters(components, existingText);
-    }
-    appendDocumentComponents(components, document);
     String deltaJson =
         buildDeltaJson(
             baseVersion,

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -159,6 +159,31 @@ public class J2clComposeSurfaceControllerTest {
   }
 
   @Test
+  public void editSubmitAllowsEmptyVisibleTextStructuralBody() {
+    FakeGateway gateway = new FakeGateway();
+    FakeView view = new FakeView();
+    CapturingDeltaFactory factory = new CapturingDeltaFactory();
+    J2clComposeSurfaceController controller =
+        new J2clComposeSurfaceController(
+            gateway,
+            view,
+            factory,
+            waveId -> { },
+            waveId -> { });
+
+    controller.start();
+    controller.onWriteSessionChanged(writeSessionWithReplyTargets());
+    controller.onBlipEditSubmitted(
+        "first visible text", "b+root", 2, "", "example.com/w+1");
+
+    Assert.assertEquals("b+root", factory.lastEditBlipId);
+    Assert.assertEquals(2, factory.lastEditBodyItemCount);
+    Assert.assertEquals("", factory.lastEditOriginalText);
+    Assert.assertEquals("first visible text", factory.lastDraftText);
+    Assert.assertEquals("", view.model.getReplyErrorText());
+  }
+
+  @Test
   public void editSubmitWaitsForInFlightAttachmentUploadBeforeBuildingRequest() {
     FakeGateway gateway = new FakeGateway();
     FakeView view = new FakeView();

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/richtext/J2clRichContentDeltaFactoryTest.java
@@ -357,6 +357,33 @@ public class J2clRichContentDeltaFactoryTest {
   }
 
   @Test
+  public void blipEditRequestInsertsBeforeEmptyStructuralBody() {
+    J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
+    J2clSidecarWriteSession session =
+        new J2clSidecarWriteSession(
+            "example.com/w+edit", "chan-7", 44L, "ABCD", "b+root", 5, 9);
+    J2clComposerDocument document =
+        J2clComposerDocument.builder().text("First visible text").build();
+
+    SidecarSubmitRequest request =
+        factory.blipEditRequest(
+            "user@example.com",
+            session,
+            "b+root",
+            document,
+            /* bodyItemCount= */ 2,
+            "");
+    String deltaJson = request.getDeltaJson();
+
+    Assert.assertEquals("example.com/w+edit/~/conv+root", request.getWaveletName());
+    assertContains(deltaJson, "\"1\":\"b+root\"", "{\"2\":\"First visible text\"}", "{\"5\":2}");
+    Assert.assertFalse("Edit must not delete existing structural body items.", deltaJson.contains("\"6\""));
+    Assert.assertFalse("Edit must not create a new reply blip.", deltaJson.contains("b+seed"));
+    Assert.assertFalse(
+        "Edit must not mutate the conversation manifest.", deltaJson.contains("\"thread\""));
+  }
+
+  @Test
   public void replyRequestAtInlineDepthLimitFallsBackToRegularSiblingReply() {
     J2clRichContentDeltaFactory factory = new J2clRichContentDeltaFactory("seed");
     J2clSidecarWriteSession session =

--- a/wave/config/changelog.d/2026-05-19-j2cl-empty-root-blip-edit.json
+++ b/wave/config/changelog.d/2026-05-19-j2cl-empty-root-blip-edit.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-05-19-j2cl-empty-root-blip-edit",
+  "version": "Unreleased",
+  "date": "2026-05-19",
+  "title": "Fix J2CL editing for empty root blips with replies",
+  "summary": "J2CL can now edit an empty-looking root blip that still contains inline reply structure.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Editing an empty-looking J2CL root blip now inserts the new text while preserving existing inline reply structure.",
+        "J2CL still blocks edits for blips that mix visible text with unsupported inline structure until full structural edit support is available."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #1301

## Summary

- allow J2CL blip edit submit only for the safe empty-visible-text structural case
- insert the submitted edit content while retaining existing inline reply structure
- keep non-empty structural blips blocked until full structural edit support exists
- add focused controller and delta-factory regression coverage plus changelog fragment

## Verification

- RED: `cd j2cl && ./mvnw -Dtest=J2clComposeSurfaceControllerTest,J2clRichContentDeltaFactoryTest test` failed on the new regression cases before the fix
- `git diff --check`
- `cd j2cl && ./mvnw -Dtest=J2clComposeSurfaceControllerTest,J2clRichContentDeltaFactoryTest test` — passed, 250 tests
- `python3 scripts/assemble-changelog.py`
- `python3 scripts/validate-changelog.py --fragments-dir wave/config/changelog.d --changelog wave/config/changelog.json`

## Local server sanity

- `bash scripts/worktree-boot.sh --port 9931` reached GWT compilation, then failed with `java.io.IOException: No space left on device` while writing `gwt-unitCache`. This is an environment disk-space blocker before app startup, not a failure in the touched J2CL edit code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that blocked editing of blips when the original text was empty but the blip contained structural content (such as inline reply structures). Users can now submit edits that were previously incorrectly rejected.
  * Edit validation safeguards remain active to prevent problematic combinations of visible text with unsupported inline structures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vega113/supawave/pull/1302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->