### PR TITLE
feat(j2cl): extract J2clHttpClient with timeout, retry and cancellation (#1276)

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSearchGateway.java
@@ -2,13 +2,13 @@ package org.waveprotocol.box.j2cl.search;
 
 import elemental2.dom.DomGlobal;
 import elemental2.dom.WebSocket;
-import elemental2.dom.XMLHttpRequest;
 import java.util.List;
 import java.util.Map;
 import jsinterop.annotations.JsMethod;
 import jsinterop.annotations.JsPackage;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentMetadataClient;
 import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceController;
+import org.waveprotocol.box.j2cl.transport.J2clHttpClient;
 import org.waveprotocol.box.j2cl.transport.SidecarFragmentsResponse;
 import org.waveprotocol.box.j2cl.transport.SidecarOpenRequest;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveReadState;
@@ -30,6 +30,8 @@ public final class J2clSearchGateway
   private static final String CROSS_HOST_WEBSOCKET_ERROR =
       "The J2CL sidecar requires core.http_websocket_presented_address to use the current page host when HttpOnly session cookies are enabled.";
   private final J2clAttachmentMetadataClient attachmentMetadataClient;
+  // #1276: single lifecycle-aware HTTP primitive for text/JSON fetches.
+  private final J2clHttpClient httpClient = new J2clHttpClient();
 
   public J2clSearchGateway() {
     this(new J2clAttachmentMetadataClient());
@@ -169,49 +171,40 @@ public final class J2clSearchGateway
       return;
     }
     String body = buildMarkBlipReadBody(waveId, blipId);
-    XMLHttpRequest request = new XMLHttpRequest();
-    request.open("POST", "/j2cl/mark-blip-read");
-    request.setRequestHeader("Content-Type", "application/json");
-    request.onload =
-        event -> {
-          if (request.status >= 200 && request.status < 300) {
-            try {
-              Map<String, Object> json = SidecarTransportCodec.parseJsonObject(request.responseText);
-              Object rawCount = json == null ? null : json.get("unreadCount");
-              Integer unreadCount = null;
-              if (rawCount instanceof Number) {
-                unreadCount = Integer.valueOf(((Number) rawCount).intValue());
-              } else if (rawCount instanceof String) {
-                try {
-                  unreadCount = Integer.valueOf(Integer.parseInt((String) rawCount));
-                } catch (NumberFormatException ignored) {
-                  // fall through to null check
-                }
+    // #1276: POST through the shared HTTP client; parse the response body here.
+    httpClient.postJson(
+        "/j2cl/mark-blip-read",
+        body,
+        responseText -> {
+          try {
+            Map<String, Object> json = SidecarTransportCodec.parseJsonObject(responseText);
+            Object rawCount = json == null ? null : json.get("unreadCount");
+            Integer unreadCount = null;
+            if (rawCount instanceof Number) {
+              unreadCount = Integer.valueOf(((Number) rawCount).intValue());
+            } else if (rawCount instanceof String) {
+              try {
+                unreadCount = Integer.valueOf(Integer.parseInt((String) rawCount));
+              } catch (NumberFormatException ignored) {
+                // fall through to null check
               }
-              if (unreadCount == null) {
-                onError.accept("Invalid markBlipRead response: missing or non-numeric unreadCount.");
-                return;
-              }
-              // The "alreadyRead" flag from the helper is informational —
-              // currently routed only through the success Integer because
-              // the controller doesn't need to distinguish "OK" from
-              // "ALREADY_READ" for live-decrement purposes (both converge
-              // on the same unreadCount). Expose it as an extra signal in
-              // a follow-up if telemetry buckets demand finer breakdown.
-              onSuccess.accept(unreadCount);
-            } catch (RuntimeException e) {
-              onError.accept(messageOrDefault(e, "Unable to decode the markBlipRead response."));
             }
-          } else {
-            onError.accept("HTTP " + request.status + " for /j2cl/mark-blip-read");
+            if (unreadCount == null) {
+              onError.accept("Invalid markBlipRead response: missing or non-numeric unreadCount.");
+              return;
+            }
+            // The "alreadyRead" flag from the helper is informational —
+            // currently routed only through the success Integer because
+            // the controller doesn't need to distinguish "OK" from
+            // "ALREADY_READ" for live-decrement purposes (both converge
+            // on the same unreadCount). Expose it as an extra signal in
+            // a follow-up if telemetry buckets demand finer breakdown.
+            onSuccess.accept(unreadCount);
+          } catch (RuntimeException e) {
+            onError.accept(messageOrDefault(e, "Unable to decode the markBlipRead response."));
           }
-        };
-    request.onerror =
-        event -> {
-          onError.accept("Network failure for /j2cl/mark-blip-read");
-          return null;
-        };
-    request.send(body);
+        },
+        onError::accept);
   }
 
   static String buildMarkBlipReadBody(String waveId, String blipId) {
@@ -471,26 +464,13 @@ public final class J2clSearchGateway
     target.append((char) (nibble < 10 ? '0' + nibble : 'A' + (nibble - 10)));
   }
 
-  private static void requestText(
+  private void requestText(
       String url,
       J2clSearchPanelController.SuccessCallback<String> onSuccess,
       J2clSearchPanelController.ErrorCallback onError) {
-    XMLHttpRequest request = new XMLHttpRequest();
-    request.open("GET", url);
-    request.onload =
-        event -> {
-          if (request.status >= 200 && request.status < 300) {
-            onSuccess.accept(request.responseText);
-          } else {
-            onError.accept("HTTP " + request.status + " for " + url);
-          }
-        };
-    request.onerror =
-        event -> {
-          onError.accept("Network failure for " + url);
-          return null;
-        };
-    request.send();
+    // #1276: route through the shared HTTP client (timeout + 5xx/network retry
+    // + cancellation) instead of a bespoke XMLHttpRequest.
+    httpClient.getText(url, onSuccess::accept, onError::accept);
   }
 
   private static String messageOrDefault(RuntimeException error, String fallback) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/J2clHttpClient.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/J2clHttpClient.java
@@ -1,0 +1,262 @@
+package org.waveprotocol.box.j2cl.transport;
+
+import elemental2.dom.DomGlobal;
+import elemental2.dom.XMLHttpRequest;
+
+/**
+ * #1276: the single, lifecycle-aware HTTP primitive for text/JSON fetches in the
+ * J2CL UI, replacing the copy-pasted {@code XMLHttpRequest + onload + status
+ * check} pattern (gateways, sandbox, attachment clients).
+ *
+ * <p>Adds what the ad-hoc sites lacked: a per-request timeout, bounded retry on
+ * 5xx / network errors / timeouts, and cancellation — {@link #getText}/{@link
+ * #postJson} return a {@link Request} handle whose {@link Request#cancel()}
+ * aborts the in-flight attempt and suppresses any pending retry, so a late
+ * response can never be processed after the owning controller is destroyed
+ * (coordinates with the #1268 dispose contract).
+ *
+ * <p>The physical HTTP attempt is injected via {@link SingleAttempt} so the
+ * retry/cancel orchestration is unit-testable off-browser; the default is a real
+ * {@link XMLHttpRequest}.
+ */
+public final class J2clHttpClient {
+
+  /** Default per-attempt timeout. */
+  public static final int DEFAULT_TIMEOUT_MS = 15000;
+
+  /** Default number of retries for 5xx / network / timeout failures. */
+  public static final int DEFAULT_MAX_RETRIES = 2;
+
+  private static final int INITIAL_RETRY_DELAY_MS = 200;
+  private static final int MAX_RETRY_DELAY_MS = 2000;
+
+  /** Delivered a successful body. */
+  @FunctionalInterface
+  public interface TextCallback {
+    void onSuccess(String responseText);
+  }
+
+  /** Delivered a terminal failure message (after retries are exhausted / non-retryable). */
+  @FunctionalInterface
+  public interface FailureCallback {
+    void onFailure(String message);
+  }
+
+  /** Cancellable handle, consistent with the Subscription / Disposable contract. */
+  public interface Request {
+    void cancel();
+  }
+
+  /** Sink for the outcome of a single physical attempt. Exactly one method fires. */
+  public interface AttemptSink {
+    void onStatus(int status, String responseText);
+
+    void onNetworkError();
+
+    void onTimeout();
+  }
+
+  /** Performs one physical HTTP attempt; returns a Runnable that aborts it. */
+  public interface SingleAttempt {
+    Runnable perform(
+        String method,
+        String url,
+        String contentType,
+        String body,
+        int timeoutMs,
+        AttemptSink sink);
+  }
+
+  /** Schedules a delayed retry (default: {@code DomGlobal.setTimeout}). */
+  public interface RetryScheduler {
+    void schedule(int delayMs, Runnable action);
+  }
+
+  private final SingleAttempt attempt;
+  private final RetryScheduler scheduler;
+  private final int timeoutMs;
+  private final int maxRetries;
+
+  public J2clHttpClient() {
+    this(DEFAULT_TIMEOUT_MS, DEFAULT_MAX_RETRIES);
+  }
+
+  public J2clHttpClient(int timeoutMs, int maxRetries) {
+    this(defaultAttempt(), defaultScheduler(), timeoutMs, maxRetries);
+  }
+
+  /** Test seam: inject the physical attempt + retry scheduler. */
+  J2clHttpClient(
+      SingleAttempt attempt, RetryScheduler scheduler, int timeoutMs, int maxRetries) {
+    this.attempt = attempt;
+    this.scheduler = scheduler;
+    this.timeoutMs = timeoutMs;
+    this.maxRetries = Math.max(0, maxRetries);
+  }
+
+  /** GET a text/JSON body. */
+  public Request getText(String url, TextCallback onSuccess, FailureCallback onFailure) {
+    return run("GET", url, null, null, onSuccess, onFailure);
+  }
+
+  /** POST a JSON body and read a text/JSON response. */
+  public Request postJson(
+      String url, String body, TextCallback onSuccess, FailureCallback onFailure) {
+    return run("POST", url, "application/json", body, onSuccess, onFailure);
+  }
+
+  private Request run(
+      String method,
+      String url,
+      String contentType,
+      String body,
+      TextCallback onSuccess,
+      FailureCallback onFailure) {
+    RequestHandle handle = new RequestHandle();
+    startAttempt(handle, method, url, contentType, body, onSuccess, onFailure, 0);
+    return handle;
+  }
+
+  private void startAttempt(
+      RequestHandle handle,
+      String method,
+      String url,
+      String contentType,
+      String body,
+      TextCallback onSuccess,
+      FailureCallback onFailure,
+      int attemptNo) {
+    if (handle.cancelled) {
+      return;
+    }
+    Runnable abort =
+        attempt.perform(
+            method,
+            url,
+            contentType,
+            body,
+            timeoutMs,
+            new AttemptSink() {
+              @Override
+              public void onStatus(int status, String responseText) {
+                if (handle.cancelled) {
+                  return;
+                }
+                if (status >= 200 && status < 300) {
+                  onSuccess.onSuccess(responseText);
+                  return;
+                }
+                if (status >= 500 && attemptNo < maxRetries) {
+                  scheduleRetry(handle, method, url, contentType, body, onSuccess, onFailure, attemptNo);
+                  return;
+                }
+                onFailure.onFailure("HTTP " + status + " for " + url);
+              }
+
+              @Override
+              public void onNetworkError() {
+                retryOrFail(
+                    handle, method, url, contentType, body, onSuccess, onFailure, attemptNo,
+                    "Network failure for " + url);
+              }
+
+              @Override
+              public void onTimeout() {
+                retryOrFail(
+                    handle, method, url, contentType, body, onSuccess, onFailure, attemptNo,
+                    "Timeout for " + url);
+              }
+            });
+    handle.currentAbort = abort;
+  }
+
+  private void retryOrFail(
+      RequestHandle handle,
+      String method,
+      String url,
+      String contentType,
+      String body,
+      TextCallback onSuccess,
+      FailureCallback onFailure,
+      int attemptNo,
+      String terminalMessage) {
+    if (handle.cancelled) {
+      return;
+    }
+    if (attemptNo < maxRetries) {
+      scheduleRetry(handle, method, url, contentType, body, onSuccess, onFailure, attemptNo);
+      return;
+    }
+    onFailure.onFailure(terminalMessage);
+  }
+
+  private void scheduleRetry(
+      RequestHandle handle,
+      String method,
+      String url,
+      String contentType,
+      String body,
+      TextCallback onSuccess,
+      FailureCallback onFailure,
+      int attemptNo) {
+    int nextAttempt = attemptNo + 1;
+    scheduler.schedule(
+        retryDelayMs(attemptNo),
+        () -> startAttempt(handle, method, url, contentType, body, onSuccess, onFailure, nextAttempt));
+  }
+
+  private static int retryDelayMs(int attemptNo) {
+    int delay = INITIAL_RETRY_DELAY_MS << attemptNo;
+    return Math.min(delay, MAX_RETRY_DELAY_MS);
+  }
+
+  private static final class RequestHandle implements Request {
+    private boolean cancelled;
+    private Runnable currentAbort;
+
+    @Override
+    public void cancel() {
+      cancelled = true;
+      Runnable abort = currentAbort;
+      currentAbort = null;
+      if (abort != null) {
+        abort.run();
+      }
+    }
+  }
+
+  private static SingleAttempt defaultAttempt() {
+    return (method, url, contentType, body, timeoutMs, sink) -> {
+      XMLHttpRequest request = new XMLHttpRequest();
+      request.open(method, url);
+      if (contentType != null) {
+        request.setRequestHeader("Content-Type", contentType);
+      }
+      if (timeoutMs > 0) {
+        request.timeout = timeoutMs;
+      }
+      request.onload = event -> sink.onStatus(request.status, request.responseText);
+      request.onerror =
+          event -> {
+            sink.onNetworkError();
+            return null;
+          };
+      request.ontimeout =
+          event -> {
+            sink.onTimeout();
+          };
+      if (body == null) {
+        request.send();
+      } else {
+        request.send(body);
+      }
+      return () -> request.abort();
+    };
+  }
+
+  private static RetryScheduler defaultScheduler() {
+    return (delayMs, action) -> {
+      DomGlobal.setTimeout(ignored -> action.run(), delayMs);
+    };
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/J2clHttpClientTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/J2clHttpClientTest.java
@@ -1,0 +1,199 @@
+package org.waveprotocol.box.j2cl.transport;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+@J2clTestInput(J2clHttpClientTest.class)
+public class J2clHttpClientTest {
+
+  @Test
+  public void getTextSuccessDeliversBody() {
+    FakeAttempt attempt = new FakeAttempt();
+    List<String> ok = new ArrayList<String>();
+    List<String> err = new ArrayList<String>();
+    J2clHttpClient client = new J2clHttpClient(attempt, autoScheduler(), 1000, 2);
+
+    client.getText("/x", ok::add, err::add);
+    attempt.last().sink.onStatus(200, "body");
+
+    Assert.assertEquals(1, attempt.calls.size());
+    Assert.assertEquals("GET", attempt.last().method);
+    Assert.assertEquals(java.util.Arrays.asList("body"), ok);
+    Assert.assertTrue(err.isEmpty());
+  }
+
+  @Test
+  public void clientErrorDoesNotRetry() {
+    FakeAttempt attempt = new FakeAttempt();
+    List<String> err = new ArrayList<String>();
+    int[] scheduled = {0};
+    J2clHttpClient client = new J2clHttpClient(attempt, countingScheduler(scheduled), 1000, 2);
+
+    client.getText("/x", s -> {}, err::add);
+    attempt.last().sink.onStatus(404, "nope");
+
+    Assert.assertEquals(1, attempt.calls.size());
+    Assert.assertEquals(0, scheduled[0]);
+    Assert.assertEquals(1, err.size());
+    Assert.assertTrue(err.get(0).contains("HTTP 404"));
+  }
+
+  @Test
+  public void serverErrorRetriesUpToMaxThenFails() {
+    FakeAttempt attempt = new FakeAttempt();
+    List<String> err = new ArrayList<String>();
+    J2clHttpClient client = new J2clHttpClient(attempt, autoScheduler(), 1000, 2);
+
+    client.getText("/x", s -> {}, err::add);
+    attempt.last().sink.onStatus(500, "");
+    attempt.last().sink.onStatus(500, "");
+    attempt.last().sink.onStatus(500, "");
+
+    Assert.assertEquals(3, attempt.calls.size()); // initial + 2 retries
+    Assert.assertEquals(1, err.size());
+    Assert.assertTrue(err.get(0).contains("HTTP 500"));
+  }
+
+  @Test
+  public void networkErrorRetriesThenFails() {
+    FakeAttempt attempt = new FakeAttempt();
+    List<String> err = new ArrayList<String>();
+    J2clHttpClient client = new J2clHttpClient(attempt, autoScheduler(), 1000, 1);
+
+    client.getText("/x", s -> {}, err::add);
+    attempt.last().sink.onNetworkError();
+    attempt.last().sink.onNetworkError();
+
+    Assert.assertEquals(2, attempt.calls.size()); // initial + 1 retry
+    Assert.assertEquals(1, err.size());
+    Assert.assertTrue(err.get(0).contains("Network failure"));
+  }
+
+  @Test
+  public void timeoutRetriesThenFails() {
+    FakeAttempt attempt = new FakeAttempt();
+    List<String> err = new ArrayList<String>();
+    J2clHttpClient client = new J2clHttpClient(attempt, autoScheduler(), 1000, 1);
+
+    client.getText("/x", s -> {}, err::add);
+    attempt.last().sink.onTimeout();
+    attempt.last().sink.onTimeout();
+
+    Assert.assertEquals(2, attempt.calls.size());
+    Assert.assertTrue(err.get(0).contains("Timeout"));
+  }
+
+  @Test
+  public void cancelStopsPendingRetryAndFiresNoCallback() {
+    FakeAttempt attempt = new FakeAttempt();
+    List<String> ok = new ArrayList<String>();
+    List<String> err = new ArrayList<String>();
+    ManualScheduler scheduler = new ManualScheduler();
+    J2clHttpClient client = new J2clHttpClient(attempt, scheduler, 1000, 2);
+
+    J2clHttpClient.Request request = client.getText("/x", ok::add, err::add);
+    attempt.last().sink.onStatus(500, ""); // schedules a retry (pending, not run)
+    request.cancel();
+    scheduler.runPending(); // the retry action should no-op because cancelled
+
+    Assert.assertTrue(attempt.last().aborted);
+    Assert.assertEquals(1, attempt.calls.size()); // no second attempt started
+    Assert.assertTrue(ok.isEmpty());
+    Assert.assertTrue(err.isEmpty());
+  }
+
+  @Test
+  public void cancelAbortsCurrentAttemptAndSuppressesLateSuccess() {
+    FakeAttempt attempt = new FakeAttempt();
+    List<String> ok = new ArrayList<String>();
+    J2clHttpClient client = new J2clHttpClient(attempt, autoScheduler(), 1000, 2);
+
+    J2clHttpClient.Request request = client.getText("/x", ok::add, s -> {});
+    request.cancel();
+    attempt.last().sink.onStatus(200, "late"); // arrives after cancel
+
+    Assert.assertTrue(attempt.last().aborted);
+    Assert.assertTrue("late response must be suppressed", ok.isEmpty());
+  }
+
+  @Test
+  public void postJsonSendsBodyAndContentType() {
+    FakeAttempt attempt = new FakeAttempt();
+    J2clHttpClient client = new J2clHttpClient(attempt, autoScheduler(), 1000, 0);
+
+    client.postJson("/y", "{\"k\":1}", s -> {}, s -> {});
+
+    FakeAttempt.Call call = attempt.last();
+    Assert.assertEquals("POST", call.method);
+    Assert.assertEquals("application/json", call.contentType);
+    Assert.assertEquals("{\"k\":1}", call.body);
+  }
+
+  private static J2clHttpClient.RetryScheduler autoScheduler() {
+    return (delayMs, action) -> action.run();
+  }
+
+  private static J2clHttpClient.RetryScheduler countingScheduler(int[] counter) {
+    return (delayMs, action) -> {
+      counter[0]++;
+      action.run();
+    };
+  }
+
+  private static final class ManualScheduler implements J2clHttpClient.RetryScheduler {
+    private Runnable pending;
+
+    @Override
+    public void schedule(int delayMs, Runnable action) {
+      pending = action;
+    }
+
+    void runPending() {
+      Runnable p = pending;
+      pending = null;
+      if (p != null) {
+        p.run();
+      }
+    }
+  }
+
+  private static final class FakeAttempt implements J2clHttpClient.SingleAttempt {
+    private final List<Call> calls = new ArrayList<Call>();
+
+    static final class Call {
+      String method;
+      String url;
+      String contentType;
+      String body;
+      int timeoutMs;
+      J2clHttpClient.AttemptSink sink;
+      boolean aborted;
+    }
+
+    @Override
+    public Runnable perform(
+        String method,
+        String url,
+        String contentType,
+        String body,
+        int timeoutMs,
+        J2clHttpClient.AttemptSink sink) {
+      final Call call = new Call();
+      call.method = method;
+      call.url = url;
+      call.contentType = contentType;
+      call.body = body;
+      call.timeoutMs = timeoutMs;
+      call.sink = sink;
+      calls.add(call);
+      return () -> call.aborted = true;
+    }
+
+    Call last() {
+      return calls.get(calls.size() - 1);
+    }
+  }
+}

--- a/wave/config/changelog.d/2026-07-05-j2cl-http-client.json
+++ b/wave/config/changelog.d/2026-07-05-j2cl-http-client.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-07-05-j2cl-http-client",
+  "version": "unreleased",
+  "date": "2026-07-05",
+  "title": "New UI: network requests now retry transient failures and cancel cleanly",
+  "summary": "The new UI's text/JSON network calls (bootstrap, read-state, mark-as-read) now go through a single HTTP client that adds a per-request timeout, automatic retry on transient 5xx/network/timeout errors, and cancellation — so a flaky connection recovers on its own and a late response can't be processed after you've navigated away.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "New UI: consolidated the duplicated XMLHttpRequest logic behind a single HTTP client with per-request timeout, bounded retry on transient 5xx/network/timeout failures, and cancellation; the selected-wave bootstrap, read-state, and mark-as-read calls now recover from transient errors and no longer process late responses after cancellation."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes #1276. The same low-level `XMLHttpRequest + onload + status check` pattern was copy-pasted across `J2clSearchGateway`, `SandboxEntryPoint`, and the attachment clients — none supporting timeout, retry, or cancellation.

### What changed
- **`org.waveprotocol.box.j2cl.transport.J2clHttpClient`** (new): `getText(url, ok, fail)` / `postJson(url, body, ok, fail)` returning a cancellable `Request`.
  - **Timeout** per attempt (default 15s).
  - **Bounded retry** (default 2) on 5xx / network error / timeout with exponential backoff; 4xx is non-retryable.
  - **Cancellation**: `Request.cancel()` aborts the in-flight attempt and suppresses any pending retry, so a late response is never processed after the owning controller is destroyed (coordinates with the #1268 Disposable contract).
  - The physical attempt is injected via a `SingleAttempt` seam (default = real `XMLHttpRequest`) and retries via a `RetryScheduler` seam (default = `DomGlobal.setTimeout`), so the retry/cancel orchestration is **unit-testable off-browser**.
- **Retrofit**: `J2clSearchGateway.requestText` (bootstrap + read-state GET) and the `markBlipRead` POST now go through the client; the bespoke `XMLHttpRequest` (and its import) is removed.

### Deferred (per the issue)
- Attachment upload/metadata and `SandboxEntryPoint` XHR sites — the issue allows attachment to keep its own XHR / get a specialized follow-up.
- Full destroy-lifecycle wiring (cancel-on-destroy) lands with #1268; the client already returns the cancellable handle it needs.

## Tests
- `J2clHttpClientTest` (new, 8 JVM-runnable via the injected seams): getText success; 4xx no-retry; 5xx retries-to-max-then-fails; network-error retry; timeout retry; **cancel stops a pending retry and fires no callback**; **cancel aborts the current attempt and suppresses a late success**; postJson sends body + `application/json`.
- `J2clSelectedWaveControllerTest` (101) + full `./mvnw test` → BUILD SUCCESS.

## Local browser verification (Playwright, `?view=j2cl-root`)
Fresh user, opened the seeded wave: it renders 6 blips, and the gateway's HTTP now flows through the client — observed `200 bootstrap.json` (getText) and `200 read-state?...` (getText) — with **0 console errors, 0 4xx/5xx**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
