### PR TITLE
feat(j2cl): wire real transport/save state into root live-surface status chips (#1233)

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceController.java
@@ -105,6 +105,41 @@ public final class J2clRootLiveSurfaceController {
     publish();
   }
 
+  /**
+   * #1233: apply a real transport connection state ({@code online} /
+   * {@code connecting} / {@code offline}) sourced from the live selected-wave
+   * socket. Unknown values normalize to {@code online} in the model. Republishes
+   * only when the state actually changes so status-chip churn stays minimal.
+   */
+  public void onConnectionState(String connectionState) {
+    if (!active) {
+      return;
+    }
+    J2clRootLiveSurfaceModel next = model.withConnectionState(connectionState);
+    if (next == model) {
+      return;
+    }
+    model = next;
+    publish();
+  }
+
+  /**
+   * #1233: apply a real save state ({@code saved} / {@code saving} /
+   * {@code unsaved}) sourced from in-flight wave-operation submits. Unknown
+   * values normalize to {@code saved}. Republishes only on change.
+   */
+  public void onSaveState(String saveState) {
+    if (!active) {
+      return;
+    }
+    J2clRootLiveSurfaceModel next = model.withSaveState(saveState);
+    if (next == model) {
+      return;
+    }
+    model = next;
+    publish();
+  }
+
   private void publish() {
     if (!active) {
       return;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceModel.java
@@ -8,34 +8,57 @@ public final class J2clRootLiveSurfaceModel {
   private static final String SELECTED_WAVE_STATUS = "Selected wave is active.";
   private static final String STARTING_STATUS = "Loading workspace.";
 
+  // Connection chip states understood by the compact wavy-header topbar
+  // (`netstatus[data-state]`): online | connecting | offline.
+  static final String CONNECTION_ONLINE = "online";
+  static final String CONNECTION_CONNECTING = "connecting";
+  static final String CONNECTION_OFFLINE = "offline";
+  // Save chip states (`savestatus[data-state]`): saved | saving | unsaved.
+  static final String SAVE_SAVED = "saved";
+  static final String SAVE_SAVING = "saving";
+  static final String SAVE_UNSAVED = "unsaved";
+
   private final String routeUrl;
   private final String query;
   private final String selectedWaveId;
   private final String statusText;
+  private final String connectionState;
+  private final String saveState;
 
   private J2clRootLiveSurfaceModel(
-      String routeUrl, String query, String selectedWaveId, String statusText) {
+      String routeUrl,
+      String query,
+      String selectedWaveId,
+      String statusText,
+      String connectionState,
+      String saveState) {
     this.routeUrl = nullToEmpty(routeUrl);
     this.query = nullToEmpty(query);
     this.selectedWaveId = emptyToNull(selectedWaveId);
     this.statusText = nullToEmpty(statusText);
+    this.connectionState = normalizeConnectionState(connectionState);
+    this.saveState = normalizeSaveState(saveState);
   }
 
   public static J2clRootLiveSurfaceModel starting() {
-    return new J2clRootLiveSurfaceModel("", "", null, STARTING_STATUS);
+    return new J2clRootLiveSurfaceModel(
+        "", "", null, STARTING_STATUS, CONNECTION_ONLINE, SAVE_SAVED);
   }
 
   public J2clRootLiveSurfaceModel withRouteUrl(String nextRouteUrl) {
     String normalizedRouteUrl = nullToEmpty(nextRouteUrl);
     if (normalizedRouteUrl.isEmpty()) {
-      return new J2clRootLiveSurfaceModel("", "", null, STARTING_STATUS);
+      return new J2clRootLiveSurfaceModel(
+          "", "", null, STARTING_STATUS, connectionState, saveState);
     }
     J2clSidecarRouteState routeState = parseRouteUrl(normalizedRouteUrl);
     return new J2clRootLiveSurfaceModel(
         normalizedRouteUrl,
         routeState.getQuery(),
         routeState.getSelectedWaveId(),
-        statusFor(normalizedRouteUrl, routeState.getQuery(), routeState.getSelectedWaveId()));
+        statusFor(normalizedRouteUrl, routeState.getQuery(), routeState.getSelectedWaveId()),
+        connectionState,
+        saveState);
   }
 
   public J2clRootLiveSurfaceModel withRouteState(J2clSidecarRouteState routeState) {
@@ -47,7 +70,9 @@ public final class J2clRootLiveSurfaceModel {
         routeUrl,
         routeState.getQuery(),
         nextSelectedWaveId,
-        statusFor(routeUrl, routeState.getQuery(), nextSelectedWaveId));
+        statusFor(routeUrl, routeState.getQuery(), nextSelectedWaveId),
+        connectionState,
+        saveState);
   }
 
   public J2clRootLiveSurfaceModel withSelectedWaveId(String nextSelectedWaveId) {
@@ -56,7 +81,36 @@ public final class J2clRootLiveSurfaceModel {
         routeUrl,
         query,
         normalizedSelectedWaveId,
-        statusFor(routeUrl, query, normalizedSelectedWaveId));
+        statusFor(routeUrl, query, normalizedSelectedWaveId),
+        connectionState,
+        saveState);
+  }
+
+  /**
+   * Returns a model carrying the given real transport connection state. Unknown
+   * values fall back to {@code online}. All route/selection fields are preserved
+   * so a route change while offline does not reset the chip.
+   */
+  public J2clRootLiveSurfaceModel withConnectionState(String nextConnectionState) {
+    String normalized = normalizeConnectionState(nextConnectionState);
+    if (normalized.equals(connectionState)) {
+      return this;
+    }
+    return new J2clRootLiveSurfaceModel(
+        routeUrl, query, selectedWaveId, statusText, normalized, saveState);
+  }
+
+  /**
+   * Returns a model carrying the given real save state. Unknown values fall back
+   * to {@code saved}. All other fields are preserved.
+   */
+  public J2clRootLiveSurfaceModel withSaveState(String nextSaveState) {
+    String normalized = normalizeSaveState(nextSaveState);
+    if (normalized.equals(saveState)) {
+      return this;
+    }
+    return new J2clRootLiveSurfaceModel(
+        routeUrl, query, selectedWaveId, statusText, connectionState, normalized);
   }
 
   public String getRouteUrl() {
@@ -89,13 +143,31 @@ public final class J2clRootLiveSurfaceModel {
   }
 
   public String getConnectionState() {
-    String status = statusText.toLowerCase();
-    return status.contains("offline") || status.contains("disconnected") ? "offline" : "online";
+    return connectionState;
   }
 
   public String getSaveState() {
-    String status = statusText.toLowerCase();
-    return status.contains("saving") || status.contains("unsaved") ? "saving" : "saved";
+    return saveState;
+  }
+
+  static String normalizeConnectionState(String value) {
+    if (CONNECTION_OFFLINE.equals(value)) {
+      return CONNECTION_OFFLINE;
+    }
+    if (CONNECTION_CONNECTING.equals(value)) {
+      return CONNECTION_CONNECTING;
+    }
+    return CONNECTION_ONLINE;
+  }
+
+  static String normalizeSaveState(String value) {
+    if (SAVE_SAVING.equals(value)) {
+      return SAVE_SAVING;
+    }
+    if (SAVE_UNSAVED.equals(value)) {
+      return SAVE_UNSAVED;
+    }
+    return SAVE_SAVED;
   }
 
   private static String routeStatus(String routeUrl, String query) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootSaveStateGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootSaveStateGateway.java
@@ -58,17 +58,25 @@ public final class J2clRootSaveStateGateway implements J2clComposeSurfaceControl
     // Guard against a delegate that invokes both callbacks (or one twice): the
     // ref-count must move exactly once per submit or the chip could latch.
     final boolean[] settled = new boolean[] {false};
-    delegate.submit(
-        bootstrap,
-        request,
-        response -> {
-          endSubmit(settled);
-          onSuccess.accept(response);
-        },
-        error -> {
-          endSubmit(settled);
-          onError.accept(error);
-        });
+    try {
+      delegate.submit(
+          bootstrap,
+          request,
+          response -> {
+            endSubmit(settled);
+            onSuccess.accept(response);
+          },
+          error -> {
+            endSubmit(settled);
+            onError.accept(error);
+          });
+    } catch (RuntimeException | Error e) {
+      // A delegate that throws synchronously (e.g. WebSocket allocation /
+      // input validation) must still release the ref-count, or the savestatus
+      // chip latches on "saving" for the rest of the session.
+      endSubmit(settled);
+      throw e;
+    }
   }
 
   private void beginSubmit() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootSaveStateGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootSaveStateGateway.java
@@ -1,0 +1,93 @@
+package org.waveprotocol.box.j2cl.root;
+
+import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceController;
+import org.waveprotocol.box.j2cl.search.J2clSearchPanelController;
+import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitResponse;
+
+/**
+ * #1233: compose-gateway decorator that reports real save state to the root
+ * live-surface status chips.
+ *
+ * <p>Every write path in the J2CL root shell (create, reply, blip edit, and the
+ * wave-header actions) funnels through {@link J2clComposeSurfaceController.Gateway#submit}.
+ * Wrapping that single choke point lets the {@code savestatus} chip flip to
+ * {@code saving} the instant an op is in flight and back to {@code saved} once
+ * every pending op has been acknowledged or has failed, without threading a
+ * listener through each submit site.
+ */
+public final class J2clRootSaveStateGateway implements J2clComposeSurfaceController.Gateway {
+
+  /** Sink for save-state transitions (typically {@code liveSurfaceController::onSaveState}). */
+  @FunctionalInterface
+  public interface SaveStateSink {
+    void onSaveState(String saveState);
+  }
+
+  private final J2clComposeSurfaceController.Gateway delegate;
+  private final SaveStateSink saveStateSink;
+  private int pendingSubmits;
+
+  public J2clRootSaveStateGateway(
+      J2clComposeSurfaceController.Gateway delegate, SaveStateSink saveStateSink) {
+    if (delegate == null) {
+      throw new IllegalArgumentException("delegate is required");
+    }
+    if (saveStateSink == null) {
+      throw new IllegalArgumentException("saveStateSink is required");
+    }
+    this.delegate = delegate;
+    this.saveStateSink = saveStateSink;
+  }
+
+  @Override
+  public void fetchRootSessionBootstrap(
+      J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> onSuccess,
+      J2clSearchPanelController.ErrorCallback onError) {
+    delegate.fetchRootSessionBootstrap(onSuccess, onError);
+  }
+
+  @Override
+  public void submit(
+      SidecarSessionBootstrap bootstrap,
+      SidecarSubmitRequest request,
+      J2clSearchPanelController.SuccessCallback<SidecarSubmitResponse> onSuccess,
+      J2clSearchPanelController.ErrorCallback onError) {
+    beginSubmit();
+    // Guard against a delegate that invokes both callbacks (or one twice): the
+    // ref-count must move exactly once per submit or the chip could latch.
+    final boolean[] settled = new boolean[] {false};
+    delegate.submit(
+        bootstrap,
+        request,
+        response -> {
+          endSubmit(settled);
+          onSuccess.accept(response);
+        },
+        error -> {
+          endSubmit(settled);
+          onError.accept(error);
+        });
+  }
+
+  private void beginSubmit() {
+    pendingSubmits++;
+    if (pendingSubmits == 1) {
+      saveStateSink.onSaveState(J2clRootLiveSurfaceModel.SAVE_SAVING);
+    }
+  }
+
+  private void endSubmit(boolean[] settled) {
+    if (settled[0]) {
+      return;
+    }
+    settled[0] = true;
+    if (pendingSubmits > 0) {
+      pendingSubmits--;
+    }
+    if (pendingSubmits == 0) {
+      saveStateSink.onSaveState(J2clRootLiveSurfaceModel.SAVE_SAVED);
+    }
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -100,9 +100,14 @@ public final class J2clRootShellController {
             routeControllerRef[0].selectWave(waveId);
           }
         };
+    // #1233: route every compose write through a save-state-tracking decorator
+    // so the topbar savestatus chip reflects real in-flight/acknowledged ops
+    // instead of a hardcoded "saved".
+    J2clComposeSurfaceController.Gateway composeGateway =
+        new J2clRootSaveStateGateway(gateway, liveSurfaceController::onSaveState);
     J2clComposeSurfaceController composeController =
         new J2clComposeSurfaceController(
-            gateway,
+            composeGateway,
             new J2clComposeSurfaceView(selectedCreateHost, selectedReplyHost),
             J2clComposeSurfaceController.richContentDeltaFactory(rootShellSessionSeed),
             J2clComposeSurfaceController.attachmentControllerFactory(rootShellSessionSeed, telemetrySink),
@@ -156,6 +161,9 @@ public final class J2clRootShellController {
             },
             telemetrySink);
     selectedWaveControllerRef[0] = selectedWaveController;
+    // #1233: feed real selected-wave socket connection transitions into the
+    // root live-surface so the netstatus chip tracks online/connecting/offline.
+    selectedWaveController.setConnectionStateListener(liveSurfaceController::onConnectionState);
     J2clSearchPanelController controller =
         new J2clSearchPanelController(
             gateway,

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -214,6 +214,22 @@ public final class J2clSelectedWaveController
     void onReadStateChanged(String waveId, int unreadCount, boolean stale);
   }
 
+  /**
+   * #1233: listener notified of real live-socket connection transitions for the
+   * selected wave so the root shell can drive the {@code netstatus} chip. The
+   * {@code state} is one of {@code "online"} (a live update arrived),
+   * {@code "connecting"} (the socket dropped and a reconnect is scheduled), or
+   * {@code "offline"} (reconnect attempts were exhausted).
+   */
+  @FunctionalInterface
+  public interface ConnectionStateListener {
+    void onConnectionStateChanged(String state);
+  }
+
+  static final String CONNECTION_ONLINE = "online";
+  static final String CONNECTION_CONNECTING = "connecting";
+  static final String CONNECTION_OFFLINE = "offline";
+
   private final Gateway gateway;
   private final View view;
   private final RetryScheduler retryScheduler;
@@ -240,6 +256,8 @@ public final class J2clSelectedWaveController
   // surface or scrolling away and back.
   private final Set<String> markBlipReadInFlight = new HashSet<String>();
   private ReadStateListener readStateListener;
+  private ConnectionStateListener connectionStateListener;
+  private String lastConnectionState = CONNECTION_ONLINE;
 
   public J2clSelectedWaveController(Gateway gateway, View view) {
     this(
@@ -537,6 +555,8 @@ public final class J2clSelectedWaveController
       // F-2 slice 5 (#1055): clear nav-row folder state when the
       // selection drops so the chrome reverts to the default pin/inbox.
       publishNavRowFolderState();
+      // #1233: no wave open — revert the netstatus chip to the online default.
+      notifyConnectionState(CONNECTION_ONLINE);
       return;
     }
 
@@ -667,6 +687,8 @@ public final class J2clSelectedWaveController
               requestAttachmentMetadataForCurrentViewport(generation);
               activeReconnectCount[0] = 0;
               this.reconnectCount = projectedReconnectCount;
+              // #1233: a live update means the socket is healthy.
+              notifyConnectionState(CONNECTION_ONLINE);
               scheduleReadStateFetch(generation);
             },
             error -> {
@@ -1140,8 +1162,12 @@ public final class J2clSelectedWaveController
               currentModel);
       view.render(currentModel);
       publishWriteSession();
+      // #1233: reconnect budget exhausted — the wave is offline.
+      notifyConnectionState(CONNECTION_OFFLINE);
       return;
     }
+    // #1233: the socket dropped and a reconnect is scheduled.
+    notifyConnectionState(CONNECTION_CONNECTING);
     int nextReconnectCount = reconnectCount + 1;
     retryScheduler.scheduleRetry(
         buildReconnectDelayMs(reconnectCount),
@@ -1593,6 +1619,21 @@ public final class J2clSelectedWaveController
    */
   public void setReadStateListener(ReadStateListener listener) {
     this.readStateListener = listener;
+  }
+
+  /** #1233: register the live-connection listener used to drive the netstatus chip. */
+  public void setConnectionStateListener(ConnectionStateListener listener) {
+    this.connectionStateListener = listener;
+  }
+
+  private void notifyConnectionState(String state) {
+    if (state == null || state.equals(lastConnectionState)) {
+      return;
+    }
+    lastConnectionState = state;
+    if (connectionStateListener != null) {
+      connectionStateListener.onConnectionStateChanged(state);
+    }
   }
 
   /**

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceControllerTest.java
@@ -423,6 +423,87 @@ public class J2clRootLiveSurfaceControllerTest {
     }
   }
 
+  @Test
+  public void onConnectionStatePublishesRealStateAndNormalizesUnknown() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller = startedController(shell);
+
+    controller.onConnectionState("offline");
+    Assert.assertEquals("offline", shell.lastModel().getConnectionState());
+
+    controller.onConnectionState("connecting");
+    Assert.assertEquals("connecting", shell.lastModel().getConnectionState());
+
+    controller.onConnectionState("bogus");
+    Assert.assertEquals("online", shell.lastModel().getConnectionState());
+  }
+
+  @Test
+  public void onSaveStatePublishesRealStateAndNormalizesUnknown() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller = startedController(shell);
+
+    controller.onSaveState("saving");
+    Assert.assertEquals("saving", shell.lastModel().getSaveState());
+
+    controller.onSaveState("nonsense");
+    Assert.assertEquals("saved", shell.lastModel().getSaveState());
+  }
+
+  @Test
+  public void unchangedConnectionOrSaveStateDoesNotRepublish() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller = startedController(shell);
+
+    // Defaults are online/saved, so re-asserting them must not republish.
+    controller.onConnectionState("online");
+    controller.onSaveState("saved");
+    Assert.assertEquals(0, shell.models.size());
+
+    controller.onConnectionState("offline");
+    Assert.assertEquals(1, shell.models.size());
+    controller.onConnectionState("offline");
+    Assert.assertEquals(1, shell.models.size());
+  }
+
+  @Test
+  public void realConnectionAndSaveStatePreservedAcrossRouteTransitions() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller = startedController(shell);
+
+    controller.onConnectionState("offline");
+    controller.onSaveState("saving");
+    controller.onRouteUrlChanged("?view=j2cl-root&q=in%3Ainbox");
+
+    Assert.assertEquals("offline", shell.lastModel().getConnectionState());
+    Assert.assertEquals("saving", shell.lastModel().getSaveState());
+    Assert.assertEquals("in:inbox", shell.lastModel().getQuery());
+  }
+
+  @Test
+  public void connectionAndSaveCallbacksBeforeStartAreSuppressed() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller =
+        new J2clRootLiveSurfaceController(shell, () -> {});
+
+    controller.onConnectionState("offline");
+    controller.onSaveState("saving");
+
+    Assert.assertEquals(0, shell.models.size());
+  }
+
+  @Test
+  public void connectionAndSaveCallbacksAfterStopAreSuppressed() {
+    FakeShellSurface shell = new FakeShellSurface();
+    J2clRootLiveSurfaceController controller = startedController(shell);
+
+    controller.stop();
+    controller.onConnectionState("offline");
+    controller.onSaveState("saving");
+
+    Assert.assertEquals(0, shell.models.size());
+  }
+
   private static J2clSearchDigestItem digest(String waveId) {
     return new J2clSearchDigestItem(
         waveId,

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceModelTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceModelTest.java
@@ -1,0 +1,105 @@
+package org.waveprotocol.box.j2cl.root;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import org.junit.Assert;
+import org.junit.Test;
+import org.waveprotocol.box.j2cl.search.J2clSidecarRouteState;
+
+@J2clTestInput(J2clRootLiveSurfaceModelTest.class)
+public class J2clRootLiveSurfaceModelTest {
+
+  @Test
+  public void startingDefaultsToOnlineAndSaved() {
+    J2clRootLiveSurfaceModel model = J2clRootLiveSurfaceModel.starting();
+    Assert.assertEquals("online", model.getConnectionState());
+    Assert.assertEquals("saved", model.getSaveState());
+  }
+
+  @Test
+  public void withConnectionStateAcceptsKnownValues() {
+    J2clRootLiveSurfaceModel model = J2clRootLiveSurfaceModel.starting();
+    Assert.assertEquals("offline", model.withConnectionState("offline").getConnectionState());
+    Assert.assertEquals("connecting", model.withConnectionState("connecting").getConnectionState());
+    Assert.assertEquals("online", model.withConnectionState("online").getConnectionState());
+  }
+
+  @Test
+  public void withConnectionStateNormalizesUnknownToOnline() {
+    J2clRootLiveSurfaceModel model =
+        J2clRootLiveSurfaceModel.starting().withConnectionState("garbage");
+    Assert.assertEquals("online", model.getConnectionState());
+  }
+
+  @Test
+  public void withSaveStateAcceptsKnownValues() {
+    J2clRootLiveSurfaceModel model = J2clRootLiveSurfaceModel.starting();
+    Assert.assertEquals("saving", model.withSaveState("saving").getSaveState());
+    Assert.assertEquals("unsaved", model.withSaveState("unsaved").getSaveState());
+    Assert.assertEquals("saved", model.withSaveState("saved").getSaveState());
+  }
+
+  @Test
+  public void withSaveStateNormalizesUnknownToSaved() {
+    J2clRootLiveSurfaceModel model = J2clRootLiveSurfaceModel.starting().withSaveState("weird");
+    Assert.assertEquals("saved", model.getSaveState());
+  }
+
+  @Test
+  public void unchangedStateReturnsSameInstance() {
+    J2clRootLiveSurfaceModel model = J2clRootLiveSurfaceModel.starting();
+    Assert.assertSame(model, model.withConnectionState("online"));
+    Assert.assertSame(model, model.withSaveState("saved"));
+  }
+
+  @Test
+  public void connectionAndSaveStateSurviveRouteUrlChange() {
+    J2clRootLiveSurfaceModel model =
+        J2clRootLiveSurfaceModel.starting()
+            .withConnectionState("offline")
+            .withSaveState("saving")
+            .withRouteUrl("?view=j2cl-root&q=in%3Ainbox");
+
+    Assert.assertEquals("offline", model.getConnectionState());
+    Assert.assertEquals("saving", model.getSaveState());
+    Assert.assertEquals("in:inbox", model.getQuery());
+  }
+
+  @Test
+  public void connectionAndSaveStateSurviveRouteStateChange() {
+    J2clRootLiveSurfaceModel model =
+        J2clRootLiveSurfaceModel.starting()
+            .withConnectionState("connecting")
+            .withSaveState("saving")
+            .withRouteState(new J2clSidecarRouteState("in:inbox", "example.com/w+1"));
+
+    Assert.assertEquals("connecting", model.getConnectionState());
+    Assert.assertEquals("saving", model.getSaveState());
+    Assert.assertEquals("example.com/w+1", model.getSelectedWaveId());
+  }
+
+  @Test
+  public void connectionAndSaveStateSurviveSelectedWaveChange() {
+    J2clRootLiveSurfaceModel model =
+        J2clRootLiveSurfaceModel.starting()
+            .withConnectionState("offline")
+            .withSaveState("unsaved")
+            .withSelectedWaveId("example.com/w+2");
+
+    Assert.assertEquals("offline", model.getConnectionState());
+    Assert.assertEquals("unsaved", model.getSaveState());
+    Assert.assertEquals("example.com/w+2", model.getSelectedWaveId());
+  }
+
+  @Test
+  public void emptyRouteUrlResetsStatusButPreservesRealState() {
+    J2clRootLiveSurfaceModel model =
+        J2clRootLiveSurfaceModel.starting()
+            .withConnectionState("offline")
+            .withSaveState("saving")
+            .withRouteUrl("");
+
+    Assert.assertEquals("Loading workspace.", model.getStatusText());
+    Assert.assertEquals("offline", model.getConnectionState());
+    Assert.assertEquals("saving", model.getSaveState());
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootSaveStateGatewayTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootSaveStateGatewayTest.java
@@ -80,6 +80,33 @@ public class J2clRootSaveStateGatewayTest {
   }
 
   @Test
+  public void synchronousDelegateThrowReleasesRefCountAndRethrows() {
+    ThrowingGateway delegate = new ThrowingGateway();
+    List<String> transitions = new ArrayList<String>();
+    J2clRootSaveStateGateway gateway = new J2clRootSaveStateGateway(delegate, transitions::add);
+
+    try {
+      gateway.submit(null, null, response -> {}, error -> {});
+      Assert.fail("Expected the synchronous delegate failure to propagate.");
+    } catch (RuntimeException expected) {
+      Assert.assertEquals("submit exploded", expected.getMessage());
+    }
+
+    // The chip must not latch on "saving": the ref-count was released.
+    Assert.assertEquals("saved", lastOf(transitions));
+
+    // And a subsequent healthy submit still transitions correctly.
+    FakeGateway healthy = new FakeGateway();
+    List<String> healthyTransitions = new ArrayList<String>();
+    J2clRootSaveStateGateway healthyGateway =
+        new J2clRootSaveStateGateway(healthy, healthyTransitions::add);
+    healthyGateway.submit(null, null, response -> {}, error -> {});
+    Assert.assertEquals("saving", lastOf(healthyTransitions));
+    healthy.settleSuccess(0);
+    Assert.assertEquals("saved", lastOf(healthyTransitions));
+  }
+
+  @Test
   public void forwardsSuccessResponseAndErrorToCaller() {
     FakeGateway delegate = new FakeGateway();
     List<String> transitions = new ArrayList<String>();
@@ -170,6 +197,23 @@ public class J2clRootSaveStateGatewayTest {
 
     private void settleError(int index, String message) {
       errors.get(index).accept(message);
+    }
+  }
+
+  /** Delegate whose {@code submit} throws synchronously, before wiring callbacks. */
+  private static final class ThrowingGateway implements J2clComposeSurfaceController.Gateway {
+    @Override
+    public void fetchRootSessionBootstrap(
+        J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> onSuccess,
+        J2clSearchPanelController.ErrorCallback onError) {}
+
+    @Override
+    public void submit(
+        SidecarSessionBootstrap bootstrap,
+        SidecarSubmitRequest request,
+        J2clSearchPanelController.SuccessCallback<SidecarSubmitResponse> onSuccess,
+        J2clSearchPanelController.ErrorCallback onError) {
+      throw new RuntimeException("submit exploded");
     }
   }
 }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootSaveStateGatewayTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/root/J2clRootSaveStateGatewayTest.java
@@ -1,0 +1,175 @@
+package org.waveprotocol.box.j2cl.root;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceController;
+import org.waveprotocol.box.j2cl.search.J2clSearchPanelController;
+import org.waveprotocol.box.j2cl.transport.SidecarSessionBootstrap;
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitRequest;
+import org.waveprotocol.box.j2cl.transport.SidecarSubmitResponse;
+
+@J2clTestInput(J2clRootSaveStateGatewayTest.class)
+public class J2clRootSaveStateGatewayTest {
+
+  @Test
+  public void submitFlipsToSavingThenSavedOnSuccess() {
+    FakeGateway delegate = new FakeGateway();
+    List<String> transitions = new ArrayList<String>();
+    J2clRootSaveStateGateway gateway = new J2clRootSaveStateGateway(delegate, transitions::add);
+
+    gateway.submit(null, null, response -> {}, error -> {});
+    Assert.assertEquals("saving", lastOf(transitions));
+
+    delegate.settleSuccess(0);
+    Assert.assertEquals("saved", lastOf(transitions));
+  }
+
+  @Test
+  public void submitFlipsToSavedOnError() {
+    FakeGateway delegate = new FakeGateway();
+    List<String> transitions = new ArrayList<String>();
+    J2clRootSaveStateGateway gateway = new J2clRootSaveStateGateway(delegate, transitions::add);
+
+    gateway.submit(null, null, response -> {}, error -> {});
+    Assert.assertEquals("saving", lastOf(transitions));
+
+    delegate.settleError(0, "boom");
+    Assert.assertEquals("saved", lastOf(transitions));
+  }
+
+  @Test
+  public void concurrentSubmitsStaySavingUntilAllSettle() {
+    FakeGateway delegate = new FakeGateway();
+    List<String> transitions = new ArrayList<String>();
+    J2clRootSaveStateGateway gateway = new J2clRootSaveStateGateway(delegate, transitions::add);
+
+    gateway.submit(null, null, response -> {}, error -> {});
+    gateway.submit(null, null, response -> {}, error -> {});
+    // Only one "saving" transition should have fired (on the first in-flight op).
+    Assert.assertEquals(1, count(transitions, "saving"));
+
+    delegate.settleSuccess(0);
+    // Still one op in flight — no "saved" yet.
+    Assert.assertEquals(0, count(transitions, "saved"));
+
+    delegate.settleSuccess(1);
+    Assert.assertEquals("saved", lastOf(transitions));
+    Assert.assertEquals(1, count(transitions, "saved"));
+  }
+
+  @Test
+  public void duplicateCallbackDoesNotUnderflowRefCount() {
+    FakeGateway delegate = new FakeGateway();
+    List<String> transitions = new ArrayList<String>();
+    J2clRootSaveStateGateway gateway = new J2clRootSaveStateGateway(delegate, transitions::add);
+
+    gateway.submit(null, null, response -> {}, error -> {});
+    delegate.settleSuccess(0);
+    // A misbehaving delegate that fires the callback again must not push the
+    // count negative and must not emit a second "saved".
+    delegate.settleError(0, "late");
+
+    Assert.assertEquals(1, count(transitions, "saved"));
+
+    // A fresh submit still works correctly.
+    gateway.submit(null, null, response -> {}, error -> {});
+    Assert.assertEquals(2, count(transitions, "saving"));
+  }
+
+  @Test
+  public void forwardsSuccessResponseAndErrorToCaller() {
+    FakeGateway delegate = new FakeGateway();
+    List<String> transitions = new ArrayList<String>();
+    J2clRootSaveStateGateway gateway = new J2clRootSaveStateGateway(delegate, transitions::add);
+    final int[] successes = {0};
+    final List<String> errors = new ArrayList<String>();
+
+    gateway.submit(null, null, response -> successes[0]++, errors::add);
+    delegate.settleSuccess(0);
+    Assert.assertEquals(1, successes[0]);
+
+    gateway.submit(null, null, response -> successes[0]++, errors::add);
+    delegate.settleError(1, "nope");
+    Assert.assertEquals(1, errors.size());
+    Assert.assertEquals("nope", errors.get(0));
+  }
+
+  @Test
+  public void fetchRootSessionBootstrapIsDelegatedWithoutSaveTransition() {
+    FakeGateway delegate = new FakeGateway();
+    List<String> transitions = new ArrayList<String>();
+    J2clRootSaveStateGateway gateway = new J2clRootSaveStateGateway(delegate, transitions::add);
+
+    gateway.fetchRootSessionBootstrap(bootstrap -> {}, error -> {});
+
+    Assert.assertEquals(1, delegate.bootstrapCount);
+    Assert.assertTrue(transitions.isEmpty());
+  }
+
+  @Test
+  public void constructorRejectsNullArguments() {
+    List<String> transitions = new ArrayList<String>();
+    try {
+      new J2clRootSaveStateGateway(null, transitions::add);
+      Assert.fail("Expected null delegate to be rejected.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertEquals("delegate is required", expected.getMessage());
+    }
+    try {
+      new J2clRootSaveStateGateway(new FakeGateway(), null);
+      Assert.fail("Expected null sink to be rejected.");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertEquals("saveStateSink is required", expected.getMessage());
+    }
+  }
+
+  private static String lastOf(List<String> values) {
+    return values.get(values.size() - 1);
+  }
+
+  private static int count(List<String> values, String target) {
+    int total = 0;
+    for (String value : values) {
+      if (target.equals(value)) {
+        total++;
+      }
+    }
+    return total;
+  }
+
+  private static final class FakeGateway implements J2clComposeSurfaceController.Gateway {
+    private int bootstrapCount;
+    private final List<J2clSearchPanelController.SuccessCallback<SidecarSubmitResponse>> successes =
+        new ArrayList<J2clSearchPanelController.SuccessCallback<SidecarSubmitResponse>>();
+    private final List<J2clSearchPanelController.ErrorCallback> errors =
+        new ArrayList<J2clSearchPanelController.ErrorCallback>();
+
+    @Override
+    public void fetchRootSessionBootstrap(
+        J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> onSuccess,
+        J2clSearchPanelController.ErrorCallback onError) {
+      bootstrapCount++;
+    }
+
+    @Override
+    public void submit(
+        SidecarSessionBootstrap bootstrap,
+        SidecarSubmitRequest request,
+        J2clSearchPanelController.SuccessCallback<SidecarSubmitResponse> onSuccess,
+        J2clSearchPanelController.ErrorCallback onError) {
+      successes.add(onSuccess);
+      errors.add(onError);
+    }
+
+    private void settleSuccess(int index) {
+      successes.get(index).accept(null);
+    }
+
+    private void settleError(int index, String message) {
+      errors.get(index).accept(message);
+    }
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveControllerTest.java
@@ -109,6 +109,63 @@ public class J2clSelectedWaveControllerTest {
   }
 
   @Test
+  public void connectionListenerReportsConnectingThenOfflineOnExhaustedReconnect() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(true);
+    List<String> states = harness.captureConnectionStates(controller);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello from the sidecar");
+    // A healthy first update matches the online default, so no redundant fire.
+    Assert.assertTrue(states.isEmpty());
+
+    harness.fireDisconnect(0);
+    Assert.assertEquals(Arrays.asList("connecting"), states);
+
+    for (int attempt = 1; attempt <= 8; attempt++) {
+      harness.runScheduledRetry(attempt - 1);
+      harness.rejectBootstrap(attempt, "Network failure for /");
+    }
+
+    Assert.assertEquals(Arrays.asList("connecting", "offline"), states);
+  }
+
+  @Test
+  public void connectionListenerReportsOnlineAfterReconnectRecovery() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(true);
+    List<String> states = harness.captureConnectionStates(controller);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello from the sidecar");
+
+    harness.fireDisconnect(0);
+    harness.runScheduledRetry(0);
+    harness.resolveBootstrap(1);
+    harness.deliverUpdate(1, "Recovered after restart");
+
+    Assert.assertEquals(Arrays.asList("connecting", "online"), states);
+  }
+
+  @Test
+  public void connectionListenerRevertsToOnlineWhenSelectionCleared() throws Exception {
+    Harness harness = new Harness();
+    Object controller = harness.createController(true);
+    List<String> states = harness.captureConnectionStates(controller);
+
+    harness.selectWave(controller, "example.com/w+1", null);
+    harness.resolveBootstrap(0);
+    harness.deliverUpdate(0, "Hello from the sidecar");
+    harness.fireDisconnect(0);
+
+    harness.selectWave(controller, null, null);
+
+    Assert.assertEquals(Arrays.asList("connecting", "online"), states);
+  }
+
+  @Test
   public void bootstrapErrorRendersSelectedWaveError() throws Exception {
     Harness harness = new Harness();
     Object controller = harness.createController(false);
@@ -2726,6 +2783,32 @@ public class J2clSelectedWaveControllerTest {
       } else {
         onWaveSelectedWithDigestMethod.invoke(controller, waveId, digestItem);
       }
+    }
+
+    /**
+     * #1233: register a proxy ConnectionStateListener on the reflectively-built
+     * controller and return the list it appends each reported state to.
+     */
+    private List<String> captureConnectionStates(Object controller) throws Exception {
+      Class<?> listenerClass =
+          Class.forName(
+              "org.waveprotocol.box.j2cl.search.J2clSelectedWaveController$ConnectionStateListener");
+      final List<String> states = new ArrayList<String>();
+      Object listener =
+          Proxy.newProxyInstance(
+              listenerClass.getClassLoader(),
+              new Class<?>[] {listenerClass},
+              (proxy, method, args) -> {
+                if ("onConnectionStateChanged".equals(method.getName())) {
+                  states.add((String) args[0]);
+                }
+                return null;
+              });
+      controller
+          .getClass()
+          .getMethod("setConnectionStateListener", listenerClass)
+          .invoke(controller, listener);
+      return states;
     }
 
     private void refreshSelectedWave(Object controller) throws Exception {

--- a/wave/config/changelog.d/2026-07-05-j2cl-live-status-chips.json
+++ b/wave/config/changelog.d/2026-07-05-j2cl-live-status-chips.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-07-05-j2cl-live-status-chips",
+  "version": "unreleased",
+  "date": "2026-07-05",
+  "title": "J2CL topbar status chips now reflect real connection and save state",
+  "summary": "In the new UI, the topbar 'Online' and 'All changes saved' chips used to be hardcoded green regardless of what was actually happening. They now track the live wave socket and in-flight edits: the network chip shows Connecting/Offline when the selected-wave stream drops and reconnects, and the save chip shows Saving while a create/reply/edit is in flight and returns to Saved once the server acknowledges it.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "New UI: the topbar network chip now reflects the real selected-wave socket — Online when live updates are flowing, Connecting while a dropped stream is retrying, and Offline once reconnect attempts are exhausted, instead of always showing Online.",
+        "New UI: the topbar save chip now shows Saving while a wave create, reply, or edit is in flight and returns to Saved once every pending operation is acknowledged (or fails), instead of always showing All changes saved."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes #1233. The J2CL topbar **netstatus** / **savestatus** chips were hardcoded green: `J2clRootLiveSurfaceModel.getConnectionState()`/`getSaveState()` scanned the route status text for keywords (`offline`, `saving`) that the fixed strings (`Loading workspace.`, `Workspace is ready.`, `Selected wave is active.`) never contain, so they always returned `online`/`saved`.

### GWT-reference vs new behavior
GWT's topbar shows a live connection state (Online / Connecting / Offline) and a live save state (All changes saved / Saving). This PR gives the J2CL root the same real signals:

- **Model** — `J2clRootLiveSurfaceModel` now carries immutable `connectionState` (`online`/`connecting`/`offline`) and `saveState` (`saved`/`saving`/`unsaved`) fields, normalized (unknown → default) and threaded through every `with*` transition, so a route change while offline no longer resets the chip.
- **Controller** — `J2clRootLiveSurfaceController` gains `onConnectionState`/`onSaveState`, which respect the active lifecycle and republish only on a real change.
- **Connection** — `J2clSelectedWaveController` gains a `ConnectionStateListener`: `online` when a live update arrives, `connecting` when a dropped stream is scheduled for reconnect, `offline` when the reconnect budget is exhausted, and `online` again when the wave is deselected.
- **Save** — new `J2clRootSaveStateGateway` decorates the single compose `Gateway.submit` choke point that every write (create / reply / blip edit / wave-header actions) funnels through: `saving` while ≥1 op is in flight, `saved` once all pending ops are acknowledged or fail. Ref-counted for concurrent submits and guarded against a delegate that fires a callback twice.
- `J2clRootShellController` wires the decorator + connection listener. `publishLiveStatus` already consumed `getConnectionState`/`getSaveState`, so the chips light up automatically. The Lit `wavy-header` already renders all three connection states and the save states — no Lit change needed.

The SSR defaults (`online`/`saved`) are unchanged, so first paint is unaffected.

## Tests
- `J2clRootLiveSurfaceModelTest` (new) — 10 passed: defaults, normalization, threading through route/route-state/selected-wave changes, same-instance on no-op.
- `J2clRootSaveStateGatewayTest` (new) — 7 passed: saving→saved on success/error, concurrent-submit ref-count, double-callback guard, bootstrap pass-through, null guards.
- `J2clRootLiveSurfaceControllerTest` — new cases for `onConnectionState`/`onSaveState` publish/normalize/idempotence/lifecycle-suppression.
- `J2clSelectedWaveControllerTest` — 101 passed, incl. 3 new: connecting→offline on exhausted reconnect, online on recovery, online on deselect.
- `cd j2cl/lit && npm test` — 889 passed, 0 failed (regression guard; no Lit changes).

## Local browser verification (Playwright, `?view=j2cl-root`, 1440×900)
Fresh registered user, opened the seeded Welcome wave, watched `wavy-header[compact-gwt-topbar]`'s `data-save-state` via a MutationObserver, then created a wave through the compose path:
- initial chips: `save=saved connection=online`
- save-state transitions during create: `["saved","saving","saved","saved"]` — flips to **saving** while the op is in flight, settles to **saved** on ack.
- 0 console errors, 0 4xx/5xx.

`connecting`/`offline` are covered by unit tests (forcing a real socket outage in a headless smoke run is impractical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
