### PR TITLE
Fix J2CL mobile shell horizontal overflow

### DIFF
--- a/j2cl/lit/src/tokens/shell-tokens.css
+++ b/j2cl/lit/src/tokens/shell-tokens.css
@@ -704,7 +704,14 @@ shell-status-strip {
 
 @media (max-width: 860px) {
   shell-root {
-    grid-template-columns: 1fr;
+    /* Use minmax(0, 1fr) rather than the bare `1fr` (which resolves to
+     * minmax(auto, 1fr)). A bare `1fr` column grows to the largest
+     * min-content of its grid items, so the wide nowrap compact topbar
+     * forced the single column — and therefore the nav rail, digest
+     * cards and wave panel — to ~402px on a 375px phone, clipping the
+     * right edge of unread counts/badges. minmax(0, 1fr) lets the column
+     * shrink to the viewport so content stays inside the screen. */
+    grid-template-columns: minmax(0, 1fr);
     grid-template-rows: auto auto auto 1fr auto auto;
     grid-template-areas:
       "skip"

--- a/wave/config/changelog.d/2026-05-24-j2cl-mobile-shell-overflow.json
+++ b/wave/config/changelog.d/2026-05-24-j2cl-mobile-shell-overflow.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-05-24-j2cl-mobile-shell-overflow",
+  "version": "PR #1305",
+  "date": "2026-05-24",
+  "title": "Fix inbox content getting cut off on the right on phones",
+  "summary": "On phone-sized screens the inbox list was wider than the viewport, so each wave's timestamp, message count and unread badge were clipped off the right edge. The layout now fits the screen.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Constrain the mobile root-shell layout to the viewport width so the inbox digest no longer overflows and clips unread counts and badges on the right edge."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
On phone widths the J2CL root shell digest/inbox overflowed horizontally, clipping the right edge of each wave row (timestamps, message counts and **unread badges**) off-screen — matching the reported mobile UI issue.

**Root cause:** the `@media (max-width: 860px)` rule in `j2cl/lit/src/tokens/shell-tokens.css` set `grid-template-columns: 1fr`. A bare `1fr` resolves to `minmax(auto, 1fr)`, whose `auto` minimum is the largest *min-content* of the column's grid items. The wide `nowrap` compact topbar has a ~402px min-content, so the single column — and therefore the nav rail, digest cards and wave panel — were all forced to ~402px on a 375px phone. The extra ~27px was clipped at the right edge (no scroll, `overflow: hidden`).

**Fix:** use `grid-template-columns: minmax(0, 1fr)` for the mobile breakpoint so the column can shrink to the viewport. Digest content now stays inside the screen; `.inner { overflow: hidden }` keeps titles/snippets gracefully ellipsised. Desktop (>860px) is unchanged.

## Verification (real local server, `?view=j2cl-root`)
- **375px (mobile):** before — `shell-root` single column resolved to `401.5px`; `shell-header`, `shell-nav-rail`, `wavy-search-rail`, `wavy-search-rail-card`, `shell-main-region` all `402px` (unread badge clipped). After — all `375px`, nothing extends past the viewport, unread badge fully visible.
- **1280px (desktop):** still resolves to `400px 6px 874px` (three-column layout intact), no regression.

## Test plan
- [ ] Open `?view=j2cl-root` on a phone-width viewport (<=860px) and confirm the digest rows' timestamps, counts and unread badges are fully visible (no right-edge clipping).
- [ ] Confirm desktop (>860px) layout is unchanged.

## Out of scope (flagged separately)
Two further mobile topbar issues observed during testing but **not** addressed here (they belong to the actively-developed compact topbar feature): the standalone "Admin" link in the compact topbar still overflows ~15px on narrow screens, and `wavy-back-to-inbox` (position:fixed top-left) overlaps the topbar brand on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)