### PR TITLE
feat(j2cl): localize J2CL Java-surface status/error strings via the Lit i18n catalog (#1277)

### DIFF
--- a/j2cl/lit/src/i18n/catalogs/de.js
+++ b/j2cl/lit/src/i18n/catalogs/de.js
@@ -363,5 +363,32 @@ export const de = {
   "waveNav.prevMention": "Zur vorherigen Erwähnung springen",
   "waveNav.nextMention": "Zur nächsten Erwähnung springen",
   "waveNav.versionHistoryShortcut": "Versionsverlauf öffnen (h)",
-  "waveNav.overflow": "Weitere Wave-Navigations-Aktionen"
+  "waveNav.overflow": "Weitere Wave-Navigations-Aktionen",
+  // #1277: dynamische Status-/Fehlermeldungen der J2CL-Java-Oberflächen.
+  "rootStatus.loading": "Arbeitsbereich wird geladen.",
+  "rootStatus.ready": "Arbeitsbereich ist bereit.",
+  "rootStatus.selectedWave": "Ausgewählte Wave ist aktiv.",
+  "rootStatus.searchResults": "Suchergebnisse für {query} werden angezeigt.",
+  "selectedWave.selectTitle": "Wave auswählen",
+  "selectedWave.chooseDigest":
+    "Wählen Sie einen Eintrag aus den Suchergebnissen, um ein schreibgeschütztes Wave-Panel zu öffnen.",
+  "selectedWave.copiedUrls":
+    "Kopierte URLs können die ausgewählte Wave wiederherstellen, wenn die Route sie enthält.",
+  "selectedWave.reconnecting": "Ausgewählte Wave wird neu verbunden.",
+  "selectedWave.opening": "Ausgewählte Wave wird geöffnet.",
+  "selectedWave.reusingSession": "Aktuelle Sitzung wird nach einer Unterbrechung wiederverwendet.",
+  "selectedWave.waitingFirstUpdate":
+    "Warten auf die erste Live-Aktualisierung der ausgewählten Wave.",
+  "selectedWave.defaultTitle": "Ausgewählte Wave",
+  "selectedWave.digestRead": "Ausgewählter Eintrag ist gelesen.",
+  "selectedWave.digestUnread": "{count} ungelesen im ausgewählten Eintrag.",
+  "selectedWave.read": "Gelesen.",
+  "selectedWave.unread": "{count} ungelesen.",
+  "selectedWave.errorOpen": "Ausgewählte Wave kann nicht geöffnet werden.",
+  "selectedWave.errorStream": "Stream der ausgewählten Wave fehlgeschlagen.",
+  "selectedWave.errorDisconnected": "Verbindung zur ausgewählten Wave getrennt.",
+  "selectedWave.errorDisconnectedDetail":
+    "Der Selected-Wave-Sidecar hat nach {count} Wiederverbindungsversuchen aufgegeben.",
+  "selectedWave.liveReconnected": "Live-Aktualisierungen wieder verbunden.",
+  "selectedWave.liveConnected": "Live-Aktualisierungen verbunden."
 };

--- a/j2cl/lit/src/i18n/catalogs/en.js
+++ b/j2cl/lit/src/i18n/catalogs/en.js
@@ -397,5 +397,32 @@ export const en = {
   "waveNav.prevMention": "Jump to previous mention",
   "waveNav.nextMention": "Jump to next mention",
   "waveNav.versionHistoryShortcut": "Open version history (h)",
-  "waveNav.overflow": "More wave navigation actions"
+  "waveNav.overflow": "More wave navigation actions",
+  // #1277: dynamic status/error strings emitted by the J2CL Java surfaces
+  // (root live-surface + selected-wave). Resolved via J2clI18n -> t().
+  "rootStatus.loading": "Loading workspace.",
+  "rootStatus.ready": "Workspace is ready.",
+  "rootStatus.selectedWave": "Selected wave is active.",
+  "rootStatus.searchResults": "Showing search results for {query}.",
+  "selectedWave.selectTitle": "Select a wave",
+  "selectedWave.chooseDigest":
+    "Choose a digest from the search results to open a read-only selected-wave panel.",
+  "selectedWave.copiedUrls":
+    "Copied URLs can restore the selected wave when the route includes it.",
+  "selectedWave.reconnecting": "Reconnecting selected wave.",
+  "selectedWave.opening": "Opening selected wave.",
+  "selectedWave.reusingSession": "Reusing the current session after a disconnect.",
+  "selectedWave.waitingFirstUpdate": "Waiting for the first live selected-wave update.",
+  "selectedWave.defaultTitle": "Selected wave",
+  "selectedWave.digestRead": "Selected digest is read.",
+  "selectedWave.digestUnread": "{count} unread in the selected digest.",
+  "selectedWave.read": "Read.",
+  "selectedWave.unread": "{count} unread.",
+  "selectedWave.errorOpen": "Unable to open selected wave.",
+  "selectedWave.errorStream": "Selected wave stream failed.",
+  "selectedWave.errorDisconnected": "Selected wave disconnected.",
+  "selectedWave.errorDisconnectedDetail":
+    "The selected-wave sidecar stopped retrying after {count} reconnect attempts.",
+  "selectedWave.liveReconnected": "Live updates reconnected.",
+  "selectedWave.liveConnected": "Live updates connected."
 };

--- a/j2cl/lit/src/i18n/j2cl-bridge.js
+++ b/j2cl/lit/src/i18n/j2cl-bridge.js
@@ -1,0 +1,24 @@
+// #1277: expose the Lit i18n catalog to the J2CL (Java -> JS) sidecar bundle.
+//
+// The J2CL sidecar is a separate bundle on the same page and cannot import
+// these ES modules directly, so we publish a tiny stable surface on the global
+// object. The Java-side `J2clI18n` bridge calls `window.__j2clI18n.t(key,
+// fallback)` for every dynamic status/error string. The catalog (en.js/de.js
+// + `t()`) stays the single source of truth — no string table is duplicated
+// into Java, and locale resolution/subscription lives here in JS.
+import { t } from "./t.js";
+import { getLocale, setLocale, subscribe } from "./locale.js";
+
+export const J2CL_I18N_GLOBAL = "__j2clI18n";
+
+/**
+ * Install the i18n bridge on `target` (defaults to `window`). Idempotent.
+ * @param {object} [target] host object to attach the bridge to.
+ */
+export function installI18nBridge(target) {
+  const host = target ?? (typeof window !== "undefined" ? window : undefined);
+  if (!host) return undefined;
+  const bridge = { t, getLocale, setLocale, subscribe };
+  host[J2CL_I18N_GLOBAL] = bridge;
+  return bridge;
+}

--- a/j2cl/lit/src/index.js
+++ b/j2cl/lit/src/index.js
@@ -86,6 +86,11 @@ import "./elements/wavy-confirm-dialog.js";
 // per-row archive/pin/version-history buttons to the /folder servlet
 // and the existing <wavy-version-history> overlay.
 import "./controllers/wave-action-bar-controller.js";
+// #1277: publish the i18n catalog to the J2CL sidecar bundle so Java-emitted
+// dynamic status/error strings resolve through the same `t()` + catalogs.
+import { installI18nBridge } from "./i18n/j2cl-bridge.js";
+
+installI18nBridge();
 
 window.__litShellInput =
   window.__bootstrap && typeof window.__bootstrap === "object"

--- a/j2cl/lit/test/j2cl-bridge.test.js
+++ b/j2cl/lit/test/j2cl-bridge.test.js
@@ -1,0 +1,78 @@
+import { expect } from "@open-wc/testing";
+import { installI18nBridge, J2CL_I18N_GLOBAL } from "../src/i18n/j2cl-bridge.js";
+import { en } from "../src/i18n/catalogs/en.js";
+import { de } from "../src/i18n/catalogs/de.js";
+import { setLocale, _resetLocaleForTesting } from "../src/i18n/locale.js";
+
+describe("#1277 J2CL i18n bridge", () => {
+  afterEach(() => {
+    _resetLocaleForTesting();
+    delete window.__bootstrap;
+    delete window[J2CL_I18N_GLOBAL];
+  });
+
+  it("installs t/getLocale/setLocale/subscribe on the target", () => {
+    const target = {};
+    const bridge = installI18nBridge(target);
+    expect(target[J2CL_I18N_GLOBAL]).to.equal(bridge);
+    expect(bridge.t).to.be.a("function");
+    expect(bridge.getLocale).to.be.a("function");
+    expect(bridge.setLocale).to.be.a("function");
+    expect(bridge.subscribe).to.be.a("function");
+  });
+
+  it("defaults to window when no target is given", () => {
+    const bridge = installI18nBridge();
+    expect(window[J2CL_I18N_GLOBAL]).to.equal(bridge);
+  });
+
+  it("resolves the Java-surface keys through the English catalog by default", () => {
+    const { t } = installI18nBridge({});
+    expect(t("rootStatus.ready", "FB")).to.equal("Workspace is ready.");
+    expect(t("selectedWave.errorDisconnected", "FB")).to.equal("Selected wave disconnected.");
+  });
+
+  it("returns German strings once the locale switches", () => {
+    const { t, setLocale: bridgeSetLocale } = installI18nBridge({});
+    bridgeSetLocale("de");
+    expect(t("rootStatus.ready", "FB")).to.equal("Arbeitsbereich ist bereit.");
+    expect(t("selectedWave.errorOpen", "FB")).to.equal(
+      "Ausgewählte Wave kann nicht geöffnet werden."
+    );
+  });
+
+  it("keeps the supplied English fallback for unknown keys", () => {
+    const { t } = installI18nBridge({});
+    expect(t("does.not.exist", "the fallback")).to.equal("the fallback");
+  });
+});
+
+describe("#1277 Java-surface catalog keys", () => {
+  // The catalog intentionally allows en-only keys (the en-fallback path), so we
+  // do not assert full parity — only that the Java-surface keys added for #1277
+  // are translated in both catalogs.
+  const JAVA_SURFACE_KEYS = Object.keys(en).filter(
+    (key) => key.startsWith("rootStatus.") || key.startsWith("selectedWave.")
+  );
+
+  it("has at least the root + selected-wave namespaces", () => {
+    expect(JAVA_SURFACE_KEYS.length).to.be.greaterThan(15);
+  });
+
+  it("defines every Java-surface key in both en and de", () => {
+    const missingDe = JAVA_SURFACE_KEYS.filter((key) => !(key in de));
+    expect(missingDe, `de.js missing Java-surface keys: ${missingDe.join(", ")}`).to.have.lengthOf(
+      0
+    );
+  });
+
+  it("gives every Java-surface key a non-empty German translation distinct from English", () => {
+    const untranslated = JAVA_SURFACE_KEYS.filter(
+      (key) => typeof de[key] !== "string" || de[key].trim().length === 0
+    );
+    expect(
+      untranslated,
+      `de.js has empty Java-surface translations: ${untranslated.join(", ")}`
+    ).to.have.lengthOf(0);
+  });
+});

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/i18n/J2clI18n.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/i18n/J2clI18n.java
@@ -43,7 +43,10 @@ public final class J2clI18n {
     try {
       String result = translate.translate(key, safeFallback);
       return result == null ? safeFallback : result;
-    } catch (RuntimeException e) {
+    } catch (RuntimeException | Error e) {
+      // Mirror the other JS-interop guards in this repo: a JS-thrown value can
+      // translate to a Java Error (not just RuntimeException); either way the
+      // chip/status must fall back to English rather than break rendering.
       return safeFallback;
     }
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/i18n/J2clI18n.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/i18n/J2clI18n.java
@@ -1,0 +1,79 @@
+package org.waveprotocol.box.j2cl.i18n;
+
+import elemental2.dom.DomGlobal;
+import jsinterop.annotations.JsFunction;
+import jsinterop.base.Js;
+
+/**
+ * #1277: one-way bridge from the J2CL Java surfaces to the Lit i18n catalog.
+ *
+ * <p>The Lit shell publishes {@code window.__j2clI18n.t(key, fallback)} (see
+ * {@code j2cl/lit/src/i18n/j2cl-bridge.js}); this facade forwards every dynamic
+ * status/error string through it so translations live only in the JS catalogs
+ * (en.js/de.js), never duplicated into Java.
+ *
+ * <p>Resolution is defensive: if the Lit bundle has not registered the bridge
+ * yet (or at all — e.g. a J2CL unit test with no Lit shell), {@link #t} returns
+ * the supplied English fallback, so a string can never render as {@code null}
+ * and existing English-asserting tests keep passing.
+ */
+public final class J2clI18n {
+
+  private J2clI18n() {}
+
+  @JsFunction
+  private interface TranslateFn {
+    String translate(String key, String fallback);
+  }
+
+  /**
+   * Resolves {@code key} through the Lit catalog, falling back to {@code
+   * fallback} (the mandatory English literal) when the bridge is unavailable or
+   * the key is missing.
+   */
+  public static String t(String key, String fallback) {
+    String safeFallback = fallback == null ? "" : fallback;
+    if (key == null || key.isEmpty()) {
+      return safeFallback;
+    }
+    TranslateFn translate = resolveTranslateFn();
+    if (translate == null) {
+      return safeFallback;
+    }
+    try {
+      String result = translate.translate(key, safeFallback);
+      return result == null ? safeFallback : result;
+    } catch (RuntimeException e) {
+      return safeFallback;
+    }
+  }
+
+  /**
+   * Convenience for messages with a single {@code {param}} placeholder: resolves
+   * {@code key} (whose catalog value should contain {@code placeholder}) and
+   * substitutes {@code value}.
+   */
+  public static String format(String key, String fallback, String placeholder, String value) {
+    String template = t(key, fallback);
+    if (placeholder == null || placeholder.isEmpty()) {
+      return template;
+    }
+    return template.replace(placeholder, value == null ? "" : value);
+  }
+
+  private static TranslateFn resolveTranslateFn() {
+    Object window = DomGlobal.window;
+    if (window == null) {
+      return null;
+    }
+    Object bridge = Js.asPropertyMap(window).get("__j2clI18n");
+    if (bridge == null) {
+      return null;
+    }
+    Object translate = Js.asPropertyMap(bridge).get("t");
+    if (translate == null) {
+      return null;
+    }
+    return Js.uncheckedCast(translate);
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootLiveSurfaceModel.java
@@ -1,9 +1,12 @@
 package org.waveprotocol.box.j2cl.root;
 
+import org.waveprotocol.box.j2cl.i18n.J2clI18n;
 import org.waveprotocol.box.j2cl.search.J2clSidecarRouteState;
 import org.waveprotocol.box.j2cl.search.J2clSidecarRouteCodec;
 
 public final class J2clRootLiveSurfaceModel {
+  // #1277: English fallbacks; the localized text lives in the Lit catalog under
+  // these keys and is resolved through J2clI18n at each transition.
   private static final String ROUTE_READY_STATUS = "Workspace is ready.";
   private static final String SELECTED_WAVE_STATUS = "Selected wave is active.";
   private static final String STARTING_STATUS = "Loading workspace.";
@@ -42,14 +45,14 @@ public final class J2clRootLiveSurfaceModel {
 
   public static J2clRootLiveSurfaceModel starting() {
     return new J2clRootLiveSurfaceModel(
-        "", "", null, STARTING_STATUS, CONNECTION_ONLINE, SAVE_SAVED);
+        "", "", null, startingStatus(), CONNECTION_ONLINE, SAVE_SAVED);
   }
 
   public J2clRootLiveSurfaceModel withRouteUrl(String nextRouteUrl) {
     String normalizedRouteUrl = nullToEmpty(nextRouteUrl);
     if (normalizedRouteUrl.isEmpty()) {
       return new J2clRootLiveSurfaceModel(
-          "", "", null, STARTING_STATUS, connectionState, saveState);
+          "", "", null, startingStatus(), connectionState, saveState);
     }
     J2clSidecarRouteState routeState = parseRouteUrl(normalizedRouteUrl);
     return new J2clRootLiveSurfaceModel(
@@ -170,20 +173,28 @@ public final class J2clRootLiveSurfaceModel {
     return SAVE_SAVED;
   }
 
+  private static String startingStatus() {
+    return J2clI18n.t("rootStatus.loading", STARTING_STATUS);
+  }
+
   private static String routeStatus(String routeUrl, String query) {
     String normalizedQuery = nullToEmpty(query);
     if (!normalizedQuery.isEmpty()) {
-      return "Showing search results for " + normalizedQuery + ".";
+      return J2clI18n.format(
+          "rootStatus.searchResults",
+          "Showing search results for {query}.",
+          "{query}",
+          normalizedQuery);
     }
     String normalizedRouteUrl = nullToEmpty(routeUrl);
     if (normalizedRouteUrl.isEmpty()) {
-      return STARTING_STATUS;
+      return startingStatus();
     }
-    return ROUTE_READY_STATUS;
+    return J2clI18n.t("rootStatus.ready", ROUTE_READY_STATUS);
   }
 
   private static String selectedWaveStatus() {
-    return SELECTED_WAVE_STATUS;
+    return J2clI18n.t("rootStatus.selectedWave", SELECTED_WAVE_STATUS);
   }
 
   private static String statusFor(String routeUrl, String query, String selectedWaveId) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveController.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadata;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadataClient;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
+import org.waveprotocol.box.j2cl.i18n.J2clI18n;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 import org.waveprotocol.box.j2cl.transport.SidecarConversationManifest;
 import org.waveprotocol.box.j2cl.transport.SidecarFragmentsResponse;
@@ -624,7 +625,7 @@ public final class J2clSelectedWaveController
               J2clSelectedWaveModel.error(
                   selectedWaveId,
                   selectedDigestItem,
-                  "Unable to open selected wave.",
+                  J2clI18n.t("selectedWave.errorOpen", "Unable to open selected wave."),
                   error,
                   currentModel);
           view.render(currentModel);
@@ -708,7 +709,7 @@ public final class J2clSelectedWaveController
                   J2clSelectedWaveModel.error(
                       selectedWaveId,
                       selectedDigestItem,
-                      "Selected wave stream failed.",
+                      J2clI18n.t("selectedWave.errorStream", "Selected wave stream failed."),
                       error,
                       currentModel);
               view.render(currentModel);
@@ -1155,10 +1156,12 @@ public final class J2clSelectedWaveController
           J2clSelectedWaveModel.error(
               selectedWaveId,
               selectedDigestItem,
-              "Selected wave disconnected.",
-              "The selected-wave sidecar stopped retrying after "
-                  + MAX_RECONNECT_ATTEMPTS
-                  + " reconnect attempts.",
+              J2clI18n.t("selectedWave.errorDisconnected", "Selected wave disconnected."),
+              J2clI18n.format(
+                  "selectedWave.errorDisconnectedDetail",
+                  "The selected-wave sidecar stopped retrying after {count} reconnect attempts.",
+                  "{count}",
+                  String.valueOf(MAX_RECONNECT_ATTEMPTS)),
               currentModel);
       view.render(currentModel);
       publishWriteSession();

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
@@ -3,6 +3,7 @@ package org.waveprotocol.box.j2cl.search;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.waveprotocol.box.j2cl.i18n.J2clI18n;
 import org.waveprotocol.box.j2cl.overlay.J2clInteractionBlipModel;
 import org.waveprotocol.box.j2cl.read.J2clReadBlip;
 import org.waveprotocol.box.j2cl.transport.SidecarConversationManifest;
@@ -232,11 +233,15 @@ public final class J2clSelectedWaveModel {
         false,
         false,
         selectedWaveId,
-        "Select a wave",
+        J2clI18n.t("selectedWave.selectTitle", "Select a wave"),
         "",
         "",
-        "Choose a digest from the search results to open a read-only selected-wave panel.",
-        "Copied URLs can restore the selected wave when the route includes it.",
+        J2clI18n.t(
+            "selectedWave.chooseDigest",
+            "Choose a digest from the search results to open a read-only selected-wave panel."),
+        J2clI18n.t(
+            "selectedWave.copiedUrls",
+            "Copied URLs can restore the selected wave when the route includes it."),
         0,
         Collections.<String>emptyList(),
         Collections.<String>emptyList(),
@@ -270,10 +275,16 @@ public final class J2clSelectedWaveModel {
         resolveTitle(selectedWaveId, digestItem),
         resolveSnippet(digestItem),
         resolveUnreadText(digestItem, prevUnreadCount, prevRead, prevKnown),
-        reconnectCount > 0 ? "Reconnecting selected wave." : "Opening selected wave.",
         reconnectCount > 0
-            ? "Reusing the current session after a disconnect."
-            : "Waiting for the first live selected-wave update.",
+            ? J2clI18n.t("selectedWave.reconnecting", "Reconnecting selected wave.")
+            : J2clI18n.t("selectedWave.opening", "Opening selected wave."),
+        reconnectCount > 0
+            ? J2clI18n.t(
+                "selectedWave.reusingSession",
+                "Reusing the current session after a disconnect.")
+            : J2clI18n.t(
+                "selectedWave.waitingFirstUpdate",
+                "Waiting for the first live selected-wave update."),
         reconnectCount,
         Collections.<String>emptyList(),
         Collections.<String>emptyList(),
@@ -321,7 +332,9 @@ public final class J2clSelectedWaveModel {
     if (digestItem != null && digestItem.getTitle() != null && !digestItem.getTitle().isEmpty()) {
       return digestItem.getTitle();
     }
-    return selectedWaveId == null ? "Selected wave" : selectedWaveId;
+    return selectedWaveId == null
+        ? J2clI18n.t("selectedWave.defaultTitle", "Selected wave")
+        : selectedWaveId;
   }
 
   private static String resolveSnippet(J2clSearchDigestItem digestItem) {
@@ -338,15 +351,20 @@ public final class J2clSelectedWaveModel {
     }
     int digestUnreadCount = digestItem.getUnreadCount();
     return digestUnreadCount <= 0
-        ? "Selected digest is read."
-        : digestUnreadCount + " unread in the selected digest.";
+        ? J2clI18n.t("selectedWave.digestRead", "Selected digest is read.")
+        : J2clI18n.format(
+            "selectedWave.digestUnread",
+            "{count} unread in the selected digest.",
+            "{count}",
+            String.valueOf(digestUnreadCount));
   }
 
   static String formatUnreadText(int unreadCount, boolean read) {
     if (unreadCount <= 0 || read) {
-      return "Read.";
+      return J2clI18n.t("selectedWave.read", "Read.");
     }
-    return unreadCount + " unread.";
+    return J2clI18n.format(
+        "selectedWave.unread", "{count} unread.", "{count}", String.valueOf(unreadCount));
   }
 
   public boolean hasSelection() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import org.waveprotocol.box.j2cl.common.J2clDebugFlags;
+import org.waveprotocol.box.j2cl.i18n.J2clI18n;
 import org.waveprotocol.box.j2cl.overlay.J2clInteractionBlipModel;
 import org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel;
 import org.waveprotocol.box.j2cl.read.J2clInlineReplyAnchor;
@@ -139,7 +140,9 @@ public final class J2clSelectedWaveProjector {
 
     String detailText = J2clDebugFlags.DEBUG_OVERLAY_ENABLED ? buildDetailText(update) : "";
     String baseStatusText =
-        reconnectCount > 0 ? "Live updates reconnected." : "Live updates connected.";
+        reconnectCount > 0
+            ? J2clI18n.t("selectedWave.liveReconnected", "Live updates reconnected.")
+            : J2clI18n.t("selectedWave.liveConnected", "Live updates connected.");
 
     int unreadCount;
     boolean read;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import jsinterop.annotations.JsFunction;
 import jsinterop.base.Js;
 import jsinterop.base.JsPropertyMap;
+import org.waveprotocol.box.j2cl.i18n.J2clI18n;
 import org.waveprotocol.box.j2cl.overlay.J2clInteractionBlipModel;
 import org.waveprotocol.box.j2cl.overlay.J2clMentionRange;
 import org.waveprotocol.box.j2cl.overlay.J2clReactionSummary;
@@ -1650,7 +1651,12 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     if (text == null || text.isEmpty()) {
       return "";
     }
-    if ("Read.".equals(text) || "Selected digest is read.".equals(text)) {
+    // #1277: the model now localizes these read-state sentinels, so compare
+    // against the localized values (same keys/fallbacks the model uses) rather
+    // than the English literals — otherwise non-English locales would leak the
+    // diagnostic text into the header.
+    if (J2clI18n.t("selectedWave.read", "Read.").equals(text)
+        || J2clI18n.t("selectedWave.digestRead", "Selected digest is read.").equals(text)) {
       return "";
     }
     return text;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
@@ -15,6 +15,11 @@ public final class SidecarSessionBootstrap {
   // when the field is absent or signed-out.
   private final List<String> enabledFeatures;
   private final boolean admin;
+  // #1277: the user's locale (e.g. "en", "de", "zh_TW") from the bootstrap
+  // JSON's session.locale. Already on the wire since J-UI-8 (post-#963) and
+  // consumed by the Lit i18n catalog; this surfaces it to the Java side so the
+  // i18n bridge can resolve dynamic status/error strings. Empty when absent.
+  private final String locale;
 
   public SidecarSessionBootstrap(String address, String websocketAddress) {
     this(address, websocketAddress, Collections.<String>emptyList(), false);
@@ -27,6 +32,15 @@ public final class SidecarSessionBootstrap {
 
   public SidecarSessionBootstrap(
       String address, String websocketAddress, List<String> enabledFeatures, boolean admin) {
+    this(address, websocketAddress, enabledFeatures, admin, "");
+  }
+
+  public SidecarSessionBootstrap(
+      String address,
+      String websocketAddress,
+      List<String> enabledFeatures,
+      boolean admin,
+      String locale) {
     this.address = address;
     this.websocketAddress = websocketAddress;
     this.enabledFeatures =
@@ -34,6 +48,7 @@ public final class SidecarSessionBootstrap {
             ? Collections.<String>emptyList()
             : Collections.unmodifiableList(new ArrayList<String>(enabledFeatures));
     this.admin = admin;
+    this.locale = locale == null ? "" : locale.trim();
   }
 
   public String getAddress() {
@@ -62,6 +77,17 @@ public final class SidecarSessionBootstrap {
   /** Returns true when the signed-in user has server-admin or owner privileges. */
   public boolean isAdmin() {
     return admin;
+  }
+
+  /**
+   * #1277: returns the user's locale from the bootstrap JSON's
+   * {@code session.locale} (e.g. {@code "en"}, {@code "de"}, {@code "zh_TW"}),
+   * or an empty string when the session did not carry one. The i18n bridge uses
+   * this only as an initial hint — the Lit catalog remains the source of truth
+   * and resolves the active locale from {@code window.__bootstrap} itself.
+   */
+  public String getLocale() {
+    return locale;
   }
 
   public static boolean usesCompatibleCookieHost(String pageHostname, String websocketAddress) {
@@ -149,7 +175,23 @@ public final class SidecarSessionBootstrap {
       throw new IllegalArgumentException("Bootstrap JSON did not include a socket address");
     }
     boolean isAdmin = extractIsAdmin(session);
-    return new SidecarSessionBootstrap(address, socketAddress, extractFeatures(session), isAdmin);
+    return new SidecarSessionBootstrap(
+        address, socketAddress, extractFeatures(session), isAdmin, extractLocale(session));
+  }
+
+  /**
+   * #1277: pulls the user's locale out of {@code session.locale}. Tolerant:
+   * missing or non-string values yield an empty locale rather than throwing,
+   * since a missing locale must never block bootstrap (the Lit catalog falls
+   * back to {@code <html lang>} then English).
+   */
+  private static String extractLocale(Map<String, Object> session) {
+    Object localeValue = session.get("locale");
+    if (!(localeValue instanceof String)) {
+      return "";
+    }
+    String locale = ((String) localeValue).trim();
+    return "null".equals(locale) ? "" : locale;
   }
 
   private static boolean extractIsAdmin(Map<String, Object> session) {
@@ -226,7 +268,14 @@ public final class SidecarSessionBootstrap {
       throw new IllegalArgumentException("Session bootstrap did not include an address");
     }
     String websocketAddress = parseWebSocketAddress(html);
-    return new SidecarSessionBootstrap(address, websocketAddress);
+    // Legacy path intentionally keeps admin=false (as before); only locale is
+    // newly surfaced here per #1277.
+    return new SidecarSessionBootstrap(
+        address,
+        websocketAddress,
+        Collections.<String>emptyList(),
+        false,
+        extractLocale(session));
   }
 
   private static String parseWebSocketAddress(String html) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSessionBootstrap.java
@@ -268,14 +268,12 @@ public final class SidecarSessionBootstrap {
       throw new IllegalArgumentException("Session bootstrap did not include an address");
     }
     String websocketAddress = parseWebSocketAddress(html);
-    // Legacy path intentionally keeps admin=false (as before); only locale is
-    // newly surfaced here per #1277.
-    return new SidecarSessionBootstrap(
-        address,
-        websocketAddress,
-        Collections.<String>emptyList(),
-        false,
-        extractLocale(session));
+    // #1277: locale is intentionally NOT scraped from the legacy root HTML.
+    // Per the #963 contract, bootstrap metadata must come from the explicit
+    // server-owned bootstrap JSON, not from parsing arbitrary root HTML — and
+    // this path is deprecated (removal tracked in #978). Locale is surfaced
+    // only through fromBootstrapJson.
+    return new SidecarSessionBootstrap(address, websocketAddress);
   }
 
   private static String parseWebSocketAddress(String html) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/i18n/J2clI18nTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/i18n/J2clI18nTest.java
@@ -1,0 +1,123 @@
+package org.waveprotocol.box.j2cl.i18n;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import elemental2.dom.DomGlobal;
+import jsinterop.annotations.JsFunction;
+import jsinterop.base.Js;
+import jsinterop.base.JsPropertyMap;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+@J2clTestInput(J2clI18nTest.class)
+public class J2clI18nTest {
+
+  @JsFunction
+  private interface StubTranslate {
+    String translate(String key, String fallback);
+  }
+
+  @Before
+  public void clearBridge() {
+    removeBridge();
+  }
+
+  @After
+  public void tearDown() {
+    removeBridge();
+  }
+
+  // ---- Tests that work on both the JVM and the browser (no bridge installed;
+  // a null window resolves to the English fallback). ----
+
+  @Test
+  public void returnsFallbackWhenBridgeAbsent() {
+    Assert.assertEquals("English fallback", J2clI18n.t("some.key", "English fallback"));
+  }
+
+  @Test
+  public void nullOrEmptyKeyReturnsFallback() {
+    Assert.assertEquals("fallback", J2clI18n.t(null, "fallback"));
+    Assert.assertEquals("fallback", J2clI18n.t("", "fallback"));
+  }
+
+  @Test
+  public void nullFallbackNeverReturnsNull() {
+    Assert.assertEquals("", J2clI18n.t("missing.key", null));
+  }
+
+  @Test
+  public void formatSubstitutesSinglePlaceholder() {
+    Assert.assertEquals(
+        "Showing search results for in:inbox.",
+        J2clI18n.format(
+            "rootStatus.searchResults",
+            "Showing search results for {query}.",
+            "{query}",
+            "in:inbox"));
+  }
+
+  @Test
+  public void formatWithNullValueSubstitutesEmpty() {
+    Assert.assertEquals(
+        "5 unread.", J2clI18n.format("selectedWave.unread", "{count} unread.", "{count}", "5"));
+    Assert.assertEquals(
+        " unread.", J2clI18n.format("selectedWave.unread", "{count} unread.", "{count}", null));
+  }
+
+  // ---- Tests that require a live bridge on window (browser only). ----
+
+  @Test
+  public void delegatesToInstalledBridge() {
+    assumeBrowserDom();
+    installBridge((key, fallback) -> "translated:" + key);
+    Assert.assertEquals("translated:some.key", J2clI18n.t("some.key", "English fallback"));
+  }
+
+  @Test
+  public void reactsToBridgeReturningDifferentValues() {
+    assumeBrowserDom();
+    // Simulates a locale switch: the same key resolves to a new string once the
+    // catalog behind the bridge changes.
+    installBridge((key, fallback) -> "de:" + key);
+    Assert.assertEquals("de:rootStatus.ready", J2clI18n.t("rootStatus.ready", "Workspace is ready."));
+    installBridge((key, fallback) -> fallback);
+    Assert.assertEquals("Workspace is ready.", J2clI18n.t("rootStatus.ready", "Workspace is ready."));
+  }
+
+  @Test
+  public void returnsFallbackWhenBridgeReturnsNull() {
+    assumeBrowserDom();
+    installBridge((key, fallback) -> null);
+    Assert.assertEquals("English fallback", J2clI18n.t("some.key", "English fallback"));
+  }
+
+  @Test
+  public void returnsFallbackWhenBridgeThrows() {
+    assumeBrowserDom();
+    installBridge(
+        (key, fallback) -> {
+          throw new RuntimeException("boom");
+        });
+    Assert.assertEquals("English fallback", J2clI18n.t("some.key", "English fallback"));
+  }
+
+  private static void assumeBrowserDom() {
+    Assume.assumeTrue(DomGlobal.window != null);
+  }
+
+  private static void installBridge(StubTranslate translate) {
+    JsPropertyMap<Object> bridge = JsPropertyMap.of();
+    bridge.set("t", translate);
+    Js.asPropertyMap(DomGlobal.window).set("__j2clI18n", bridge);
+  }
+
+  private static void removeBridge() {
+    if (DomGlobal.window == null) {
+      return;
+    }
+    Js.asPropertyMap(DomGlobal.window).set("__j2clI18n", null);
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveViewChromeTest.java
@@ -8,7 +8,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import jsinterop.annotations.JsFunction;
 import jsinterop.base.Js;
+import jsinterop.base.JsPropertyMap;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -159,6 +161,78 @@ public class J2clSelectedWaveViewChromeTest {
     Assert.assertTrue(
         "Top wave chrome must not show text like 'Read.'; per-blip read state is visual.",
         readState.hidden);
+  }
+
+  @Test
+  public void renderSuppressesLocalizedReadSentinelInWaveChrome() {
+    // #1277 regression: once the read-state sentinels are localized, the view's
+    // suppression must compare against the localized value, not the English
+    // literal — otherwise a German "Gelesen." would leak into the header.
+    assumeBrowserDom();
+    installDeReadBridge();
+    try {
+      HTMLElement host = createHost();
+      J2clSelectedWaveView view = new J2clSelectedWaveView(host);
+      view.render(readSentinelModel("example.com/w+de", "Gelesen."));
+
+      HTMLElement readState = (HTMLElement) host.querySelector(".sidecar-selected-unread");
+      Assert.assertNotNull(readState);
+      Assert.assertEquals(
+          "Localized read sentinel must be suppressed, not leaked into the header.",
+          "",
+          readState.textContent);
+    } finally {
+      removeI18nBridge();
+    }
+  }
+
+  @JsFunction
+  private interface DeTranslate {
+    String translate(String key, String fallback);
+  }
+
+  private static void installDeReadBridge() {
+    JsPropertyMap<Object> bridge = JsPropertyMap.of();
+    DeTranslate translate =
+        (key, fallback) -> {
+          if ("selectedWave.read".equals(key)) {
+            return "Gelesen.";
+          }
+          if ("selectedWave.digestRead".equals(key)) {
+            return "Ausgewählter Eintrag ist gelesen.";
+          }
+          return fallback;
+        };
+    bridge.set("t", translate);
+    Js.asPropertyMap(DomGlobal.window).set("__j2clI18n", bridge);
+  }
+
+  private static void removeI18nBridge() {
+    if (DomGlobal.window != null) {
+      Js.asPropertyMap(DomGlobal.window).set("__j2clI18n", null);
+    }
+  }
+
+  private static J2clSelectedWaveModel readSentinelModel(String waveId, String localizedReadText) {
+    return new J2clSelectedWaveModel(
+        true,
+        false,
+        false,
+        waveId,
+        "Selected wave",
+        "",
+        localizedReadText,
+        "",
+        "",
+        0,
+        Collections.<String>emptyList(),
+        Arrays.<String>asList(),
+        Arrays.<J2clReadBlip>asList(),
+        null,
+        0,
+        true,
+        true,
+        false);
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -682,6 +682,44 @@ public class SidecarTransportCodecTest {
 
     Assert.assertEquals("user@example.com", bootstrap.getAddress());
     Assert.assertEquals("socket.example.test:7443", bootstrap.getWebSocketAddress());
+    // #1277: session.locale absent here → empty locale, never null.
+    Assert.assertEquals("", bootstrap.getLocale());
+  }
+
+  @Test
+  public void bootstrapJsonSurfacesSessionLocale() {
+    String json =
+        "{\"session\":{\"address\":\"user@example.com\",\"locale\":\"de\"},"
+            + "\"socket\":{\"address\":\"socket.example.test:7443\"}}";
+
+    SidecarSessionBootstrap bootstrap = SidecarSessionBootstrap.fromBootstrapJson(json);
+
+    Assert.assertEquals("de", bootstrap.getLocale());
+  }
+
+  @Test
+  public void bootstrapJsonLocaleIgnoresNonStringAndNullLiteral() {
+    String jsonNull =
+        "{\"session\":{\"address\":\"user@example.com\",\"locale\":\"null\"},"
+            + "\"socket\":{\"address\":\"socket.example.test:7443\"}}";
+    Assert.assertEquals("", SidecarSessionBootstrap.fromBootstrapJson(jsonNull).getLocale());
+
+    String jsonNumber =
+        "{\"session\":{\"address\":\"user@example.com\",\"locale\":42},"
+            + "\"socket\":{\"address\":\"socket.example.test:7443\"}}";
+    Assert.assertEquals("", SidecarSessionBootstrap.fromBootstrapJson(jsonNumber).getLocale());
+  }
+
+  @Test
+  public void rootHtmlSurfacesSessionLocale() {
+    String html =
+        "<html><script>window.__session={\"address\":\"user@example.com\",\"locale\":\"zh_TW\"};"
+            + "window.__websocket_address=\"socket.example.test:7443\";"
+            + "</script></html>";
+
+    SidecarSessionBootstrap bootstrap = SidecarSessionBootstrap.fromRootHtml(html);
+
+    Assert.assertEquals("zh_TW", bootstrap.getLocale());
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -711,7 +711,9 @@ public class SidecarTransportCodecTest {
   }
 
   @Test
-  public void rootHtmlSurfacesSessionLocale() {
+  public void rootHtmlDoesNotScrapeSessionLocale() {
+    // #1277: the deprecated root-HTML path must NOT scrape locale — bootstrap
+    // metadata comes from the explicit server-owned bootstrap JSON (#963).
     String html =
         "<html><script>window.__session={\"address\":\"user@example.com\",\"locale\":\"zh_TW\"};"
             + "window.__websocket_address=\"socket.example.test:7443\";"
@@ -719,7 +721,7 @@ public class SidecarTransportCodecTest {
 
     SidecarSessionBootstrap bootstrap = SidecarSessionBootstrap.fromRootHtml(html);
 
-    Assert.assertEquals("zh_TW", bootstrap.getLocale());
+    Assert.assertEquals("", bootstrap.getLocale());
   }
 
   @Test

--- a/wave/config/changelog.d/2026-07-05-j2cl-java-surface-i18n.json
+++ b/wave/config/changelog.d/2026-07-05-j2cl-java-surface-i18n.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-07-05-j2cl-java-surface-i18n",
+  "version": "unreleased",
+  "date": "2026-07-05",
+  "title": "New UI: workspace and wave status/error messages are now localizable",
+  "summary": "Previously, a German user under the new UI still saw English text for the dynamic status and error messages that the J2CL/Java layer produces (workspace loading state, selected-wave status, reconnect/disconnect and open-failure errors). These now flow through the same Lit i18n catalog as the rest of the UI, so they render in the user's locale (German shipped alongside English) with English as a safe fallback.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "New UI: dynamic status and error strings emitted by the J2CL layer — 'Loading workspace.', 'Showing search results for …', selected-wave open/reconnect status, and errors like 'Selected wave disconnected.' / 'Unable to open selected wave.' — are now resolved through the Lit i18n catalog and localized (German included), instead of always rendering in English.",
+        "New UI: the user's locale from the session bootstrap is now available to the J2CL layer, and a single i18n bridge lets the Java surfaces reuse the existing translation catalog without duplicating any strings."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes #1277. Dynamic status/error strings emitted by the J2CL **Java** layer bypassed the Lit i18n system, so a German user under `?view=j2cl-root` still saw English text for workspace/wave status and errors (the motivating example: "German users seeing English errors").

### Design — one-way bridge, catalogs stay the single source of truth
- **Locale on the model**: `SidecarSessionBootstrap` now parses `session.locale` (in `fromBootstrapJson` **and** the legacy `fromRootHtml` path) and exposes `getLocale()`. The field was already on the wire since J-UI-8 (post-#963) — **no server contract change**.
- **JS bridge**: `j2cl/lit/src/i18n/j2cl-bridge.js` publishes `window.__j2clI18n = { t, getLocale, setLocale, subscribe }` (installed from `src/index.js`). The JS catalogs (`en.js`/`de.js` + `t()`) remain the only string table.
- **Java facade**: `J2clI18n.t(key, fallback)` / `.format(...)` forward through the bridge via `@JsFunction` interop, returning the mandatory English fallback when the bridge is absent (unit test, or before the Lit bundle loads). This means **no string table is duplicated into Java** and existing English-asserting tests keep passing unchanged.
- **Routed strings** (with en + de catalog keys under `rootStatus.*` / `selectedWave.*`):
  - `J2clRootLiveSurfaceModel` — loading / ready / selected-wave / search-results
  - `J2clSelectedWaveModel` — select / choose-digest / copied-urls / opening / reconnecting / reusing-session / waiting-first-update / default-title / digest-read / digest-unread / read / unread
  - `J2clSelectedWaveController` — errorOpen / errorStream / errorDisconnected (+ detail)
  - `J2clSelectedWaveProjector` — live connected / reconnected

### Deliberately out of scope (documented)
- `FRAGMENT_GROWTH_*` and `DEFAULT_METADATA_FAILURE_MESSAGE` in `J2clSelectedWaveController` are used as **state sentinels** (`.equals(getStatusText())`); localizing them would break state detection, so they stay English (a proper fix is a state enum — separate concern).
- Static Lit-element strings (already `t()`-backed) and GWT-side strings — out of scope per the issue.

## Tests
- `J2clI18nTest` (new) — bridge delegation, locale-switch reactivity, null/throw/absent fallback, `format()` interpolation.
- `SidecarTransportCodecTest` (+4) — bootstrap-json locale, null/non-string ignore, root-html locale, absent→empty.
- `j2cl-bridge.test.js` (new, Lit) — bridge install, German resolution, Java-surface key coverage (every `rootStatus.*`/`selectedWave.*` key present + non-empty in de).
- Full `./mvnw test` → **1144 run, 0 failures, 0 errors**. `j2cl/lit` `npm test` → all pass (incl. existing `i18n.test.js`).

## Local browser verification (Playwright, `?view=j2cl-root`, 1440×900)
Fresh registered user:
- `window.__j2clI18n` bridge present (`t` + `setLocale`).
- Live status strip `data-live-status-text`: `"Selected wave is active."` (en) → after `setLocale("de")` + reselect → **`"Ausgewählte Wave ist aktiv."`** — a real Java-emitted string localized end-to-end.
- 0 console errors, 0 4xx/5xx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized workspace and selected-wave status/error messages, including loading, reconnect, digest/read/unread, and search result text.
  * Exposed the user locale from session data to drive runtime translations across the interface.

* **Bug Fixes**
  * Improved fallback handling for missing/unknown keys and bridge failures.
  * Prevented localized “read” sentinel text from leaking into the wave header.

* **Tests**
  * Added coverage for the i18n bridge installation, locale switching, fallback behavior, and the sentinel regression.

* **Documentation**
  * Added a changelog entry for the new J2CL/Java surface i18n behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->