### PR TITLE
feat(j2cl): add shared J2clNotificationService and route compose failures through it (#1271)

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentComposerController;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentIdGenerator;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentUploadClient;
+import org.waveprotocol.box.j2cl.notify.J2clNotificationService;
 import org.waveprotocol.box.j2cl.search.J2clPlainTextDeltaFactory;
 import org.waveprotocol.box.j2cl.search.J2clSearchPanelController;
 import org.waveprotocol.box.j2cl.search.J2clSidecarWriteSession;
@@ -688,6 +689,10 @@ public final class J2clComposeSurfaceController {
   private final CreateSuccessHandler createSuccessHandler;
   private final ReplySuccessHandler replySuccessHandler;
   private final J2clClientTelemetry.Sink telemetrySink;
+  // #1271: optional shared notification service. When injected, create/reply
+  // failures are also surfaced through the consolidated toast + ARIA live
+  // region (in addition to the existing inline error text, for compat).
+  private J2clNotificationService notificationService;
   // F-3.S3 (#1038, R-5.5): listener invoked after each successful
   // bootstrap with the resolved signed-in address. The root shell uses
   // this to set the selected-wave view's current-user address so the
@@ -2066,6 +2071,22 @@ public final class J2clComposeSurfaceController {
     this.preCreateSubmitHook = hook;
   }
 
+  /** #1271: inject the shared notification service used to surface failures. */
+  public void setNotificationService(J2clNotificationService service) {
+    this.notificationService = service;
+  }
+
+  /**
+   * #1271: route a failure message to the shared notification service (toast +
+   * ARIA live region). No-op when no service is injected; the inline error text
+   * continues to render for compat during the migration.
+   */
+  private void notifyError(String message) {
+    if (notificationService != null && message != null && !message.isEmpty()) {
+      notificationService.showError(message);
+    }
+  }
+
   /**
    * J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-DA7T: install a
    * hook fired on every create-failure path so the search panel can drop
@@ -2254,6 +2275,7 @@ public final class J2clComposeSurfaceController {
       replyGeneration++;
       if (wasReplySubmitting) {
         replyErrorText = STALE_REPLY_MESSAGE;
+        notifyError(replyErrorText);
         replyStaleBasis = true;
         // submitReply() guarantees a non-empty selected wave id here, but stay defensive.
         replyStaleWaveId = writeSession == null ? null : writeSession.getSelectedWaveId();
@@ -2485,6 +2507,7 @@ public final class J2clComposeSurfaceController {
     createSubmitting = false;
     createStatusText = "";
     createErrorText = error == null || error.isEmpty() ? "Create wave failed." : error;
+    notifyError(createErrorText);
     render();
     // J-UI-3 (#1081, R-5.1) — codex P2 PRRT_kwDOBwxLXs5-DA7T + PRRT_kwDOBwxLXs5-DZqM:
     // pair the pre-submit stamp with a failure-time drop, gated by
@@ -2758,6 +2781,7 @@ public final class J2clComposeSurfaceController {
     replySubmitting = false;
     replyStatusText = "";
     replyErrorText = error == null || error.isEmpty() ? "Reply failed." : error;
+    notifyError(replyErrorText);
     activeCommandId = "";
     // Preserve annotationCommandId so the user can retry with the same formatting intent.
     commandStatusText = "";

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceController.java
@@ -2082,8 +2082,15 @@ public final class J2clComposeSurfaceController {
    * continues to render for compat during the migration.
    */
   private void notifyError(String message) {
-    if (notificationService != null && message != null && !message.isEmpty()) {
+    if (notificationService == null || message == null || message.isEmpty()) {
+      return;
+    }
+    // Best-effort: a notification failure must never block the inline error
+    // render that follows this call.
+    try {
       notificationService.showError(message);
+    } catch (RuntimeException | Error e) {
+      // Swallow — the inline error text still renders.
     }
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/notify/J2clDomNotificationService.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/notify/J2clDomNotificationService.java
@@ -1,0 +1,127 @@
+package org.waveprotocol.box.j2cl.notify;
+
+import elemental2.dom.DomGlobal;
+import elemental2.dom.HTMLElement;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * #1271: default DOM-backed {@link J2clNotificationService} for the
+ * {@code ?view=j2cl-root} shell.
+ *
+ * <p>Mounts a notification region under a host element containing (a) two
+ * visually-hidden ARIA live regions — assertive for errors, polite for
+ * status/success — so screen readers announce every failure path, and (b) a
+ * visible toast stack. Error toasts auto-dismiss after a longer window (or stay
+ * until cleared when {@code timeoutMs <= 0}); success/transient toasts are
+ * calmer and shorter. This is deliberately Java+DOM only; a Lit
+ * {@code wave-notification} bridge is a follow-up under #964.
+ */
+public final class J2clDomNotificationService implements J2clNotificationService {
+
+  static final String REGION_CLASS = "j2cl-notify-region";
+  static final String TOAST_STACK_CLASS = "j2cl-notify-toasts";
+  static final String TOAST_CLASS = "j2cl-notify-toast";
+
+  private final HTMLElement region;
+  private final HTMLElement liveAssertive;
+  private final HTMLElement livePolite;
+  private final HTMLElement toastStack;
+  private final List<Double> pendingTimers = new ArrayList<Double>();
+
+  public J2clDomNotificationService(HTMLElement host) {
+    region = (HTMLElement) DomGlobal.document.createElement("div");
+    region.className = REGION_CLASS;
+    region.setAttribute("data-j2cl-notify-region", "true");
+
+    liveAssertive = createLiveRegion("assertive");
+    livePolite = createLiveRegion("polite");
+    toastStack = (HTMLElement) DomGlobal.document.createElement("div");
+    toastStack.className = TOAST_STACK_CLASS;
+
+    region.appendChild(liveAssertive);
+    region.appendChild(livePolite);
+    region.appendChild(toastStack);
+    if (host != null) {
+      host.appendChild(region);
+    }
+  }
+
+  private static HTMLElement createLiveRegion(String politeness) {
+    HTMLElement live = (HTMLElement) DomGlobal.document.createElement("div");
+    live.setAttribute("aria-live", politeness);
+    live.setAttribute("aria-atomic", "true");
+    live.setAttribute("role", "assertive".equals(politeness) ? "alert" : "status");
+    live.className = "j2cl-notify-live";
+    // Visually hidden but available to assistive technology.
+    live.setAttribute(
+        "style",
+        "position:absolute;width:1px;height:1px;overflow:hidden;"
+            + "clip:rect(0 0 0 0);white-space:nowrap;");
+    return live;
+  }
+
+  /** Test/host seam: the mounted region element. */
+  public HTMLElement getRegionElement() {
+    return region;
+  }
+
+  @Override
+  public void showError(String message, int timeoutMs) {
+    announce(liveAssertive, message);
+    addToast(message, Level.ERROR, timeoutMs);
+  }
+
+  @Override
+  public void showSuccess(String message) {
+    announce(livePolite, message);
+    addToast(message, Level.SUCCESS, DEFAULT_TRANSIENT_TIMEOUT_MS);
+  }
+
+  @Override
+  public void showTransient(String message, Level level) {
+    announce(level == Level.ERROR ? liveAssertive : livePolite, message);
+    addToast(message, level == null ? Level.INFO : level, DEFAULT_TRANSIENT_TIMEOUT_MS);
+  }
+
+  @Override
+  public void clear() {
+    for (Double handle : pendingTimers) {
+      DomGlobal.clearTimeout(handle);
+    }
+    pendingTimers.clear();
+    toastStack.innerHTML = "";
+    liveAssertive.textContent = "";
+    livePolite.textContent = "";
+  }
+
+  private static void announce(HTMLElement liveRegion, String message) {
+    // Re-assert the text so identical consecutive messages are still announced.
+    liveRegion.textContent = "";
+    liveRegion.textContent = message == null ? "" : message;
+  }
+
+  private void addToast(String message, Level level, int timeoutMs) {
+    if (message == null || message.isEmpty()) {
+      return;
+    }
+    HTMLElement toast = (HTMLElement) DomGlobal.document.createElement("div");
+    toast.className = TOAST_CLASS + " " + TOAST_CLASS + "-" + level.name().toLowerCase();
+    toast.setAttribute("data-j2cl-notify-level", level.name().toLowerCase());
+    // The live regions own AT announcement; the toast is a visual affordance.
+    toast.setAttribute("role", "presentation");
+    toast.textContent = message;
+    toastStack.appendChild(toast);
+    if (timeoutMs > 0) {
+      double handle =
+          DomGlobal.setTimeout(
+              ignored -> {
+                if (toast.parentNode != null) {
+                  toast.parentNode.removeChild(toast);
+                }
+              },
+              timeoutMs);
+      pendingTimers.add(handle);
+    }
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/notify/J2clDomNotificationService.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/notify/J2clDomNotificationService.java
@@ -113,15 +113,19 @@ public final class J2clDomNotificationService implements J2clNotificationService
     toast.textContent = message;
     toastStack.appendChild(toast);
     if (timeoutMs > 0) {
-      double handle =
+      final double[] handleHolder = new double[1];
+      handleHolder[0] =
           DomGlobal.setTimeout(
               ignored -> {
                 if (toast.parentNode != null) {
                   toast.parentNode.removeChild(toast);
                 }
+                // Drop the fired handle so the pending list does not grow
+                // unbounded over a long session.
+                pendingTimers.remove(Double.valueOf(handleHolder[0]));
               },
               timeoutMs);
-      pendingTimers.add(handle);
+      pendingTimers.add(handleHolder[0]);
     }
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/notify/J2clNotificationService.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/notify/J2clNotificationService.java
@@ -1,0 +1,47 @@
+package org.waveprotocol.box.j2cl.notify;
+
+/**
+ * #1271: single sink for the transient error / status / success messages that
+ * were previously scattered across per-surface model fields (create/reply/
+ * command error text, fetch failures, etc.).
+ *
+ * <p>Implementations own the presentation (toast stacking + auto-dismiss) and
+ * the ARIA live-region announcement so every failure path gets consistent
+ * timing, level semantics, and screen-reader treatment instead of overwriting a
+ * per-surface string.
+ */
+public interface J2clNotificationService {
+
+  /** Default auto-dismiss window for error toasts. */
+  int DEFAULT_ERROR_TIMEOUT_MS = 8000;
+
+  /** Default auto-dismiss window for calmer success/status toasts. */
+  int DEFAULT_TRANSIENT_TIMEOUT_MS = 4000;
+
+  /** Severity of a notification; drives styling and assertive-vs-polite a11y. */
+  enum Level {
+    INFO,
+    SUCCESS,
+    ERROR
+  }
+
+  /**
+   * Surface an error. Announced assertively for AT. {@code timeoutMs <= 0}
+   * keeps it until explicitly cleared; otherwise it auto-dismisses.
+   */
+  void showError(String message, int timeoutMs);
+
+  /** Surface a calmer success message (polite AT, auto-dismiss). */
+  void showSuccess(String message);
+
+  /** Surface a transient message at the given level (polite AT, auto-dismiss). */
+  void showTransient(String message, Level level);
+
+  /** Remove any visible notifications and clear the live regions. */
+  void clear();
+
+  /** Convenience: error with the default auto-dismiss window. */
+  default void showError(String message) {
+    showError(message, DEFAULT_ERROR_TIMEOUT_MS);
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -267,6 +267,8 @@ public final class J2clRootShellController {
         "wavy-back-to-inbox-clicked",
         event -> {
           event.preventDefault();
+          // #1271: a wave switch should not carry stale error toasts across.
+          notificationService.clear();
           routeControllerRef[0].selectWave(null);
         });
     liveSurfaceController.start();

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -13,6 +13,8 @@ import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceController;
 import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceController.CreateSuccessHandler;
 import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceController.ReplySuccessHandler;
 import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceView;
+import org.waveprotocol.box.j2cl.notify.J2clDomNotificationService;
+import org.waveprotocol.box.j2cl.notify.J2clNotificationService;
 import org.waveprotocol.box.j2cl.search.J2clSearchGateway;
 import org.waveprotocol.box.j2cl.search.J2clSearchPanelController;
 import org.waveprotocol.box.j2cl.search.J2clSearchPanelView;
@@ -183,6 +185,10 @@ public final class J2clRootShellController {
     // not leave a stale submit-query stamp that scopes the next
     // successful create's stub to the wrong rail.
     composeController.setCreateFailureHook(controller::discardOldestSubmitStamp);
+    // #1271: mount the shared notification service (toast + ARIA live region)
+    // under the shell host and route compose failures through it.
+    J2clNotificationService notificationService = new J2clDomNotificationService(host);
+    composeController.setNotificationService(notificationService);
     // J-UI-3 (#1081, R-5.1): the rail's New Wave button focuses the create
     // form's title input. Listening on document.body so the event bubbles
     // up regardless of where the rail is currently mounted.

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/compose/J2clComposeSurfaceControllerTest.java
@@ -11,6 +11,8 @@ import org.junit.Test;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentComposerController;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentIdGenerator;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentUploadClient;
+import org.waveprotocol.box.j2cl.notify.J2clNotificationService;
+import org.waveprotocol.box.j2cl.notify.RecordingNotificationSink;
 import org.waveprotocol.box.j2cl.search.J2clPlainTextDeltaFactory;
 import org.waveprotocol.box.j2cl.search.J2clSearchPanelController;
 import org.waveprotocol.box.j2cl.search.J2clSidecarWriteSession;
@@ -1011,6 +1013,44 @@ public class J2clComposeSurfaceControllerTest {
     Assert.assertEquals("", view.model.getReplyDraft());
     Assert.assertEquals(Arrays.asList("example.com/w+1"), refreshed);
     Assert.assertEquals("Reply", factory.lastReplyText);
+  }
+
+  @Test
+  public void replyFailureIsRoutedToNotificationServiceWithExactText() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.submitError = "Reply rejected by server.";
+    FakeView view = new FakeView();
+    RecordingNotificationSink sink = new RecordingNotificationSink();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+    controller.setNotificationService(sink);
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Reply");
+
+    // Inline error text is preserved (compat) AND surfaced via the shared service.
+    Assert.assertEquals("Reply rejected by server.", view.model.getReplyErrorText());
+    Assert.assertEquals("Reply rejected by server.", sink.last().message);
+    Assert.assertEquals(J2clNotificationService.Level.ERROR, sink.last().level);
+  }
+
+  @Test
+  public void noNotificationServiceInjectedDoesNotThrowOnFailure() {
+    FakeGateway gateway = new FakeGateway();
+    gateway.submitError = "boom";
+    FakeView view = new FakeView();
+    J2clComposeSurfaceController controller =
+        newController(gateway, view, new FakeFactory(), new ArrayList<String>(), new ArrayList<String>());
+
+    controller.start();
+    controller.onWriteSessionChanged(
+        new J2clSidecarWriteSession("example.com/w+1", "chan-1", 44L, "ABCD", "b+root"));
+    controller.onReplySubmitted("Reply");
+
+    // Without a service injected the inline text still works and nothing throws.
+    Assert.assertEquals("boom", view.model.getReplyErrorText());
   }
 
   @Test
@@ -4993,6 +5033,7 @@ public class J2clComposeSurfaceControllerTest {
     private int submitCalls;
     private boolean autoResolveBootstrap = true;
     private String bootstrapError;
+    private String submitError;
     private SidecarSubmitResponse submitResponse = new SidecarSubmitResponse(1, "", 45L);
     private SidecarSubmitRequest lastSubmitRequest;
     private J2clSearchPanelController.SuccessCallback<SidecarSessionBootstrap> pendingBootstrapSuccess;
@@ -5023,6 +5064,10 @@ public class J2clComposeSurfaceControllerTest {
         J2clSearchPanelController.ErrorCallback onError) {
       submitCalls++;
       lastSubmitRequest = request;
+      if (submitError != null) {
+        onError.accept(submitError);
+        return;
+      }
       onSuccess.accept(submitResponse);
     }
 

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/notify/J2clDomNotificationServiceTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/notify/J2clDomNotificationServiceTest.java
@@ -1,0 +1,118 @@
+package org.waveprotocol.box.j2cl.notify;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import elemental2.dom.DomGlobal;
+import elemental2.dom.HTMLElement;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+@J2clTestInput(J2clDomNotificationServiceTest.class)
+public class J2clDomNotificationServiceTest {
+
+  private HTMLElement host;
+
+  @After
+  public void tearDown() {
+    if (host != null && host.parentElement != null) {
+      host.parentElement.removeChild(host);
+    }
+    host = null;
+  }
+
+  @Test
+  public void mountsRegionWithBothLiveRegions() {
+    assumeBrowserDom();
+    J2clDomNotificationService service = mountService();
+
+    HTMLElement region = service.getRegionElement();
+    Assert.assertEquals("true", region.getAttribute("data-j2cl-notify-region"));
+    Assert.assertEquals(2, region.querySelectorAll("[aria-live]").length);
+    Assert.assertNotNull(region.querySelector("[aria-live='assertive']"));
+    Assert.assertNotNull(region.querySelector("[aria-live='polite']"));
+  }
+
+  @Test
+  public void showErrorAddsToastAndAnnouncesAssertively() {
+    assumeBrowserDom();
+    J2clDomNotificationService service = mountService();
+
+    service.showError("Create wave failed.", 0);
+
+    HTMLElement toast =
+        (HTMLElement) service.getRegionElement().querySelector(".j2cl-notify-toast");
+    Assert.assertNotNull(toast);
+    Assert.assertEquals("Create wave failed.", toast.textContent);
+    Assert.assertEquals("error", toast.getAttribute("data-j2cl-notify-level"));
+    HTMLElement live =
+        (HTMLElement) service.getRegionElement().querySelector("[aria-live='assertive']");
+    Assert.assertEquals("Create wave failed.", live.textContent);
+  }
+
+  @Test
+  public void showSuccessUsesPoliteLiveRegionAndSuccessLevel() {
+    assumeBrowserDom();
+    J2clDomNotificationService service = mountService();
+
+    service.showSuccess("Saved.");
+
+    HTMLElement toast =
+        (HTMLElement) service.getRegionElement().querySelector(".j2cl-notify-toast");
+    Assert.assertNotNull(toast);
+    Assert.assertEquals("success", toast.getAttribute("data-j2cl-notify-level"));
+    HTMLElement polite =
+        (HTMLElement) service.getRegionElement().querySelector("[aria-live='polite']");
+    Assert.assertEquals("Saved.", polite.textContent);
+  }
+
+  @Test
+  public void emptyMessageAddsNoToast() {
+    assumeBrowserDom();
+    J2clDomNotificationService service = mountService();
+
+    service.showError("", 0);
+
+    Assert.assertEquals(
+        0, service.getRegionElement().querySelectorAll(".j2cl-notify-toast").length);
+  }
+
+  @Test
+  public void clearRemovesToastsAndLiveText() {
+    assumeBrowserDom();
+    J2clDomNotificationService service = mountService();
+    service.showError("Boom", 0);
+    service.showSuccess("Yay");
+    Assert.assertTrue(service.getRegionElement().querySelectorAll(".j2cl-notify-toast").length >= 1);
+
+    service.clear();
+
+    Assert.assertEquals(
+        0, service.getRegionElement().querySelectorAll(".j2cl-notify-toast").length);
+    HTMLElement live =
+        (HTMLElement) service.getRegionElement().querySelector("[aria-live='assertive']");
+    Assert.assertEquals("", live.textContent);
+  }
+
+  @Test
+  public void multipleErrorsStack() {
+    assumeBrowserDom();
+    J2clDomNotificationService service = mountService();
+
+    service.showError("First", 0);
+    service.showError("Second", 0);
+
+    Assert.assertEquals(
+        2, service.getRegionElement().querySelectorAll(".j2cl-notify-toast").length);
+  }
+
+  private static void assumeBrowserDom() {
+    Assume.assumeTrue(DomGlobal.document != null && DomGlobal.document.body != null);
+  }
+
+  private J2clDomNotificationService mountService() {
+    host = (HTMLElement) DomGlobal.document.createElement("div");
+    DomGlobal.document.body.appendChild(host);
+    return new J2clDomNotificationService(host);
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/notify/RecordingNotificationSink.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/notify/RecordingNotificationSink.java
@@ -1,0 +1,73 @@
+package org.waveprotocol.box.j2cl.notify;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * #1271: test double for {@link J2clNotificationService} that records every
+ * notification so call-site migrations can assert the exact user-visible text
+ * without a DOM. Mirrors {@code RecordingTelemetrySink}.
+ */
+public final class RecordingNotificationSink implements J2clNotificationService {
+
+  /** A single recorded notification. */
+  public static final class Notification {
+    public final J2clNotificationService.Level level;
+    public final String message;
+    public final int timeoutMs;
+
+    Notification(J2clNotificationService.Level level, String message, int timeoutMs) {
+      this.level = level;
+      this.message = message;
+      this.timeoutMs = timeoutMs;
+    }
+  }
+
+  private final List<Notification> notifications = new ArrayList<Notification>();
+  private int clearCount;
+
+  @Override
+  public void showError(String message, int timeoutMs) {
+    notifications.add(new Notification(Level.ERROR, message, timeoutMs));
+  }
+
+  @Override
+  public void showSuccess(String message) {
+    notifications.add(new Notification(Level.SUCCESS, message, DEFAULT_TRANSIENT_TIMEOUT_MS));
+  }
+
+  @Override
+  public void showTransient(String message, Level level) {
+    notifications.add(
+        new Notification(level == null ? Level.INFO : level, message, DEFAULT_TRANSIENT_TIMEOUT_MS));
+  }
+
+  @Override
+  public void clear() {
+    clearCount++;
+  }
+
+  public List<Notification> notifications() {
+    return Collections.unmodifiableList(notifications);
+  }
+
+  public Notification last() {
+    if (notifications.isEmpty()) {
+      throw new IllegalStateException("No notifications recorded");
+    }
+    return notifications.get(notifications.size() - 1);
+  }
+
+  public List<String> messages() {
+    List<String> out = new ArrayList<String>();
+    for (Notification n : notifications) {
+      out.add(n.message);
+    }
+    return out;
+  }
+
+  public int clearCount() {
+    return clearCount;
+  }
+}

--- a/wave/config/changelog.d/2026-07-05-j2cl-notification-service.json
+++ b/wave/config/changelog.d/2026-07-05-j2cl-notification-service.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-07-05-j2cl-notification-service",
+  "version": "unreleased",
+  "date": "2026-07-05",
+  "title": "New UI: create/reply failures now announced consistently to screen readers",
+  "summary": "The new UI gains a shared notification service with a toast surface and ARIA live regions. Create and reply failures are now surfaced through it — announced to assistive technology and auto-dismissed on a consistent timer — instead of only overwriting a per-surface error string. The existing inline error text is unchanged, so nothing is lost visually.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "New UI: wave create and reply failures are now routed through a shared notification service that announces them via an ARIA live region and shows an auto-dismissing toast, in addition to the existing inline error text — giving screen-reader users a consistent, non-overwriting notification of failures."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes #1271. Transient error/status text was scattered across per-surface model fields (create/reply/command error text, etc.) with no consistent timeout, ARIA live-region treatment, or stacking — messages could overwrite or lose one another, and there was no screen-reader announcement.

### What changed
- **`J2clNotificationService`** (new interface): `showError(msg, timeoutMs)` / `showSuccess(msg)` / `showTransient(msg, Level)` / `clear()` (+ a default `showError(msg)`). `Level` = INFO | SUCCESS | ERROR.
- **`J2clDomNotificationService`** (new, default DOM impl): mounts a `[data-j2cl-notify-region]` under the shell host with two visually-hidden ARIA live regions — **assertive** for errors, **polite** for status/success — plus a visible toast stack. Error toasts auto-dismiss after a longer window (or persist when `timeoutMs <= 0`); success/transient are calmer/shorter. `clear()` cancels timers and empties the regions.
- **`RecordingNotificationSink`** (test helper, mirrors `RecordingTelemetrySink`).
- Mounted in `J2clRootShellController` and injected into the compose controller. The primary **create/reply server-failure paths** (create failure, reply failure, stale-reply) now route through the service **additively**: the existing inline error text is preserved (no visual/behavioral regression) and the service adds the toast + a11y announcement. There is no `Window.alert` in the J2CL Java.

### Explicitly deferred (per the issue's "scoped for this lane" plan)
- Migrating the remaining failure surfaces (search panel, selected-wave header, toolbar precondition validations, fetch/mark-read/reaction/task) — incremental, same injection pattern.
- The Lit `wave-notification` receiver + bridge contract — deferred to a follow-up under #964 (no `wavy-status-strip` transient receiver exists yet). The Java service is designed so it can later become a thin CustomEvent bridge.

## Tests
- `J2clDomNotificationServiceTest` (new): region + both live regions mount; showError adds an `error` toast + assertive announcement; showSuccess uses the polite region + `success` level; empty message adds no toast; errors stack; `clear()` empties toasts + live text.
- `J2clComposeSurfaceControllerTest` (+2): a reply failure routes the **exact** text to the injected `RecordingNotificationSink` at ERROR level **and** keeps `getReplyErrorText()` (compat); no service injected → no throw.
- Full `./mvnw test` → BUILD SUCCESS.

## Local browser verification (Playwright, `?view=j2cl-root`)
Fresh user: the notification region is mounted in the shell with `aria-live="assertive"` + `aria-live="polite"` regions and zero toasts on a clean load; **0 console errors, 0 4xx/5xx**. (The failure→toast routing is covered by JVM unit tests since forcing a server-side failure in a local smoke run is impractical.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared notification service for the J2CL UI, showing error/success/toast messages via ARIA live regions plus toast notifications.
  * Compose create/reply failures are now surfaced through the notification area as well as inline text.
* **Bug Fixes**
  * Prevents stale notifications when switching back to the inbox.
  * Safely ignores empty notification messages and avoids interruptions if notification delivery fails.
* **Tests**
  * Added DOM notification service tests (mounting, live-region updates, toast stacking/clearing) and compose failure routing tests (with and without an injected notification service).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->