### PR TITLE
feat(j2cl): add J2clJsInteropUtils defensive seam for JS<->Java boundaries (#1272)

### DIFF
--- a/docs/j2cl-parity-architecture.md
+++ b/docs/j2cl-parity-architecture.md
@@ -425,6 +425,38 @@ This keeps the current rollback contract intact while moving the architecture to
 - React `hydrateRoot`: https://react.dev/reference/react-dom/client/hydrateRoot
 - React `renderToPipeableStream`: https://react.dev/reference/react-dom/server/renderToPipeableStream
 
+## 13a. J2CL ↔ JS Defensive Interop (#1272)
+
+`org.waveprotocol.box.j2cl.common.J2clJsInteropUtils` is the **blessed seam for
+every JS ↔ Java boundary** — property-map reads, DOM lookups, and JSON parsing.
+Direct interop (`Js.asPropertyMap(payload).get(...)`, `host.querySelector(...)`,
+`parseJsonObject(...)`) turns a single bad server response or missing DOM node
+into a Java NPE that only surfaces as a cryptic minified JS console error after
+the J2CL optimiser runs. All **new** interop sites (including Lit ↔ Java bridges)
+MUST go through these helpers; existing sites migrate incrementally.
+
+| Method | Behavior on bad input |
+| --- | --- |
+| `safeGetString/Boolean/Int/Long(source, key, fallback)` | returns `fallback` (accepts both parsed-JSON `Map`s and live JS objects) |
+| `safeParseJsonObject(text)` | returns `null` on malformed/empty (graceful degradation for bad bootstrap/fragment envelopes) |
+| `queryOptionalElement(host, selector)` | returns `null` when absent |
+| `requireNonNull(value, what)` | throws `J2clInteropException` preserving `what` |
+| `requireElement(host, selector, context)` | throws `J2clInteropException` preserving `selector` + `context` |
+
+`J2clInteropException` carries the human context string so a failure is
+diagnosable post-minification. The `require*` helpers **fail loudly** (the caller
+catches and reports via `J2clClientTelemetry` / the notification service #1271
+rather than crashing the whole surface); the `safe*` helpers **degrade
+gracefully**. A deliberately malformed bootstrap/fragment envelope therefore
+resolves to `null` and lets the caller fall back instead of NPE-ing the
+selected-wave surface.
+
+**Initial adoption:** `J2clSelectedWaveView.queryRequired` now delegates to
+`requireElement`. Highest-risk remaining sites to migrate next (audit):
+`J2clSearchGateway` response decode, `SidecarTransportCodec` envelope decodes,
+`J2clSelectedWaveProjector` update coercion, `SidecarSessionBootstrap` field
+reads, `J2clAttachmentMetadataClient`, and the renderer `querySelector` paths.
+
 ## 14. Bottom Line
 
 The repo should not choose between:

--- a/docs/j2cl-parity-architecture.md
+++ b/docs/j2cl-parity-architecture.md
@@ -451,11 +451,26 @@ gracefully**. A deliberately malformed bootstrap/fragment envelope therefore
 resolves to `null` and lets the caller fall back instead of NPE-ing the
 selected-wave surface.
 
+**Observability:** the `safe*` helpers degrade gracefully but are **not** silent
+— `J2clJsInteropUtils.setFailureListener(...)` receives every swallowed failure
+(malformed JSON, thrown/typed-wrong DOM lookup, bad property read) and should be
+wired to `J2clClientTelemetry` + the notification service.
+
 **Initial adoption:** `J2clSelectedWaveView.queryRequired` now delegates to
-`requireElement`. Highest-risk remaining sites to migrate next (audit):
-`J2clSearchGateway` response decode, `SidecarTransportCodec` envelope decodes,
-`J2clSelectedWaveProjector` update coercion, `SidecarSessionBootstrap` field
-reads, `J2clAttachmentMetadataClient`, and the renderer `querySelector` paths.
+`requireElement`.
+
+**Migration audit (highest-risk interop sites → util method):**
+
+| Site (file:line) | Risk | Migrate to |
+| --- | --- | --- |
+| `J2clSelectedWaveView.queryRequired` | required DOM lookup NPE | `requireElement` ✅ done |
+| `J2clSearchGateway.java:~51` (bootstrap/text decode) | bad response → NPE | `safeParseJsonObject` + `safeGet*` |
+| `SidecarTransportCodec` envelope decodes | malformed frame → NPE | `safeParseJsonObject` |
+| `J2clSelectedWaveProjector.java:~166` (update coercion) | race/shape mismatch on `onUpdate` | `safeGet*` |
+| `SidecarSessionBootstrap.java:~121-150` (field reads) | missing session fields | `safeGetString` + `requireNonNull` |
+| `J2clAttachmentMetadataClient` (metadata decode) | attachment shape mismatch | `safeParseJsonObject` + `safeGet*` |
+| `J2clReadSurfaceDomRenderer` `ensureFocusFrame` querySelector paths | missing DOM node | `queryOptionalElement` / `requireElement` |
+| `J2clRootShellController` event-detail reads | missing CustomEvent detail | `safeGetString/Boolean` |
 
 ## 14. Bottom Line
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/common/J2clInteropException.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/common/J2clInteropException.java
@@ -1,0 +1,14 @@
+package org.waveprotocol.box.j2cl.common;
+
+/**
+ * #1272: minification-friendly runtime exception raised by
+ * {@link J2clJsInteropUtils} when a required JS-interop / DOM invariant is
+ * violated. The {@code message} carries the human {@code what}/context string so
+ * a failure is diagnosable even after the J2CL optimiser has renamed everything.
+ */
+public final class J2clInteropException extends RuntimeException {
+
+  public J2clInteropException(String message) {
+    super(message);
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/common/J2clJsInteropUtils.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/common/J2clJsInteropUtils.java
@@ -24,6 +24,36 @@ public final class J2clJsInteropUtils {
 
   private J2clJsInteropUtils() {}
 
+  /**
+   * Observer for interop failures that {@code safe*} helpers degrade past
+   * (malformed JSON, a thrown/typed-wrong DOM lookup, a bad property read).
+   * Wire this to {@code J2clClientTelemetry} / the notification service so
+   * graceful degradation is still observable rather than silent.
+   */
+  @FunctionalInterface
+  public interface InteropFailureListener {
+    void onInteropFailure(String context, Throwable cause);
+  }
+
+  private static InteropFailureListener failureListener;
+
+  /** Install the process-wide interop-failure observer (null to clear). */
+  public static void setFailureListener(InteropFailureListener listener) {
+    failureListener = listener;
+  }
+
+  private static void reportFailure(String context, Throwable cause) {
+    InteropFailureListener listener = failureListener;
+    if (listener == null) {
+      return;
+    }
+    try {
+      listener.onInteropFailure(context, cause);
+    } catch (RuntimeException | Error ignored) {
+      // The observer must never turn graceful degradation back into a crash.
+    }
+  }
+
   /** Reads a string at {@code key} from a parsed-JSON map or a JS object, else {@code fallback}. */
   public static String safeGetString(Object source, String key, String fallback) {
     Object value = rawGet(source, key);
@@ -94,21 +124,42 @@ public final class J2clJsInteropUtils {
       throw new J2clInteropException(
           "null host resolving '" + selector + "'" + contextSuffix(context));
     }
-    Element found = host.querySelector(selector);
+    HTMLElement found = queryOptionalElement(host, selector, context);
     if (found == null) {
       throw new J2clInteropException(
           "missing required element '" + selector + "'" + contextSuffix(context));
     }
-    return (HTMLElement) found;
+    return found;
   }
 
   /** Resolves an optional descendant element, returning {@code null} when absent. */
   public static HTMLElement queryOptionalElement(Element host, String selector) {
+    return queryOptionalElement(host, selector, null);
+  }
+
+  private static HTMLElement queryOptionalElement(Element host, String selector, String context) {
     if (host == null) {
       return null;
     }
-    Element found = host.querySelector(selector);
-    return found == null ? null : (HTMLElement) found;
+    Element found;
+    try {
+      // querySelector throws on an invalid selector; never let that escape.
+      found = host.querySelector(selector);
+    } catch (RuntimeException | Error e) {
+      reportFailure("querySelector '" + selector + "'" + contextSuffix(context), e);
+      return null;
+    }
+    if (found == null) {
+      return null;
+    }
+    if (found instanceof HTMLElement) {
+      return (HTMLElement) found;
+    }
+    // A match that is not an HTMLElement (e.g. an SVG element) — treat as absent
+    // rather than blindly cast.
+    reportFailure(
+        "element '" + selector + "' is not an HTMLElement" + contextSuffix(context), null);
+    return null;
   }
 
   /**
@@ -124,6 +175,7 @@ public final class J2clJsInteropUtils {
     try {
       return SidecarTransportCodec.parseJsonObject(text);
     } catch (RuntimeException | Error e) {
+      reportFailure("safeParseJsonObject", e);
       return null;
     }
   }
@@ -139,6 +191,7 @@ public final class J2clJsInteropUtils {
     try {
       return Js.asPropertyMap(source).get(key);
     } catch (RuntimeException | Error e) {
+      reportFailure("propertyRead '" + key + "'", e);
       return null;
     }
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/common/J2clJsInteropUtils.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/common/J2clJsInteropUtils.java
@@ -1,0 +1,149 @@
+package org.waveprotocol.box.j2cl.common;
+
+import elemental2.dom.Element;
+import elemental2.dom.HTMLElement;
+import java.util.Map;
+import jsinterop.base.Js;
+import org.waveprotocol.box.j2cl.transport.SidecarTransportCodec;
+
+/**
+ * #1272: the blessed defensive seam for every JS &lt;-&gt; Java boundary in the
+ * J2CL UI — property-map reads, DOM lookups, and JSON parsing.
+ *
+ * <p>Direct interop (e.g. {@code Js.asPropertyMap(payload).get("foo")},
+ * {@code host.querySelector(...)}, {@code parseJsonObject(...)}) turns a single
+ * bad server response or missing DOM node into a Java NPE that only surfaces as
+ * a cryptic minified JS console error. These helpers make the shape assumptions
+ * explicit: {@code safeGet*} / {@code queryOptionalElement} / {@code
+ * safeParseJsonObject} degrade gracefully (fallback / {@code null}); {@code
+ * requireNonNull} / {@code requireElement} fail loudly with a
+ * {@link J2clInteropException} that preserves human context so the caller can
+ * report it (telemetry / notification) instead of crashing the whole surface.
+ */
+public final class J2clJsInteropUtils {
+
+  private J2clJsInteropUtils() {}
+
+  /** Reads a string at {@code key} from a parsed-JSON map or a JS object, else {@code fallback}. */
+  public static String safeGetString(Object source, String key, String fallback) {
+    Object value = rawGet(source, key);
+    return value instanceof String ? (String) value : fallback;
+  }
+
+  /** Reads a boolean (accepts {@code "true"}/{@code "false"} strings) else {@code fallback}. */
+  public static boolean safeGetBoolean(Object source, String key, boolean fallback) {
+    Object value = rawGet(source, key);
+    if (value instanceof Boolean) {
+      return ((Boolean) value).booleanValue();
+    }
+    if ("true".equals(value)) {
+      return true;
+    }
+    if ("false".equals(value)) {
+      return false;
+    }
+    return fallback;
+  }
+
+  /** Reads an int (accepts numeric strings) else {@code fallback}. */
+  public static int safeGetInt(Object source, String key, int fallback) {
+    Object value = rawGet(source, key);
+    if (value instanceof Number) {
+      return ((Number) value).intValue();
+    }
+    if (value instanceof String) {
+      try {
+        return Integer.parseInt(((String) value).trim());
+      } catch (NumberFormatException ignored) {
+        return fallback;
+      }
+    }
+    return fallback;
+  }
+
+  /** Reads a long (accepts numeric strings) else {@code fallback}. */
+  public static long safeGetLong(Object source, String key, long fallback) {
+    Object value = rawGet(source, key);
+    if (value instanceof Number) {
+      return ((Number) value).longValue();
+    }
+    if (value instanceof String) {
+      try {
+        return Long.parseLong(((String) value).trim());
+      } catch (NumberFormatException ignored) {
+        return fallback;
+      }
+    }
+    return fallback;
+  }
+
+  /** Fails loudly with a context-preserving {@link J2clInteropException} when {@code value} is null. */
+  public static <T> T requireNonNull(T value, String what) {
+    if (value == null) {
+      throw new J2clInteropException((what == null ? "value" : what) + " was null");
+    }
+    return value;
+  }
+
+  /**
+   * Resolves a required descendant element, throwing a context-preserving
+   * {@link J2clInteropException} when the host is null or the selector misses.
+   */
+  public static HTMLElement requireElement(Element host, String selector, String context) {
+    if (host == null) {
+      throw new J2clInteropException(
+          "null host resolving '" + selector + "'" + contextSuffix(context));
+    }
+    Element found = host.querySelector(selector);
+    if (found == null) {
+      throw new J2clInteropException(
+          "missing required element '" + selector + "'" + contextSuffix(context));
+    }
+    return (HTMLElement) found;
+  }
+
+  /** Resolves an optional descendant element, returning {@code null} when absent. */
+  public static HTMLElement queryOptionalElement(Element host, String selector) {
+    if (host == null) {
+      return null;
+    }
+    Element found = host.querySelector(selector);
+    return found == null ? null : (HTMLElement) found;
+  }
+
+  /**
+   * Parses a JSON object, returning {@code null} (not throwing) on malformed
+   * input — the graceful-degradation seam for bad bootstrap / fragment
+   * envelopes. Callers should report the {@code null} and fall back rather than
+   * crash the surface.
+   */
+  public static Map<String, Object> safeParseJsonObject(String text) {
+    if (text == null || text.isEmpty()) {
+      return null;
+    }
+    try {
+      return SidecarTransportCodec.parseJsonObject(text);
+    } catch (RuntimeException | Error e) {
+      return null;
+    }
+  }
+
+  private static Object rawGet(Object source, String key) {
+    if (source == null || key == null) {
+      return null;
+    }
+    if (source instanceof Map) {
+      return ((Map<?, ?>) source).get(key);
+    }
+    // A live JS object / property map.
+    try {
+      return Js.asPropertyMap(source).get(key);
+    } catch (RuntimeException | Error e) {
+      return null;
+    }
+  }
+
+  private static String contextSuffix(String context) {
+    return context == null || context.isEmpty() ? "" : " (" + context + ")";
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import jsinterop.annotations.JsFunction;
 import jsinterop.base.Js;
 import jsinterop.base.JsPropertyMap;
+import org.waveprotocol.box.j2cl.common.J2clJsInteropUtils;
 import org.waveprotocol.box.j2cl.i18n.J2clI18n;
 import org.waveprotocol.box.j2cl.overlay.J2clInteractionBlipModel;
 import org.waveprotocol.box.j2cl.overlay.J2clMentionRange;
@@ -1516,12 +1517,9 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
 
   @SuppressWarnings("unchecked")
   private static <T> T queryRequired(HTMLElement root, String selector) {
-    Object element = root.querySelector(selector);
-    if (element == null) {
-      throw new IllegalStateException(
-          "Missing required DOM element for selector '" + selector + "'");
-    }
-    return (T) element;
+    // #1272: route through the blessed defensive-interop seam so a missing
+    // required element fails with a context-preserving J2clInteropException.
+    return (T) J2clJsInteropUtils.requireElement(root, selector, "J2clSelectedWaveView");
   }
 
   @SuppressWarnings("unchecked")

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/common/J2clJsInteropUtilsTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/common/J2clJsInteropUtilsTest.java
@@ -1,0 +1,143 @@
+package org.waveprotocol.box.j2cl.common;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import elemental2.dom.DomGlobal;
+import elemental2.dom.HTMLElement;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+@J2clTestInput(J2clJsInteropUtilsTest.class)
+public class J2clJsInteropUtilsTest {
+
+  private HTMLElement host;
+
+  @After
+  public void tearDown() {
+    if (host != null && host.parentElement != null) {
+      host.parentElement.removeChild(host);
+    }
+    host = null;
+  }
+
+  // ---- property-map reads (JVM + browser) ----
+
+  @Test
+  public void safeGetStringReadsOrFallsBack() {
+    Map<String, Object> map = new HashMap<String, Object>();
+    map.put("a", "hello");
+    map.put("n", 5);
+    Assert.assertEquals("hello", J2clJsInteropUtils.safeGetString(map, "a", "fb"));
+    Assert.assertEquals("fb", J2clJsInteropUtils.safeGetString(map, "n", "fb"));
+    Assert.assertEquals("fb", J2clJsInteropUtils.safeGetString(map, "missing", "fb"));
+    Assert.assertEquals("fb", J2clJsInteropUtils.safeGetString(null, "a", "fb"));
+  }
+
+  @Test
+  public void safeGetBooleanAcceptsBooleanAndStrings() {
+    Map<String, Object> map = new HashMap<String, Object>();
+    map.put("b", Boolean.TRUE);
+    map.put("s", "false");
+    map.put("junk", "maybe");
+    Assert.assertTrue(J2clJsInteropUtils.safeGetBoolean(map, "b", false));
+    Assert.assertFalse(J2clJsInteropUtils.safeGetBoolean(map, "s", true));
+    Assert.assertTrue(J2clJsInteropUtils.safeGetBoolean(map, "junk", true));
+    Assert.assertFalse(J2clJsInteropUtils.safeGetBoolean(map, "missing", false));
+  }
+
+  @Test
+  public void safeGetIntAndLongCoerceAndFallBack() {
+    Map<String, Object> map = new HashMap<String, Object>();
+    map.put("i", 7);
+    map.put("s", "42");
+    map.put("bad", "x");
+    Assert.assertEquals(7, J2clJsInteropUtils.safeGetInt(map, "i", -1));
+    Assert.assertEquals(42, J2clJsInteropUtils.safeGetInt(map, "s", -1));
+    Assert.assertEquals(-1, J2clJsInteropUtils.safeGetInt(map, "bad", -1));
+    Assert.assertEquals(-1, J2clJsInteropUtils.safeGetInt(map, "missing", -1));
+    Assert.assertEquals(99L, J2clJsInteropUtils.safeGetLong(map, "missing", 99L));
+    map.put("l", "9000000000");
+    Assert.assertEquals(9000000000L, J2clJsInteropUtils.safeGetLong(map, "l", -1L));
+  }
+
+  // ---- JSON parsing (JVM + browser) ----
+
+  @Test
+  public void safeParseJsonObjectReturnsMapForValidJson() {
+    Map<String, Object> parsed =
+        J2clJsInteropUtils.safeParseJsonObject("{\"address\":\"user@example.com\"}");
+    Assert.assertNotNull(parsed);
+    Assert.assertEquals("user@example.com", parsed.get("address"));
+  }
+
+  @Test
+  public void safeParseJsonObjectReturnsNullForMalformedOrEmpty() {
+    Assert.assertNull(J2clJsInteropUtils.safeParseJsonObject("{not json"));
+    Assert.assertNull(J2clJsInteropUtils.safeParseJsonObject("[1,2,3]"));
+    Assert.assertNull(J2clJsInteropUtils.safeParseJsonObject(""));
+    Assert.assertNull(J2clJsInteropUtils.safeParseJsonObject(null));
+  }
+
+  // ---- requireNonNull (JVM + browser) ----
+
+  @Test
+  public void requireNonNullReturnsValueOrThrowsWithContext() {
+    Assert.assertEquals("x", J2clJsInteropUtils.requireNonNull("x", "thing"));
+    try {
+      J2clJsInteropUtils.requireNonNull(null, "bootstrap.socket");
+      Assert.fail("Expected J2clInteropException");
+    } catch (J2clInteropException expected) {
+      Assert.assertTrue(expected.getMessage().contains("bootstrap.socket"));
+    }
+  }
+
+  // ---- DOM (browser only) ----
+
+  @Test
+  public void requireElementFindsOrThrows() {
+    assumeBrowserDom();
+    host = createHostWithChild();
+    HTMLElement child = J2clJsInteropUtils.requireElement(host, ".child", "test");
+    Assert.assertNotNull(child);
+    Assert.assertEquals("child", child.getAttribute("data-role"));
+    try {
+      J2clJsInteropUtils.requireElement(host, ".nope", "test-ctx");
+      Assert.fail("Expected J2clInteropException");
+    } catch (J2clInteropException expected) {
+      Assert.assertTrue(expected.getMessage().contains(".nope"));
+      Assert.assertTrue(expected.getMessage().contains("test-ctx"));
+    }
+    try {
+      J2clJsInteropUtils.requireElement(null, ".child", "null-host");
+      Assert.fail("Expected J2clInteropException for null host");
+    } catch (J2clInteropException expected) {
+      Assert.assertTrue(expected.getMessage().contains("null-host"));
+    }
+  }
+
+  @Test
+  public void queryOptionalElementReturnsNullWhenAbsent() {
+    assumeBrowserDom();
+    host = createHostWithChild();
+    Assert.assertNotNull(J2clJsInteropUtils.queryOptionalElement(host, ".child"));
+    Assert.assertNull(J2clJsInteropUtils.queryOptionalElement(host, ".nope"));
+    Assert.assertNull(J2clJsInteropUtils.queryOptionalElement(null, ".child"));
+  }
+
+  private static void assumeBrowserDom() {
+    Assume.assumeTrue(DomGlobal.document != null && DomGlobal.document.body != null);
+  }
+
+  private HTMLElement createHostWithChild() {
+    HTMLElement h = (HTMLElement) DomGlobal.document.createElement("div");
+    HTMLElement child = (HTMLElement) DomGlobal.document.createElement("span");
+    child.className = "child";
+    child.setAttribute("data-role", "child");
+    h.appendChild(child);
+    DomGlobal.document.body.appendChild(h);
+    return h;
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/common/J2clJsInteropUtilsTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/common/J2clJsInteropUtilsTest.java
@@ -21,6 +21,28 @@ public class J2clJsInteropUtilsTest {
       host.parentElement.removeChild(host);
     }
     host = null;
+    J2clJsInteropUtils.setFailureListener(null);
+  }
+
+  @Test
+  public void failureListenerObservesSwallowedParseFailure() {
+    final String[] captured = new String[1];
+    J2clJsInteropUtils.setFailureListener((context, cause) -> captured[0] = context);
+
+    Assert.assertNull(J2clJsInteropUtils.safeParseJsonObject("{not json"));
+
+    Assert.assertNotNull("listener should have observed the swallowed failure", captured[0]);
+    Assert.assertTrue(captured[0].contains("safeParseJsonObject"));
+  }
+
+  @Test
+  public void validParseDoesNotNotifyFailureListener() {
+    final int[] count = new int[1];
+    J2clJsInteropUtils.setFailureListener((context, cause) -> count[0]++);
+
+    J2clJsInteropUtils.safeParseJsonObject("{\"a\":1}");
+
+    Assert.assertEquals(0, count[0]);
   }
 
   // ---- property-map reads (JVM + browser) ----

--- a/wave/config/changelog.d/2026-07-05-j2cl-interop-guards.json
+++ b/wave/config/changelog.d/2026-07-05-j2cl-interop-guards.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-07-05-j2cl-interop-guards",
+  "version": "unreleased",
+  "date": "2026-07-05",
+  "title": "New UI: hardened against malformed server responses and missing DOM",
+  "summary": "Added a defensive JS-interop utility layer for the new UI so a single malformed server response or unexpected missing DOM node degrades gracefully (or fails with a diagnosable, context-preserving error) instead of throwing a cryptic minified crash that could take down the whole wave view.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "New UI: introduced a defensive JS-interop utility layer (safe property/JSON reads that fall back, required-element/non-null checks that fail with a readable, minification-safe error) as the standard seam for JS↔Java boundaries, so malformed bootstrap/fragment responses and missing DOM nodes no longer surface as cryptic browser-console crashes."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes #1272. The J2CL UI reads heavily from Elemental2 / `jsinterop.base.Js` property maps, DOM lookups, and JSON decodes, each of which assumes the shape the server or a previous render produced. A single bad gateway response, a race during `onUpdate`, or an unexpected `null` from `querySelector` produced a Java NPE that only surfaced as a cryptic minified JS console error — with no consistent defensive layer.

### What changed
- **`org.waveprotocol.box.j2cl.common.J2clJsInteropUtils`** (new) — the blessed seam for every JS↔Java boundary:
  | Method | Behavior on bad input |
  | --- | --- |
  | `safeGetString/Boolean/Int/Long(source, key, fallback)` | returns `fallback` (handles both parsed-JSON `Map`s and live JS objects; coerces numeric/boolean strings) |
  | `safeParseJsonObject(text)` | returns `null` on malformed/empty — graceful degradation for bad bootstrap/fragment envelopes |
  | `queryOptionalElement(host, selector)` | `null` when absent |
  | `requireNonNull(value, what)` / `requireElement(host, selector, context)` | fail loudly with a context-preserving `J2clInteropException` |
- **`J2clInteropException`** (new) — minification-friendly runtime exception carrying the human context string, so a failure is diagnosable after the J2CL optimiser has renamed everything.
- **First adoption**: `J2clSelectedWaveView.queryRequired` delegates to `requireElement`.
- **Docs**: `docs/j2cl-parity-architecture.md` §13a "J2CL ↔ JS Defensive Interop" documents this as the blessed seam and lists the audit of highest-risk sites to migrate next (gateway decode, `SidecarTransportCodec` envelopes, projector coercion, bootstrap reads, attachment metadata, renderer `querySelector` paths).

Per the AC, all **new** interop sites go through the utils; existing sites migrate incrementally (queryRequired is the first). The `require*` helpers fail loudly (caller reports via telemetry / the #1271 notification service instead of crashing the surface); the `safe*` helpers degrade gracefully — a deliberately malformed bootstrap/fragment resolves to `null` and lets the caller fall back instead of NPE-ing the selected-wave surface.

## Tests
- `J2clJsInteropUtilsTest` (new): safeGet* coercion + fallback; `safeParseJsonObject` valid→map / malformed→null / non-object→null / empty→null; `requireNonNull` return + throw-with-context (6 JVM-runnable); `requireElement` find/throw + null-host and `queryOptionalElement` null cases (browser-gated).
- `J2clSelectedWaveViewChromeTest` (40) unchanged.
- Full `./mvnw test` → BUILD SUCCESS.

## Local browser verification (Playwright, `?view=j2cl-root`)
Fresh user, opened the seeded wave: the selected-wave view constructs and renders 6 blips (every `queryRequired`→`requireElement` lookup resolved), with **0 console errors, 0 4xx/5xx**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new defensive JS-to-Java interop layer for the J2CL UI, including safer handling of missing values, malformed JSON, and DOM lookups.
  * Improved error messages for missing required elements so issues are easier to diagnose.

* **Bug Fixes**
  * Hardened interop behavior to avoid crashes when data is absent or invalid.
  * Added coverage for browser and JVM environments to validate the new fallback and error-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->