### PR TITLE
Fix J2CL/Lit UI parity gaps found in GWT side-by-side audit

### DIFF
--- a/j2cl/lit/src/design/wavy-thread-collapse.css
+++ b/j2cl/lit/src/design/wavy-thread-collapse.css
@@ -269,3 +269,68 @@ wavy-search-rail .waveform > svg {
 .wavy-awareness-pill[hidden] {
   display: none;
 }
+
+/* Mobile list<->wave switch (GWT parity). On <=860px the shell grid
+ * stacks the search rail above the wave region, and the rail's auto row
+ * consumed nearly the whole 100vh shell, leaving the opened wave an
+ * unreachable sliver below the fold. Mirror the GWT mobile model
+ * instead: the rail and the opened wave are alternating full-screen
+ * views, switched by the body[data-j2cl-wave-open] attribute that
+ * J2clSelectedWaveView.render maintains.
+ *
+ * These are document-level rules on purpose: they coordinate the
+ * shell grid, slotted light-DOM regions, and fixed-position floating
+ * controls that live outside <shell-root>, which no single element's
+ * shadow stylesheet can reach. */
+@media (max-width: 860px) {
+  body[data-j2cl-wave-open] shell-root > [slot="nav"] {
+    display: none;
+  }
+
+  /* The read surface may inherit a desktop min-width through the rail
+   * sizing tokens; clamp it to the viewport so the opened wave cannot
+   * force horizontal scrolling inside the clipped shell. */
+  body[data-j2cl-wave-open] shell-main-region .j2cl-read-surface,
+  body[data-j2cl-wave-open] shell-main-region [data-j2cl-read-surface] {
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  /* J.5 back-to-inbox: only meaningful while a wave is open (the rail
+   * IS the inbox otherwise), and it must sit inside the 40px compact
+   * topbar band where the brand normally paints — so the brand yields
+   * while the affordance is shown. Document-level rules deliberately
+   * override the element's :host defaults (top/left 12px), which were
+   * sized for the dark full-bleed wavy chrome, not the compact topbar. */
+  wavy-back-to-inbox {
+    display: none;
+  }
+
+  body[data-j2cl-wave-open] wavy-back-to-inbox {
+    display: inline-flex;
+    top: 4px;
+    left: 4px;
+    z-index: 95;
+  }
+
+  body[data-j2cl-wave-open] shell-header[compact-gwt-topbar] > [slot="brand"] {
+    visibility: hidden;
+  }
+
+  /* The SSR topbar Admin link is redundant on phones (the user menu
+   * carries the same destination) and overflowed the 375px topbar,
+   * painting as a clipped half-button. */
+  shell-header[compact-gwt-topbar] > a[data-j2cl-root-admin-link] {
+    display: none;
+  }
+}
+
+/* J.4 nav-drawer toggle: the drawer chrome itself has not shipped yet
+ * (#shell-nav-drawer is a hidden placeholder and nothing consumes
+ * wavy-nav-drawer-toggled), so the fixed-position hamburger was a dead
+ * control painting on top of the topbar user menu. Keep it mounted for
+ * the floating-mount parity contract but suppress it until the drawer
+ * lands. */
+wavy-nav-drawer-toggle {
+  display: none;
+}

--- a/j2cl/lit/src/design/wavy-thread-collapse.css
+++ b/j2cl/lit/src/design/wavy-thread-collapse.css
@@ -330,7 +330,10 @@ wavy-search-rail .waveform > svg {
  * wavy-nav-drawer-toggled), so the fixed-position hamburger was a dead
  * control painting on top of the topbar user menu. Keep it mounted for
  * the floating-mount parity contract but suppress it until the drawer
- * lands. */
+ * lands.
+ * TODO(F-2.S5 / shell-nav-drawer): remove this rule when the drawer
+ * ships, and re-position the toggle so it does not overlap the compact
+ * topbar user menu (its :host default is fixed top-right 12px). */
 wavy-nav-drawer-toggle {
   display: none;
 }

--- a/j2cl/lit/src/elements/wavy-back-to-inbox.js
+++ b/j2cl/lit/src/elements/wavy-back-to-inbox.js
@@ -20,8 +20,11 @@ import { t } from "../i18n/t.js";
  * A11y:
  *   - aria-label="Back to inbox"
  *
- * Events emitted (CustomEvent, bubbles + composed, NOT cancelling):
- *   - `wavy-back-to-inbox-clicked` — no detail.
+ * Events emitted (CustomEvent, bubbles + composed, cancelable):
+ *   - `wavy-back-to-inbox-clicked` — no detail. Calling preventDefault()
+ *     on it cancels the anchor's default navigation so a router can
+ *     handle the transition in-shell (the href remains functional for
+ *     middle-click, new-tab, and no-listener fallbacks).
  */
 export class WavyBackToInbox extends LitElement {
   static properties = {
@@ -67,13 +70,17 @@ export class WavyBackToInbox extends LitElement {
     this.href = "#inbox";
   }
 
-  _onClick() {
-    this.dispatchEvent(
+  _onClick(e) {
+    const notPrevented = this.dispatchEvent(
       new CustomEvent("wavy-back-to-inbox-clicked", {
         bubbles: true,
-        composed: true
+        composed: true,
+        cancelable: true
       })
     );
+    if (!notPrevented && e) {
+      e.preventDefault();
+    }
   }
 
   render() {

--- a/j2cl/lit/src/elements/wavy-back-to-inbox.js
+++ b/j2cl/lit/src/elements/wavy-back-to-inbox.js
@@ -72,6 +72,15 @@ export class WavyBackToInbox extends LitElement {
   }
 
   _onClick(e) {
+    // Modified or non-primary clicks (ctrl/cmd/shift/alt, middle-click)
+    // keep native anchor semantics — open in new tab/window — so neither
+    // dispatch the router event nor cancel the navigation for them.
+    if (
+      e &&
+      (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey)
+    ) {
+      return;
+    }
     const notPrevented = this.dispatchEvent(
       new CustomEvent("wavy-back-to-inbox-clicked", {
         bubbles: true,

--- a/j2cl/lit/src/elements/wavy-back-to-inbox.js
+++ b/j2cl/lit/src/elements/wavy-back-to-inbox.js
@@ -5,8 +5,9 @@ import { t } from "../i18n/t.js";
  * <wavy-back-to-inbox> — F-2.S4 (#1048, J.5) "Back to inbox" header
  * affordance shown on mobile breakpoints. Renders an anchor (so it
  * behaves like a normal link for AT + browser middle-click) but also
- * emits a `wavy-back-to-inbox-clicked` CustomEvent so the future router
- * can intercept (without preventing the default link traversal).
+ * emits a cancelable `wavy-back-to-inbox-clicked` CustomEvent so a
+ * router can intercept and handle the transition in-shell (calling
+ * preventDefault() on the event cancels the anchor navigation).
  *
  * Properties:
  *   - href: string — the URL to navigate to. Defaults to "#inbox".

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -2846,10 +2846,12 @@ export class WavyComposer extends LitElement {
       this._pendingFocusRequest = false;
       // Focusing synchronously inside updated() does not stick on a
       // freshly mounted composer (Chromium drops focus applied while the
-      // shadow tree is still being committed), so defer one frame.
+      // shadow tree is still being committed), so defer one frame. Re-arm
+      // the pending request if focus could not land so a later update can
+      // retry instead of dropping the request silently.
       requestAnimationFrame(() => {
-        if (this.isConnected) {
-          this.focusComposer();
+        if (this.isConnected && !this.focusComposer()) {
+          this._pendingFocusRequest = true;
         }
       });
     }

--- a/j2cl/lit/src/elements/wavy-composer.js
+++ b/j2cl/lit/src/elements/wavy-composer.js
@@ -565,7 +565,17 @@ export class WavyComposer extends LitElement {
     // because `document.getSelection()` does not reliably pierce the
     // shadow root in WebKit / Firefox.
     this._lastSelectionRange = null;
-    this._handleFocusRequest = () => this.focusComposer();
+    // GWT parity (R-5.1): the controller dispatches composer-focus-request
+    // synchronously right after mounting the element, before Lit's first
+    // async render creates the contenteditable body. Remember the request
+    // and honor it from updated() once the body exists, so opening an
+    // inline reply/edit composer lands the caret in the editor like GWT.
+    this._pendingFocusRequest = false;
+    this._handleFocusRequest = () => {
+      if (!this.focusComposer()) {
+        this._pendingFocusRequest = true;
+      }
+    };
     this._handleSelectionChange = () => this._onSelectionChange();
   }
 
@@ -2802,11 +2812,22 @@ export class WavyComposer extends LitElement {
     card.activeSelection = this._activeSelection;
   }
 
-  /** Focus the contenteditable body. Bound to `composer-focus-request`. */
+  /**
+   * Focus the contenteditable body. Bound to `composer-focus-request`.
+   * Returns true when focus landed; false when the body is not ready yet
+   * (first render pending) so the caller can retry after render.
+   */
   focusComposer() {
-    if (!this.available) return;
+    if (!this.available) return false;
     const body = this._bodyElement;
-    if (!body || !body.isConnected) return;
+    if (!body || !body.isConnected) return false;
+    // The controller intentionally restores the scroll position of the
+    // surrounding surface after mounting an inline composer, which can
+    // leave the editor below the fold. Focusing must bring it into view
+    // (GWT scrolls the caret into view when a reply editor opens).
+    if (typeof body.scrollIntoView === "function") {
+      body.scrollIntoView({ block: "nearest", inline: "nearest" });
+    }
     body.focus();
     // Place caret at end if the body is non-empty.
     const range = document.createRange();
@@ -2817,9 +2838,21 @@ export class WavyComposer extends LitElement {
       selection.removeAllRanges();
       selection.addRange(range);
     }
+    return true;
   }
 
   updated(changed) {
+    if (this._pendingFocusRequest && this._bodyElement && this.available) {
+      this._pendingFocusRequest = false;
+      // Focusing synchronously inside updated() does not stick on a
+      // freshly mounted composer (Chromium drops focus applied while the
+      // shadow tree is still being committed), so defer one frame.
+      requestAnimationFrame(() => {
+        if (this.isConnected) {
+          this.focusComposer();
+        }
+      });
+    }
     if (changed.has("draft") && this._bodyElement) {
       // F-3.S2 (#1038, R-5.3): skip the textContent overwrite when the
       // body has rich content (mention chips, task lists) the plain

--- a/j2cl/lit/test/wavy-back-to-inbox.test.js
+++ b/j2cl/lit/test/wavy-back-to-inbox.test.js
@@ -40,6 +40,23 @@ describe("<wavy-back-to-inbox>", () => {
     expect(ev.composed).to.equal(true);
   });
 
+  it("preventDefault on wavy-back-to-inbox-clicked cancels anchor navigation", async () => {
+    const el = await fixture(html`<wavy-back-to-inbox></wavy-back-to-inbox>`);
+    el.addEventListener("wavy-back-to-inbox-clicked", (ev) => ev.preventDefault());
+    const a = el.renderRoot.querySelector("a");
+    const click = new MouseEvent("click", { bubbles: true, cancelable: true });
+    a.dispatchEvent(click);
+    expect(click.defaultPrevented).to.equal(true);
+  });
+
+  it("anchor navigation proceeds when no listener intercepts", async () => {
+    const el = await fixture(html`<wavy-back-to-inbox></wavy-back-to-inbox>`);
+    const a = el.renderRoot.querySelector("a");
+    const click = new MouseEvent("click", { bubbles: true, cancelable: true });
+    a.dispatchEvent(click);
+    expect(click.defaultPrevented).to.equal(false);
+  });
+
   it("clearing href falls back to #inbox in the rendered output", async () => {
     const el = await fixture(html`<wavy-back-to-inbox></wavy-back-to-inbox>`);
     el.href = "";

--- a/j2cl/lit/test/wavy-back-to-inbox.test.js
+++ b/j2cl/lit/test/wavy-back-to-inbox.test.js
@@ -49,6 +49,22 @@ describe("<wavy-back-to-inbox>", () => {
     expect(click.defaultPrevented).to.equal(true);
   });
 
+  it("modified clicks keep native anchor semantics even when intercepted", async () => {
+    const el = await fixture(html`<wavy-back-to-inbox></wavy-back-to-inbox>`);
+    el.addEventListener("wavy-back-to-inbox-clicked", (ev) => ev.preventDefault());
+    const a = el.renderRoot.querySelector("a");
+    for (const init of [{ metaKey: true }, { ctrlKey: true }, { shiftKey: true }, { altKey: true }, { button: 1 }]) {
+      let routed = 0;
+      const count = () => routed++;
+      el.addEventListener("wavy-back-to-inbox-clicked", count);
+      const click = new MouseEvent("click", { bubbles: true, cancelable: true, ...init });
+      a.dispatchEvent(click);
+      el.removeEventListener("wavy-back-to-inbox-clicked", count);
+      expect(click.defaultPrevented, JSON.stringify(init)).to.equal(false);
+      expect(routed, "router event for " + JSON.stringify(init)).to.equal(0);
+    }
+  });
+
   it("anchor navigation proceeds when no listener intercepts", async () => {
     const el = await fixture(html`<wavy-back-to-inbox></wavy-back-to-inbox>`);
     const a = el.renderRoot.querySelector("a");

--- a/j2cl/lit/test/wavy-composer.test.js
+++ b/j2cl/lit/test/wavy-composer.test.js
@@ -288,6 +288,24 @@ describe("<wavy-composer>", () => {
     el.remove();
   });
 
+  it("honors a composer-focus-request dispatched before first render", async () => {
+    // Mirrors J2clComposeSurfaceView.openInlineComposer: the element is
+    // created, configured, appended and receives composer-focus-request
+    // synchronously — before Lit's first async render creates the body.
+    const el = document.createElement("wavy-composer");
+    el.available = true;
+    el.mode = "reply";
+    document.body.appendChild(el);
+    el.dispatchEvent(new Event("composer-focus-request"));
+    await el.updateComplete;
+    // The pending focus lands one animation frame after first render.
+    for (let i = 0; i < 10 && el.renderRoot.activeElement !== getBody(el); i++) {
+      await new Promise((r) => requestAnimationFrame(r));
+    }
+    expect(el.renderRoot.activeElement === getBody(el)).to.equal(true);
+    el.remove();
+  });
+
   it("renders the hint strip and save indicator", async () => {
     const el = await fixture(html`<wavy-composer available submitting></wavy-composer>`);
     expect(el.renderRoot.querySelector("[data-hint-strip]")).to.exist;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -3,6 +3,7 @@ package org.waveprotocol.box.j2cl.compose;
 import elemental2.core.JsArray;
 import elemental2.core.JsDate;
 import elemental2.dom.DomGlobal;
+import elemental2.dom.Element;
 import elemental2.dom.Event;
 import elemental2.dom.File;
 import elemental2.dom.FileList;
@@ -256,7 +257,10 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
           event -> closeInlineComposer(eventDetailString(event, "replyTargetBlipId")));
       DomGlobal.document.body.addEventListener(
           "wavy-read-surface-rendered",
-          event -> ensureActiveInlineComposerMounted(activeInlineComposer()));
+          event -> {
+            ensureActiveInlineComposerMounted(activeInlineComposer());
+            ensureRootReplyTriggerMounted();
+          });
     }
 
     // F-3.S2 (#1038): mention popover + per-blip task affordance events.
@@ -524,6 +528,7 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
         setProperty(cached, "mode", mode);
         cached.dispatchEvent(new Event("composer-focus-request"));
         activeInlineComposerKey = key;
+        syncRootReplyTriggerVisibility();
         return;
       }
       // Cached entry is detached (blip DOM was rebuilt); evict and remount.
@@ -647,6 +652,7 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     if (scrollAnchor != null) {
       scrollAnchor.scrollTop = scrollTopBeforeMount;
     }
+    syncRootReplyTriggerVisibility();
   }
 
   private void closeInlineComposer(String blipId) {
@@ -658,10 +664,64 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     if (key.equals(activeInlineComposerKey)) {
       activeInlineComposerKey = "";
     }
+    syncRootReplyTriggerVisibility();
   }
 
   private HTMLElement activeInlineComposer() {
     return inlineComposers.get(activeInlineComposerKey);
+  }
+
+  /**
+   * F-3.S1 (#1038, J.1): GWT renders a persistent full-width "Click here to
+   * reply" box after the root thread ({@code ReplyBoxViewBuilder}); the Lit
+   * equivalent {@code <wavy-wave-root-reply-trigger>} existed but nothing
+   * mounted it on live waves. Keep it as the read surface's last child on
+   * every render — the renderer rebuilds and reorders blip DOM, so this
+   * re-appends after each {@code wavy-read-surface-rendered}.
+   */
+  private void ensureRootReplyTriggerMounted() {
+    if (!inlineRichComposerEnabled) {
+      return;
+    }
+    HTMLElement surface =
+        (HTMLElement) DomGlobal.document.querySelector("[data-j2cl-read-surface='true']");
+    if (surface == null) {
+      return;
+    }
+    Element existing = surface.querySelector("wavy-wave-root-reply-trigger");
+    HTMLElement trigger =
+        existing != null
+            ? (HTMLElement) existing
+            : (HTMLElement) DomGlobal.document.createElement("wavy-wave-root-reply-trigger");
+    Element waveIdHost = surface.closest("[data-wave-id]");
+    String waveId = waveIdHost == null ? null : waveIdHost.getAttribute("data-wave-id");
+    if (waveId != null && !waveId.isEmpty()) {
+      trigger.setAttribute("wave-id", waveId);
+    }
+    if (trigger.parentNode != surface || trigger.nextElementSibling != null) {
+      surface.appendChild(trigger);
+    }
+    syncRootReplyTriggerVisibility();
+  }
+
+  /**
+   * GWT hides the bottom reply box while the wave-root editor is open (the
+   * editor takes its place); mirror that by hiding the trigger whenever the
+   * wave-root composer (key "") is mounted.
+   */
+  private void syncRootReplyTriggerVisibility() {
+    Element trigger =
+        DomGlobal.document.querySelector(
+            "[data-j2cl-read-surface='true'] wavy-wave-root-reply-trigger");
+    if (trigger == null) {
+      return;
+    }
+    boolean rootComposerOpen = inlineComposers.containsKey("");
+    if (rootComposerOpen) {
+      trigger.setAttribute("hidden", "");
+    } else {
+      trigger.removeAttribute("hidden");
+    }
   }
 
   @Override

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceView.java
@@ -697,6 +697,11 @@ public final class J2clComposeSurfaceView implements J2clComposeSurfaceControlle
     String waveId = waveIdHost == null ? null : waveIdHost.getAttribute("data-wave-id");
     if (waveId != null && !waveId.isEmpty()) {
       trigger.setAttribute("wave-id", waveId);
+    } else {
+      // Never keep a previous wave's id across a transition where the host
+      // lookup fails — a click would emit wave-root-reply-requested for the
+      // wrong wave.
+      trigger.removeAttribute("wave-id");
     }
     if (trigger.parentNode != surface || trigger.nextElementSibling != null) {
       surface.appendChild(trigger);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContent.java
@@ -343,7 +343,13 @@ public final class J2clReadBlipContent {
       decodedVisibleLength = Math.max(0, decodedVisibleLength - 1);
       clampInlineReplyAnchorOffsets(inlineReplyAnchors, decodedVisibleLength);
     }
-    if (stripped.length() > 0 && stripped.charAt(stripped.length() - 1) != '\n') {
+    // GWT parity (R-3.1 content fidelity): every <line/> after the first
+    // starts a new rendered line, including consecutive <line/> tags that
+    // produce intentional blank lines between paragraphs. Only the leading
+    // <line/> (no text yet) is swallowed so documents do not start with a
+    // phantom blank line. The previous `!= '\n'` guard collapsed blank
+    // lines entirely.
+    if (stripped.length() > 0) {
       stripped.append('\n');
       decodedVisibleLength++;
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -3655,6 +3655,14 @@ public final class J2clReadSurfaceDomRenderer {
       return false;
     }
     HTMLElement active = (HTMLElement) DomGlobal.document.activeElement;
+    // Check the outer host chain BEFORE descending into shadow roots:
+    // closest() does not cross shadow boundaries, so once `active` is
+    // replaced by a shadow descendant (e.g. the composer's Cancel button),
+    // closest("wavy-composer") would return null and a read-surface rebuild
+    // could steal focus from a composer control mid-interaction.
+    if (active.closest("wavy-composer") != null) {
+      return true;
+    }
     // document.activeElement stops at shadow hosts; descend through
     // shadowRoot.activeElement so a contenteditable inside any shadow tree
     // (not just <wavy-composer>) is recognized as an editing surface.

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -3655,6 +3655,20 @@ public final class J2clReadSurfaceDomRenderer {
       return false;
     }
     HTMLElement active = (HTMLElement) DomGlobal.document.activeElement;
+    // document.activeElement stops at shadow hosts; descend through
+    // shadowRoot.activeElement so a contenteditable inside any shadow tree
+    // (not just <wavy-composer>) is recognized as an editing surface.
+    for (int depth = 0; depth < 16; depth++) {
+      Object shadowRoot = Js.asPropertyMap(active).get("shadowRoot");
+      if (shadowRoot == null) {
+        break;
+      }
+      Object inner = Js.asPropertyMap(shadowRoot).get("activeElement");
+      if (!(inner instanceof HTMLElement) || inner == active) {
+        break;
+      }
+      active = (HTMLElement) inner;
+    }
     // elemental2's HTMLElement does not expose isContentEditable; read the
     // live DOM property instead.
     if (Js.isTruthy(Js.asPropertyMap(active).get("isContentEditable"))) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -2938,6 +2938,16 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   private void onBlipKeyDown(Event event) {
+    // GWT parity (R-5.1): keystrokes originating inside an editable or
+    // interactive element belong to that control, never to blip
+    // navigation. The inline <wavy-composer> body is a contenteditable in
+    // a shadow root mounted within the blip DOM, so its keydowns bubble
+    // here with a retargeted event.target — without this guard, typing
+    // "g" into a reply yanked focus to the first blip (Home alias) and
+    // the rest of the sentence was lost to shortcut handling.
+    if (isInteractiveClick(event)) {
+      return;
+    }
     KeyboardEvent keyEvent = (KeyboardEvent) event;
     String key = keyEvent.key;
     if (event.currentTarget != null && currentVisibleBlipIndex(visibleBlips()) < 0) {
@@ -3629,7 +3639,39 @@ public final class J2clReadSurfaceDomRenderer {
     return false;
   }
 
+  /**
+   * True when keyboard focus currently lives in an editing surface — the
+   * inline {@code <wavy-composer>} (focus composes up to the host element),
+   * a form field, or any contenteditable. A read-surface rebuild must not
+   * steal focus back to the focus-frame blip while the user is typing:
+   * the inline composer mounts inside the blip DOM, so
+   * {@code currentFocusedBlipId()} resolves it to its containing blip and
+   * the restore would re-focus that blip mid-keystroke (GWT keeps the
+   * editor caret across incremental renders).
+   */
+  private static boolean focusIsInEditingSurface() {
+    if (DomGlobal.document == null
+        || !(DomGlobal.document.activeElement instanceof HTMLElement)) {
+      return false;
+    }
+    HTMLElement active = (HTMLElement) DomGlobal.document.activeElement;
+    // elemental2's HTMLElement does not expose isContentEditable; read the
+    // live DOM property instead.
+    if (Js.isTruthy(Js.asPropertyMap(active).get("isContentEditable"))) {
+      return true;
+    }
+    String tag = active.tagName == null ? "" : active.tagName.toLowerCase();
+    if ("textarea".equals(tag) || "input".equals(tag) || "select".equals(tag)) {
+      return true;
+    }
+    return active.closest("wavy-composer") != null;
+  }
+
   private void restoreFocusedBlip(HTMLElement previousFocusedBlip) {
+    if (focusIsInEditingSurface()) {
+      ensureSingleTabStop();
+      return;
+    }
     HTMLElement restored = visibleRenderedBlip(previousFocusedBlip);
     if (restored == null) {
       restored = visibleRenderedBlip((HTMLElement) DomGlobal.document.activeElement);
@@ -3645,6 +3687,10 @@ public final class J2clReadSurfaceDomRenderer {
   }
 
   private void restoreFocusedBlipById(String blipId) {
+    if (focusIsInEditingSurface()) {
+      ensureSingleTabStop();
+      return;
+    }
     HTMLElement restored = visibleRenderedBlip(renderedBlipById(blipId));
     if (restored != null) {
       focusBlip(restored);

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -1,6 +1,7 @@
 package org.waveprotocol.box.j2cl.root;
 
 import elemental2.core.JsArray;
+import elemental2.dom.DomGlobal;
 import elemental2.dom.Event;
 import elemental2.dom.HTMLElement;
 import java.util.ArrayList;
@@ -243,6 +244,17 @@ public final class J2clRootShellController {
     // The rehydration runs inside the live-surface starter so the URL
     // depth value is applied right after route.start().
     bindDepthEventsToRoute(selectedWaveView, routeController);
+    // Mobile list<->wave switch (GWT parity): <wavy-back-to-inbox> emits a
+    // cancelable wavy-back-to-inbox-clicked before its anchor navigates.
+    // Intercept it to clear the selection through the route controller so
+    // returning to the inbox is an instant in-shell transition (the anchor
+    // href stays functional for middle-click / no-JS fallbacks).
+    DomGlobal.document.body.addEventListener(
+        "wavy-back-to-inbox-clicked",
+        event -> {
+          event.preventDefault();
+          routeControllerRef[0].selectWave(null);
+        });
     liveSurfaceController.start();
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -746,6 +746,16 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     // <wave-blip> renderer can lift it onto each rendered card without
     // changing the renderer signature. Cleared explicitly when no wave is
     // selected so a stale id is not propagated to the next opened wave.
+    // Mobile list<->wave switch (GWT parity): the <=860px layout shows the
+    // search rail and the opened wave as alternating full-screen views.
+    // Surface the selection state on <body> so the document stylesheet can
+    // collapse the rail while a wave is open and reveal the back-to-inbox
+    // affordance. No-op for desktop layouts, which show both regions.
+    if (renderedWaveId.isEmpty()) {
+      DomGlobal.document.body.removeAttribute("data-j2cl-wave-open");
+    } else {
+      DomGlobal.document.body.setAttribute("data-j2cl-wave-open", "true");
+    }
     if (renderedWaveId.isEmpty()) {
       contentList.removeAttribute("data-wave-id");
       if (waveNavRow != null) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -645,7 +645,14 @@ public final class SidecarTransportCodec {
       text.deleteCharAt(text.length() - 1);
       clampInlineReplyAnchorOffsets(inlineReplyAnchors, text.length());
     }
-    if (text.length() > 0 && text.charAt(text.length() - 1) != '\n') {
+    // GWT parity (R-3.1 content fidelity): every <line/> after the first
+    // starts a new rendered line, including consecutive <line/> tags that
+    // produce intentional blank lines between paragraphs. Only the leading
+    // <line/> (text still empty) is swallowed so documents do not start
+    // with a phantom blank line. The previous `!= '\n'` guard collapsed
+    // blank lines entirely, so paragraph spacing present in the GWT client
+    // vanished in the J2CL read surface.
+    if (text.length() > 0) {
       text.append('\n');
     }
   }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/read/J2clReadBlipContentTest.java
@@ -120,11 +120,14 @@ public class J2clReadBlipContentTest {
   }
 
   @Test
-  public void consecutiveLineTagsInsideTextCollapseToSingleSeparator() {
+  public void consecutiveLineTagsInsideTextPreserveBlankLine() {
+    // GWT parity (R-3.1): consecutive <line/> tags are intentional blank
+    // lines between paragraphs (WelcomeWaveContentBuilder#appendBlankLine)
+    // and must survive extraction instead of collapsing to one separator.
     J2clReadBlipContent parsed =
         J2clReadBlipContent.parseRawSnapshot("<body>Hello<line/><line/>World</body>");
 
-    Assert.assertEquals("Hello\nWorld", parsed.getText());
+    Assert.assertEquals("Hello\n\nWorld", parsed.getText());
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -294,6 +294,34 @@ public class SidecarTransportCodecTest {
   }
 
   @Test
+  public void decodeSelectedWaveUpdatePreservesBlankLinesBetweenParagraphs() {
+    // GWT parity (R-3.1): consecutive <line/> tags are intentional blank
+    // lines between paragraphs and must survive text extraction. Only the
+    // leading <line/> of a document is swallowed.
+    String json =
+        "{\"sequenceNumber\":14,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"
+            + "\"1\":\"local.net!w+s4635670bfbwA/~/conv+root\","
+            + "\"5\":{\"1\":\"conv+root\",\"2\":[\"user@example.com\"],"
+            + "\"3\":[{\"1\":\"b+abc123\","
+            + "\"2\":{\"1\":[{\"3\":{\"1\":\"body\",\"2\":[]}},"
+            + "{\"2\":\"para1\"},"
+            + "{\"3\":{\"1\":\"line\",\"2\":[]}},"
+            + "{\"4\":true},"
+            + "{\"3\":{\"1\":\"line\",\"2\":[]}},"
+            + "{\"4\":true},"
+            + "{\"2\":\"para2\"},"
+            + "{\"4\":true}]},"
+            + "\"3\":\"user@example.com\",\"5\":[1,0],\"6\":[2,0]}]},"
+            + "\"6\":true,\"7\":\"ch3\"}}";
+
+    SidecarSelectedWaveDocument document =
+        SidecarTransportCodec.decodeSelectedWaveUpdate(json).getDocuments().get(0);
+
+    Assert.assertEquals("para1\n\npara2", document.getTextContent());
+    Assert.assertEquals(16, document.getBodyItemCount());
+  }
+
+  @Test
   public void decodeSelectedWaveUpdateReadsRootLockDocumentState() {
     String json =
         "{\"sequenceNumber\":14,\"messageType\":\"ProtocolWaveletUpdate\",\"message\":{"

--- a/wave/config/changelog.d/2026-07-05-j2cl-gwt-parity-fixes.json
+++ b/wave/config/changelog.d/2026-07-05-j2cl-gwt-parity-fixes.json
@@ -1,0 +1,20 @@
+{
+  "releaseId": "2026-07-05-j2cl-gwt-parity-fixes",
+  "version": "unreleased",
+  "date": "2026-07-05",
+  "title": "J2CL/Lit UI parity fixes: mobile wave view, reply focus, blank lines, unread state",
+  "summary": "A GWT vs Lit side-by-side audit found and fixed the biggest remaining gaps in the new UI: opening a wave on a phone now actually shows the wave, replying places the caret in the editor without losing keystrokes, paragraph spacing matches the classic client, the bottom 'Click here to reply' box is back, and per-wave unread state works for freshly created waves.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Mobile: selecting a wave now switches to a full-screen wave view with a working '← Inbox' control instead of leaving the inbox list on screen with the wave unreachable below the fold.",
+        "Mobile: removed the dead hamburger toggle that painted on top of the user menu, hid the topbar Admin link that overflowed the 375px topbar (it remains in the user menu), and stopped the floating 'Inbox' link from painting over the brand.",
+        "Reply: clicking a reply/edit affordance now scrolls the inline composer into view and places the caret in it, and typing into the composer no longer loses focus to blip keyboard shortcuts after characters like 'g'.",
+        "Read surface: blank lines between paragraphs are preserved again, matching the GWT client's rendering of consecutive line tags.",
+        "Read surface: the GWT bottom-of-wave 'Click here to reply' box is now mounted on live waves and hides while the wave-root composer is open.",
+        "Unread state: /read-state and mark-blip-read no longer 404/500 for waves created since the last server restart (stale storage-snapshot lookup now unions live in-memory wavelets; delta reads prefer the in-memory cache to avoid racing in-flight writes)."
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletState.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletState.java
@@ -52,6 +52,7 @@ import org.waveprotocol.wave.model.wave.data.WaveletData;
 import org.waveprotocol.wave.util.escapers.jvm.JavaUrlCodec;
 import org.waveprotocol.wave.util.logging.Log;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -262,11 +263,29 @@ class DeltaStoreBasedWaveletState implements WaveletState {
   private static WaveletDeltaRecord getDelta(WaveletDeltaRecordReader reader,
       ConcurrentNavigableMap<HashedVersion, WaveletDeltaRecord> cachedDeltas,
       HashedVersion version) throws IOException {
-    WaveletDeltaRecord delta = reader.getDelta(version.getVersion());
-    if (delta == null && cachedDeltas != null) {
-      delta = cachedDeltas.get(version);
+    // Not-yet-persisted deltas live in cachedDeltas until the async persist
+    // completes and evicts them, so the cache is authoritative for recent
+    // versions. Consult it first: reading the file for a delta whose append
+    // is still in flight can hit a partially flushed record (EOFException),
+    // which used to surface as a 500 when e.g. mark-blip-read transformed
+    // against history submitted moments earlier.
+    if (cachedDeltas != null) {
+      WaveletDeltaRecord cached = cachedDeltas.get(version);
+      if (cached != null) {
+        return cached;
+      }
     }
-    return delta;
+    try {
+      return reader.getDelta(version.getVersion());
+    } catch (EOFException e) {
+      // The record is mid-append. If persistence completed between the cache
+      // miss above and the file read, retry the cache once before failing.
+      WaveletDeltaRecord cached = cachedDeltas == null ? null : cachedDeltas.get(version);
+      if (cached != null) {
+        return cached;
+      }
+      throw e;
+    }
   }
 
   private final Executor persistExecutor;

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
@@ -25,7 +25,9 @@ import com.google.inject.name.Named;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.waveprotocol.box.server.CoreSettingsNames;
 import org.waveprotocol.box.server.util.WaveletDataUtil;
 import org.waveprotocol.wave.model.id.IdUtil;
@@ -128,14 +130,27 @@ public class SelectedWaveReadStateHelper {
       return Result.notFound();
     }
 
-    ImmutableSet<WaveletId> waveletIds;
+    ImmutableSet<WaveletId> storedWaveletIds;
     try {
-      waveletIds = waveMap.lookupWavelets(waveId);
+      storedWaveletIds = waveMap.lookupWavelets(waveId);
     } catch (WaveletStateException e) {
       LOG.warning("read-state: failed to look up wavelets for " + waveId, e);
       throw new RuntimeException("Failed to load read state for " + waveId, e);
     }
-    if (waveletIds == null || waveletIds.isEmpty()) {
+    // lookupWavelets is a storage snapshot taken when the wave entry was
+    // first cached — a wave created in this process lifetime resolves to an
+    // empty snapshot forever. Union in the live in-memory containers (the
+    // same combination MemoryPerUserWaveViewHandlerImpl uses) so read-state
+    // works for freshly created waves without a server restart.
+    Set<WaveletId> waveletIds = new HashSet<WaveletId>();
+    if (storedWaveletIds != null) {
+      waveletIds.addAll(storedWaveletIds);
+    }
+    ImmutableSet<WaveletId> inMemoryWaveletIds = waveMap.getInMemoryWaveletIds(waveId);
+    if (inMemoryWaveletIds != null) {
+      waveletIds.addAll(inMemoryWaveletIds);
+    }
+    if (waveletIds.isEmpty()) {
       return Result.notFound();
     }
 
@@ -156,7 +171,7 @@ public class SelectedWaveReadStateHelper {
   }
 
   private WaveViewData buildAccessibleWaveView(
-      WaveId waveId, ImmutableSet<WaveletId> waveletIds, ParticipantId user) {
+      WaveId waveId, Set<WaveletId> waveletIds, ParticipantId user) {
     // Build the view directly rather than via
     // AbstractSearchProviderImpl.buildWaveViewData, which swallows
     // WaveletStateException per wavelet. A swallowed conversational-wavelet

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveMap.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveMap.java
@@ -165,6 +165,26 @@ public class WaveMap {
     return ExceptionalIterator.FromIterator.create(inner);
   }
 
+  /**
+   * Returns the ids of this wave's wavelet containers that are live in memory
+   * right now, without touching storage. Complements {@link #lookupWavelets},
+   * whose result is a point-in-time storage snapshot taken when the wave entry
+   * was first cached: wavelets created after that moment (e.g. a wave created
+   * in this process lifetime whose entry was cached during its own creation)
+   * are only visible through the in-memory containers.
+   */
+  public ImmutableSet<WaveletId> getInMemoryWaveletIds(WaveId waveId) {
+    Wave wave = waveId == null ? null : waves.getIfPresent(waveId);
+    if (wave == null) {
+      return ImmutableSet.of();
+    }
+    ImmutableSet.Builder<WaveletId> ids = ImmutableSet.builder();
+    for (WaveletContainer container : wave) {
+      ids.add(container.getWaveletName().waveletId);
+    }
+    return ids.build();
+  }
+
   public ImmutableSet<WaveletId> lookupWavelets(WaveId waveId) throws WaveletStateException {
     try {
       ListenableFuture<ImmutableSet<WaveletId>> future = waves.get(waveId).getLookedupWavelets();

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveMap.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveMap.java
@@ -172,6 +172,11 @@ public class WaveMap {
    * was first cached: wavelets created after that moment (e.g. a wave created
    * in this process lifetime whose entry was cached during its own creation)
    * are only visible through the in-memory containers.
+   *
+   * <p>This method deliberately uses {@code getIfPresent} and never loads the
+   * wave entry itself. Callers combining it with {@link #lookupWavelets} must
+   * call {@code lookupWavelets} first — that call populates the cache entry,
+   * after which this method sees its containers.
    */
   public ImmutableSet<WaveletId> getInMemoryWaveletIds(WaveId waveId) {
     Wave wave = waveId == null ? null : waves.getIfPresent(waveId);

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletStateTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/DeltaStoreBasedWaveletStateTest.java
@@ -168,6 +168,40 @@ public class DeltaStoreBasedWaveletStateTest extends WaveletStateTestBase {
     assertNotNull(durable.getDelta(first.getResultingVersion().getVersion()));
   }
 
+  public void testTransformedDeltaHistoryReadsFromCacheWhenFileReadHitsEof() throws Exception {
+    // Regression test: the delta reader used to consult the file before the
+    // in-memory cache, so a history read racing an in-flight append could
+    // hit a partially flushed record (EOFException) and surface as a 500
+    // (e.g. mark-blip-read transforming against just-submitted history).
+    // Cache-first reads must serve unflushed deltas without touching the
+    // file at all.
+    DeltaStore.DeltasAccess durable = store.open(NAME);
+    WaveletState state = DeltaStoreBasedWaveletState.create(
+        new EofThrowingDeltasAccess(durable), PERSIST_EXECUTOR);
+    WaveletDeltaRecord first = makeDelta(V0, 1234567890L, 1);
+    WaveletDeltaRecord second = makeDelta(first.getResultingVersion(), 1234567891L, 1);
+
+    state.appendDelta(first);
+    state.appendDelta(second);
+
+    // Both deltas are cache-only (not flushed); every file read throws EOF.
+    java.util.List<TransformedWaveletDelta> received =
+        new java.util.ArrayList<TransformedWaveletDelta>();
+    state.getTransformedDeltaHistory(
+        V0,
+        second.getResultingVersion(),
+        new org.waveprotocol.box.common.Receiver<TransformedWaveletDelta>() {
+          @Override
+          public boolean put(TransformedWaveletDelta delta) {
+            received.add(delta);
+            return true;
+          }
+        });
+
+    assertEquals(2, received.size());
+    assertEquals(second.getResultingVersion(), received.get(1).getResultingVersion());
+  }
+
   // TODO(soren): We need to add tests here that verify interactions with storage.
   // The base tests only test the public interface, not any interactions with the storage system.
 
@@ -179,6 +213,74 @@ public class DeltaStoreBasedWaveletStateTest extends WaveletStateTestBase {
         appliedAtVersion,
         applied,
         AppliedDeltaUtil.buildTransformedDelta(applied, delta));
+  }
+
+  /**
+   * Delegates everything to the real access but simulates an in-flight file
+   * append: every per-version file read fails with {@link java.io.EOFException}.
+   */
+  private static final class EofThrowingDeltasAccess implements DeltaStore.DeltasAccess {
+    private final DeltaStore.DeltasAccess delegate;
+
+    private EofThrowingDeltasAccess(DeltaStore.DeltasAccess delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public WaveletName getWaveletName() {
+      return delegate.getWaveletName();
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return delegate.isEmpty();
+    }
+
+    @Override
+    public HashedVersion getEndVersion() {
+      return delegate.getEndVersion();
+    }
+
+    @Override
+    public WaveletDeltaRecord getDelta(long version) throws java.io.IOException {
+      throw new java.io.EOFException("simulated in-flight append");
+    }
+
+    @Override
+    public WaveletDeltaRecord getDeltaByEndVersion(long version) throws java.io.IOException {
+      throw new java.io.EOFException("simulated in-flight append");
+    }
+
+    @Override
+    public HashedVersion getAppliedAtVersion(long version) throws java.io.IOException {
+      throw new java.io.EOFException("simulated in-flight append");
+    }
+
+    @Override
+    public HashedVersion getResultingVersion(long version) throws java.io.IOException {
+      throw new java.io.EOFException("simulated in-flight append");
+    }
+
+    @Override
+    public ByteStringMessage<org.waveprotocol.wave.federation.Proto.ProtocolAppliedWaveletDelta>
+        getAppliedDelta(long version) throws java.io.IOException {
+      throw new java.io.EOFException("simulated in-flight append");
+    }
+
+    @Override
+    public TransformedWaveletDelta getTransformedDelta(long version) throws java.io.IOException {
+      throw new java.io.EOFException("simulated in-flight append");
+    }
+
+    @Override
+    public void append(java.util.Collection<WaveletDeltaRecord> deltas) throws PersistenceException {
+      delegate.append(deltas);
+    }
+
+    @Override
+    public void close() throws java.io.IOException {
+      delegate.close();
+    }
   }
 
   private static final class PartiallyFailingDeltasAccess implements DeltaStore.DeltasAccess {

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelperTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelperTest.java
@@ -161,6 +161,34 @@ public final class SelectedWaveReadStateHelperTest extends TestCase {
     assertEquals(1, result.getUnreadCount());
   }
 
+  public void testComputeReadStateUnionsStoredAndInMemoryWavelets() throws Exception {
+    WaveMap waveMap = mock(WaveMap.class);
+    WaveDigester digester = mock(WaveDigester.class);
+    SelectedWaveReadStateHelper helper =
+        new SelectedWaveReadStateHelper(DOMAIN, waveMap, digester);
+
+    // The conversational wavelet is already persisted while the user-data
+    // wavelet only exists in memory (e.g. created moments ago); both must
+    // contribute to the digest view.
+    when(waveMap.lookupWavelets(WAVE_ID)).thenReturn(ImmutableSet.of(ACCESSIBLE_CONV));
+    when(waveMap.getInMemoryWaveletIds(WAVE_ID)).thenReturn(ImmutableSet.of(USER_UDW));
+
+    stubWaveletContainer(waveMap, ACCESSIBLE_CONV, wavelet(ACCESSIBLE_CONV, USER));
+    stubWaveletContainer(waveMap, USER_UDW, wavelet(USER_UDW, USER));
+
+    when(digester.getUnreadBlipState(eq(USER), any(WaveViewData.class)))
+        .thenReturn(new WaveDigester.UnreadBlipState(Arrays.asList("b+1")));
+
+    SelectedWaveReadStateHelper.Result result = helper.computeReadState(USER, WAVE_ID);
+
+    assertTrue(result.exists());
+    ArgumentCaptor<WaveViewData> viewCaptor = ArgumentCaptor.forClass(WaveViewData.class);
+    verify(digester).getUnreadBlipState(eq(USER), viewCaptor.capture());
+    WaveViewData digestedView = viewCaptor.getValue();
+    assertNotNull(digestedView.getWavelet(ACCESSIBLE_CONV));
+    assertNotNull(digestedView.getWavelet(USER_UDW));
+  }
+
   private static ObservableWaveletData wavelet(WaveletId waveletId, ParticipantId participant) {
     ObservableWaveletData wavelet = mock(ObservableWaveletData.class);
     when(wavelet.getWaveletId()).thenReturn(waveletId);

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelperTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelperTest.java
@@ -135,6 +135,32 @@ public final class SelectedWaveReadStateHelperTest extends TestCase {
     assertNull(digestedView.getWavelet(OTHER_UDW));
   }
 
+  public void testComputeReadStateFindsFreshWaveViaInMemoryWavelets() throws Exception {
+    WaveMap waveMap = mock(WaveMap.class);
+    WaveDigester digester = mock(WaveDigester.class);
+    SelectedWaveReadStateHelper helper =
+        new SelectedWaveReadStateHelper(DOMAIN, waveMap, digester);
+
+    // Freshly created wave: the storage snapshot is empty because the wave
+    // entry was cached during its own creation (Wave#lookedupWavelets is a
+    // one-shot future). Only the in-memory containers know the wavelets, so
+    // read-state must union them in instead of returning 404.
+    when(waveMap.lookupWavelets(WAVE_ID)).thenReturn(ImmutableSet.<WaveletId>of());
+    when(waveMap.getInMemoryWaveletIds(WAVE_ID))
+        .thenReturn(ImmutableSet.of(ACCESSIBLE_CONV, USER_UDW));
+
+    stubWaveletContainer(waveMap, ACCESSIBLE_CONV, wavelet(ACCESSIBLE_CONV, USER));
+    stubWaveletContainer(waveMap, USER_UDW, wavelet(USER_UDW, USER));
+
+    when(digester.getUnreadBlipState(eq(USER), any(WaveViewData.class)))
+        .thenReturn(new WaveDigester.UnreadBlipState(Arrays.asList("b+1")));
+
+    SelectedWaveReadStateHelper.Result result = helper.computeReadState(USER, WAVE_ID);
+
+    assertTrue(result.exists());
+    assertEquals(1, result.getUnreadCount());
+  }
+
   private static ObservableWaveletData wavelet(WaveletId waveletId, ParticipantId participant) {
     ObservableWaveletData wavelet = mock(ObservableWaveletData.class);
     when(wavelet.getWaveletId()).thenReturn(waveletId);


### PR DESCRIPTION
## Summary

A fresh side-by-side audit of the legacy GWT UI (`/?view=gwt`) against the new J2CL/Lit shell (`/?view=j2cl-root`) — desktop 1440x900 and mobile 375x812, driven by a Playwright harness with freshly registered users — surfaced six user-visible parity gaps plus two server-side unread-state bugs. All are fixed here.

### Client (J2CL/Lit)

- **Mobile list↔wave switch**: selecting a wave used to leave the inbox list on screen with the wave rendered into an unreachable ~8px sliver below the 100vh shell. `J2clSelectedWaveView` now reflects selection as `body[data-j2cl-wave-open]`; on ≤860px the rail hides while a wave is open, a working `← Inbox` control appears in the topbar band (brand yields), and `J2clRootShellController` intercepts the now-cancelable `wavy-back-to-inbox-clicked` to return in-shell without a reload.
- **Mobile topbar overlaps**: hid the dead nav-drawer hamburger (nothing consumes `wavy-nav-drawer-toggled` until the drawer ships — TODO left in place) that painted over the user menu, and the SSR Admin link that overflowed the 375px topbar (it remains in the user menu).
- **Reply focus**: `composer-focus-request` fired before Lit's first render, so the caret never entered the editor and the composer opened below the fold. `wavy-composer` now remembers the pending request, focuses one frame after first render (re-arming on failure), and scrolls the body into view.
- **Reply keystroke theft**: typing in the inline composer bubbled keydowns to the blip host where `g`/`G`/`Home`/`End` aliases yanked focus away mid-sentence and the text was lost. `onBlipKeyDown` now ignores events from editable/interactive composed-path targets, and the read-surface rebuild focus-restore skips (shadow-piercing check) while an editing surface owns focus.
- **Blank lines**: both text-extraction paths (`SidecarTransportCodec`, `J2clReadBlipContent`) collapsed consecutive `<line/>` tags, dropping the paragraph spacing GWT renders. Blank lines are preserved now.
- **GWT J.1 bottom reply box**: `<wavy-wave-root-reply-trigger>` existed but was never mounted on live waves. It now mounts as the read surface's last child (wave-id kept fresh, cleared on failed host lookup) and hides while the wave-root composer is open.

### Server

- **`/read-state` 404 for fresh waves**: `Wave#lookedupWavelets` is a one-shot storage snapshot cached during the wave's own creation, so freshly created waves resolved to an empty set forever. `SelectedWaveReadStateHelper` now unions `WaveMap.getInMemoryWaveletIds` (same combination the search path uses). Fixes the console error on every fresh wave open and restores live unread state (R-4.4); also unblocks `mark-blip-read`, which routes through the same helper.
- **`mark-blip-read` 500**: `DeltaStoreBasedWaveletState` read the delta file before the in-memory cache and could hit a partially flushed record (`EOFException`) when transforming against just-submitted history. Reads are now cache-first with an EOF cache retry, plus a regression test simulating the in-flight append.

## Verification

- `cd j2cl/lit && npm test` — 888+ passed, 0 failed (includes new composer-focus and back-to-inbox interception tests)
- `cd j2cl && ./mvnw test` — 1105 run, 0 failures (includes new blank-line preservation tests)
- `sbt testOnly` for `SelectedWaveReadStateHelperTest` (5), `DeltaStoreBasedWaveletStateTest` (16 incl. new EOF/cache regression) and `jakartaTest:testOnly` for the J2CL parity classes — 0 failed
- Scripted browser pass on a staged server (port 9903), desktop + mobile, fresh user: **zero console errors, zero 4xx/5xx**; reply typed text lands and persists (visible from GWT too); mobile wave view usable end-to-end. Evidence: `journal/local-verification/2026-07-05-branch-claude-upbeat-hawking-d518ea.md`
- Reviewed with Grok in two rounds; final verdict "Mergeable — ship it" after addressing all priority findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)