### PR TITLE
feat(j2cl): introduce Disposable contract and tear down view/renderer listeners (#1268)

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/common/Disposable.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/common/Disposable.java
@@ -1,0 +1,21 @@
+package org.waveprotocol.box.j2cl.common;
+
+/**
+ * #1268: explicit teardown contract for J2CL controllers and views that bind
+ * DOM/custom-event listeners, timers, or transport subscriptions.
+ *
+ * <p>Without this, listeners and in-flight callbacks accumulate across wave
+ * switches / sidecar open-close / shell re-render, producing leaks, duplicate
+ * handlers, and stale callbacks mutating detached DOM. A surface that owns any
+ * such resource implements {@link #destroy()} to release them.
+ */
+public interface Disposable {
+
+  /**
+   * Release all listeners, timers, and subscriptions this instance owns.
+   *
+   * <p>Must be idempotent and safe to call on an instance that never registered
+   * anything or that has already been destroyed.
+   */
+  void destroy();
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/common/J2clDisposeRegistry.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/common/J2clDisposeRegistry.java
@@ -1,0 +1,78 @@
+package org.waveprotocol.box.j2cl.common;
+
+import elemental2.dom.DomGlobal;
+import elemental2.dom.EventListener;
+import elemental2.dom.EventTarget;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * #1268: collects the teardown actions a {@link Disposable} surface accumulates
+ * (event listeners, timers, arbitrary un-binders) so {@link #destroy()} can
+ * release them all at once — the single place that makes leak-free teardown
+ * mechanical instead of hand-tracking every handler ref.
+ *
+ * <p>Registering after {@link #destroy()} runs the disposer immediately (so a
+ * late binding cannot leak), and {@code destroy()} is idempotent.
+ */
+public final class J2clDisposeRegistry implements Disposable {
+
+  private final List<Runnable> disposers = new ArrayList<Runnable>();
+  private boolean destroyed;
+
+  /**
+   * Adds {@code listener} to {@code target} for {@code type} and tracks its
+   * removal. No-op when target/listener is null.
+   */
+  public void addListener(EventTarget target, String type, EventListener listener) {
+    if (target == null || listener == null) {
+      return;
+    }
+    target.addEventListener(type, listener);
+    track(() -> target.removeEventListener(type, listener));
+  }
+
+  /** Tracks a {@code setTimeout}/{@code setInterval} handle for cancellation. */
+  public void trackTimeout(double handle) {
+    track(() -> DomGlobal.clearTimeout(handle));
+  }
+
+  /** Tracks an arbitrary teardown action (e.g. a transport {@code Subscription::close}). */
+  public void track(Runnable disposer) {
+    if (disposer == null) {
+      return;
+    }
+    if (destroyed) {
+      // Already torn down — run the disposer now rather than retain it.
+      runQuietly(disposer);
+      return;
+    }
+    disposers.add(disposer);
+  }
+
+  /** True once {@link #destroy()} has run. */
+  public boolean isDestroyed() {
+    return destroyed;
+  }
+
+  @Override
+  public void destroy() {
+    if (destroyed) {
+      return;
+    }
+    destroyed = true;
+    // Tear down in reverse registration order (mirrors nested resource scoping).
+    for (int i = disposers.size() - 1; i >= 0; i--) {
+      runQuietly(disposers.get(i));
+    }
+    disposers.clear();
+  }
+
+  private static void runQuietly(Runnable disposer) {
+    try {
+      disposer.run();
+    } catch (RuntimeException | Error ignored) {
+      // One failing disposer must not abort the rest of teardown.
+    }
+  }
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -3104,6 +3104,9 @@ public final class J2clReadSurfaceDomRenderer implements Disposable {
   @Override
   public void destroy() {
     disposeRegistry.destroy();
+    // #1268: cancel pending viewport-dwell mark-read timers so they cannot fire
+    // (and mark blips read / mutate) after teardown.
+    cancelAllDwellTimers();
     scrollListenerBound = false;
   }
 

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/read/J2clReadSurfaceDomRenderer.java
@@ -23,6 +23,8 @@ import java.util.Set;
 import jsinterop.base.Js;
 import jsinterop.base.JsPropertyMap;
 import org.waveprotocol.box.j2cl.attachment.J2clAttachmentRenderModel;
+import org.waveprotocol.box.j2cl.common.Disposable;
+import org.waveprotocol.box.j2cl.common.J2clDisposeRegistry;
 import org.waveprotocol.box.j2cl.overlay.J2clMentionRange;
 import org.waveprotocol.box.j2cl.overlay.J2clReactionSummary;
 import org.waveprotocol.box.j2cl.overlay.J2clTaskItemModel;
@@ -30,7 +32,9 @@ import org.waveprotocol.box.j2cl.telemetry.J2clClientTelemetry;
 import org.waveprotocol.box.j2cl.transport.SidecarConversationManifest;
 import org.waveprotocol.box.j2cl.viewport.J2clViewportGrowthDirection;
 
-public final class J2clReadSurfaceDomRenderer {
+public final class J2clReadSurfaceDomRenderer implements Disposable {
+  // #1268: tracks the host + window scroll listeners for teardown.
+  private final J2clDisposeRegistry disposeRegistry = new J2clDisposeRegistry();
   // Roughly one compact blip of lead time before a viewport edge reaches the exact scroll boundary.
   private static final double EDGE_SCROLL_THRESHOLD_PX = 64;
   private static final String ATTACHMENT_TELEMETRY_BOUND = "data-attachment-telemetry-bound";
@@ -257,8 +261,10 @@ public final class J2clReadSurfaceDomRenderer {
       lastScrollDirection = null;
     }
     if (!scrollListenerBound) {
-      host.addEventListener("scroll", this::onHostScroll);
-      DomGlobal.window.addEventListener("scroll", this::onHostScroll);
+      // #1268: bound through the dispose registry so both scroll listeners are
+      // removed on destroy() instead of leaking for the page's lifetime.
+      disposeRegistry.addListener(host, "scroll", this::onHostScroll);
+      disposeRegistry.addListener(DomGlobal.window, "scroll", this::onHostScroll);
       scrollListenerBound = true;
     }
   }
@@ -314,8 +320,10 @@ public final class J2clReadSurfaceDomRenderer {
       evaluateDwellTimers();
     }
     if (!scrollListenerBound) {
-      host.addEventListener("scroll", this::onHostScroll);
-      DomGlobal.window.addEventListener("scroll", this::onHostScroll);
+      // #1268: bound through the dispose registry so both scroll listeners are
+      // removed on destroy() instead of leaking for the page's lifetime.
+      disposeRegistry.addListener(host, "scroll", this::onHostScroll);
+      disposeRegistry.addListener(DomGlobal.window, "scroll", this::onHostScroll);
       scrollListenerBound = true;
     }
   }
@@ -3087,6 +3095,16 @@ public final class J2clReadSurfaceDomRenderer {
     } catch (Throwable ignored) {
       // Telemetry is observational.
     }
+  }
+
+  /**
+   * #1268: remove the host + window scroll listeners. Idempotent; the renderer
+   * stops responding to scroll once destroyed.
+   */
+  @Override
+  public void destroy() {
+    disposeRegistry.destroy();
+    scrollListenerBound = false;
   }
 
   private void onHostScroll(Event event) {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -34,6 +34,9 @@ public final class J2clRootShellController implements org.waveprotocol.box.j2cl.
   // #1268: retained for teardown so a pagehide / destroy() releases the
   // selected-wave view's listeners (which cascade to the read surface).
   private J2clSelectedWaveView selectedWaveView;
+  // #1268: this shell's own global body/window listeners, released on destroy().
+  private final org.waveprotocol.box.j2cl.common.J2clDisposeRegistry disposeRegistry =
+      new org.waveprotocol.box.j2cl.common.J2clDisposeRegistry();
 
   public J2clRootShellController(HTMLElement host) {
     this.host = host;
@@ -196,23 +199,23 @@ public final class J2clRootShellController implements org.waveprotocol.box.j2cl.
     // J-UI-3 (#1081, R-5.1): the rail's New Wave button focuses the create
     // form's title input. Listening on document.body so the event bubbles
     // up regardless of where the rail is currently mounted.
-    elemental2.dom.DomGlobal.document.body.addEventListener(
+    disposeRegistry.addListener(elemental2.dom.DomGlobal.document.body, 
         "wavy-new-wave-requested",
         evt -> composeController.focusCreateSurface(newWaveTriggerFromEvent(evt)));
-    elemental2.dom.DomGlobal.document.body.addEventListener(
+    disposeRegistry.addListener(elemental2.dom.DomGlobal.document.body, 
         "wave-new-with-participants-requested",
         evt -> composeController.onCreateRequestedWithParticipants(participantsFromEvent(evt)));
-    elemental2.dom.DomGlobal.document.body.addEventListener(
+    disposeRegistry.addListener(elemental2.dom.DomGlobal.document.body, 
         "wave-add-participant-requested",
         evt ->
             composeController.onAddParticipantsRequested(
                 sourceWaveIdFromEvent(evt), addParticipantAddressesFromEvent(evt)));
-    elemental2.dom.DomGlobal.document.body.addEventListener(
+    disposeRegistry.addListener(elemental2.dom.DomGlobal.document.body, 
         "wave-publicity-toggle-requested",
         evt ->
             composeController.onPublicityToggleRequested(
                 sourceWaveIdFromEvent(evt), nextPublicFromEvent(evt)));
-    elemental2.dom.DomGlobal.document.body.addEventListener(
+    disposeRegistry.addListener(elemental2.dom.DomGlobal.document.body, 
         "wave-root-lock-toggle-requested",
         evt ->
             composeController.onLockStateToggleRequested(
@@ -267,7 +270,7 @@ public final class J2clRootShellController implements org.waveprotocol.box.j2cl.
     // Intercept it to clear the selection through the route controller so
     // returning to the inbox is an instant in-shell transition (the anchor
     // href stays functional for middle-click / no-JS fallbacks).
-    DomGlobal.document.body.addEventListener(
+    disposeRegistry.addListener(DomGlobal.document.body, 
         "wavy-back-to-inbox-clicked",
         event -> {
           event.preventDefault();
@@ -277,7 +280,7 @@ public final class J2clRootShellController implements org.waveprotocol.box.j2cl.
         });
     // #1268: final teardown on navigation away releases the selected-wave view's
     // listeners (which cascade to the read surface) so they do not leak.
-    DomGlobal.window.addEventListener("pagehide", event -> destroy());
+    disposeRegistry.addListener(DomGlobal.window, "pagehide", event -> destroy());
     liveSurfaceController.start();
   }
 
@@ -287,6 +290,9 @@ public final class J2clRootShellController implements org.waveprotocol.box.j2cl.
    */
   @Override
   public void destroy() {
+    // Release this shell's own global body/window listeners (incl. pagehide)...
+    disposeRegistry.destroy();
+    // ...then cascade to the selected-wave view (which cascades to the read surface).
     if (selectedWaveView != null) {
       selectedWaveView.destroy();
     }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -28,9 +28,12 @@ import org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceController;
 import org.waveprotocol.box.j2cl.toolbar.J2clToolbarSurfaceView;
 import org.waveprotocol.box.j2cl.transport.SidecarSelectedWaveDocument;
 
-public final class J2clRootShellController {
+public final class J2clRootShellController implements org.waveprotocol.box.j2cl.common.Disposable {
   private final HTMLElement host;
   private boolean started;
+  // #1268: retained for teardown so a pagehide / destroy() releases the
+  // selected-wave view's listeners (which cascade to the read surface).
+  private J2clSelectedWaveView selectedWaveView;
 
   public J2clRootShellController(HTMLElement host) {
     this.host = host;
@@ -72,6 +75,7 @@ public final class J2clRootShellController {
     J2clSelectedWaveView selectedWaveView =
         new J2clSelectedWaveView(searchView.getSelectedWaveHost(), telemetrySink);
     selectedWaveViewRef[0] = selectedWaveView;
+    this.selectedWaveView = selectedWaveView;
     HTMLElement selectedWaveComposeHost = selectedWaveView.getComposeHost();
     HTMLElement selectedCreateHost =
         createSiblingHostBefore(selectedWaveComposeHost, "j2cl-root-create-host");
@@ -271,7 +275,21 @@ public final class J2clRootShellController {
           notificationService.clear();
           routeControllerRef[0].selectWave(null);
         });
+    // #1268: final teardown on navigation away releases the selected-wave view's
+    // listeners (which cascade to the read surface) so they do not leak.
+    DomGlobal.window.addEventListener("pagehide", event -> destroy());
     liveSurfaceController.start();
+  }
+
+  /**
+   * #1268: release the surfaces this shell owns. Idempotent — safe to call from
+   * both {@code pagehide} and an explicit host teardown.
+   */
+  @Override
+  public void destroy() {
+    if (selectedWaveView != null) {
+      selectedWaveView.destroy();
+    }
   }
 
   /**

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -441,13 +441,16 @@ public final class J2clRootShellController implements org.waveprotocol.box.j2cl.
    * the read-surface attribute (kept in sync by setDepthFocus); and for
    * {@code wavy-depth-root} we clear the depth.
    */
-  private static void bindDepthEventsToRoute(
+  // #1268: instance so the depth listeners bind through the shell's dispose
+  // registry and are removed on destroy().
+  private void bindDepthEventsToRoute(
       J2clSelectedWaveView view, J2clSidecarRouteController routeController) {
     HTMLElement card = view.getCardElement();
     if (card == null || routeController == null) {
       return;
     }
-    card.addEventListener(
+    disposeRegistry.addListener(
+        card,
         "wavy-depth-drill-in",
         evt -> {
           Object detail = Js.asPropertyMap(evt).get("detail");
@@ -464,7 +467,8 @@ public final class J2clRootShellController implements org.waveprotocol.box.j2cl.
             view.setDepthFocus(resolved, "", "");
           }
         });
-    card.addEventListener(
+    disposeRegistry.addListener(
+        card,
         "wavy-depth-up",
         evt -> {
           Object detail = Js.asPropertyMap(evt).get("detail");
@@ -480,13 +484,15 @@ public final class J2clRootShellController implements org.waveprotocol.box.j2cl.
           routeController.onDepthChanged(parentId.isEmpty() ? null : parentId);
           view.setDepthFocus(parentId.isEmpty() ? "" : parentId, "", "");
         });
-    card.addEventListener(
+    disposeRegistry.addListener(
+        card,
         "wavy-depth-root",
         (Event evt) -> {
           routeController.onDepthChanged(null);
           view.setDepthFocus("", "", "");
         });
-    card.addEventListener(
+    disposeRegistry.addListener(
+        card,
         "wavy-depth-jump-to-crumb",
         evt -> {
           Object detail = Js.asPropertyMap(evt).get("detail");

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -20,6 +20,8 @@ import java.util.Set;
 import jsinterop.annotations.JsFunction;
 import jsinterop.base.Js;
 import jsinterop.base.JsPropertyMap;
+import org.waveprotocol.box.j2cl.common.Disposable;
+import org.waveprotocol.box.j2cl.common.J2clDisposeRegistry;
 import org.waveprotocol.box.j2cl.common.J2clJsInteropUtils;
 import org.waveprotocol.box.j2cl.i18n.J2clI18n;
 import org.waveprotocol.box.j2cl.overlay.J2clInteractionBlipModel;
@@ -36,7 +38,9 @@ import org.waveprotocol.box.j2cl.transport.SidecarViewportHints;
 import org.waveprotocol.box.j2cl.common.J2clDebugFlags;
 import org.waveprotocol.box.j2cl.viewport.J2clViewportGrowthDirection;
 
-public final class J2clSelectedWaveView implements J2clSelectedWaveController.View {
+public final class J2clSelectedWaveView implements J2clSelectedWaveController.View, Disposable {
+  // #1268: tracks this view's persistent card/content listeners for teardown.
+  private final J2clDisposeRegistry disposeRegistry = new J2clDisposeRegistry();
   /**
    * Initial selected-wave viewport size for normal client-side opens.
    *
@@ -371,12 +375,13 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
    * <p>The compose surface's own body-level listener still owns the delta
    * submission; this hook is purely about the in-flight UI state.
    */
-  private static void bindOptimisticTaskToggleListener(
+  private void bindOptimisticTaskToggleListener(
       HTMLElement contentList, J2clReadSurfaceDomRenderer renderer) {
     if (contentList == null || renderer == null) {
       return;
     }
-    contentList.addEventListener(
+    disposeRegistry.addListener(
+        contentList,
         "wave-blip-task-toggled",
         evt -> {
           Object detail = jsinterop.base.Js.asPropertyMap(evt).get("detail");
@@ -474,7 +479,8 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     if (card == null) {
       return;
     }
-    card.addEventListener(
+    disposeRegistry.addListener(
+        card,
         "wavy-selected-wave-refresh-requested",
         evt -> {
           if (selectedWaveRefreshHandler == null) {
@@ -498,7 +504,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
    * surface. S2 records telemetry for each click; S5 will add the
    * controller wiring on top.
    */
-  private static void bindChromeEvents(HTMLElement card, J2clClientTelemetry.Sink sink) {
+  private void bindChromeEvents(HTMLElement card, J2clClientTelemetry.Sink sink) {
     String[] navEvents = {
       "wave-nav-recent-requested",
       "wave-nav-next-unread-requested",
@@ -512,7 +518,8 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       "wave-nav-version-history-requested"
     };
     for (final String navEvent : navEvents) {
-      card.addEventListener(
+      disposeRegistry.addListener(
+          card,
           navEvent,
           evt -> {
             try {
@@ -527,7 +534,8 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     }
     String[] depthEvents = {"wavy-depth-up", "wavy-depth-root", "wavy-depth-jump-to-crumb"};
     for (final String depthEvent : depthEvents) {
-      card.addEventListener(
+      disposeRegistry.addListener(
+          card,
           depthEvent,
           evt -> {
             try {
@@ -544,16 +552,31 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
 
   private void bindNavigationEvents(HTMLElement card) {
     // #1273: the nav-row events are thin callers into the single focus owner.
-    card.addEventListener("wave-nav-recent-requested", evt -> blipFocus.focusMostRecent());
-    card.addEventListener(
-        "wave-nav-next-unread-requested", evt -> blipFocus.focusNextMatching("unread", 1));
-    card.addEventListener("wave-nav-previous-requested", evt -> blipFocus.focusAdjacent(-1));
-    card.addEventListener("wave-nav-next-requested", evt -> blipFocus.focusAdjacent(1));
-    card.addEventListener("wave-nav-end-requested", evt -> blipFocus.focusLast());
-    card.addEventListener(
-        "wave-nav-prev-mention-requested", evt -> blipFocus.focusNextMatching("has-mention", -1));
-    card.addEventListener(
-        "wave-nav-next-mention-requested", evt -> blipFocus.focusNextMatching("has-mention", 1));
+    // #1268: bound through the dispose registry so they are removed on destroy().
+    disposeRegistry.addListener(
+        card, "wave-nav-recent-requested", evt -> blipFocus.focusMostRecent());
+    disposeRegistry.addListener(
+        card, "wave-nav-next-unread-requested", evt -> blipFocus.focusNextMatching("unread", 1));
+    disposeRegistry.addListener(
+        card, "wave-nav-previous-requested", evt -> blipFocus.focusAdjacent(-1));
+    disposeRegistry.addListener(card, "wave-nav-next-requested", evt -> blipFocus.focusAdjacent(1));
+    disposeRegistry.addListener(card, "wave-nav-end-requested", evt -> blipFocus.focusLast());
+    disposeRegistry.addListener(
+        card, "wave-nav-prev-mention-requested", evt -> blipFocus.focusNextMatching("has-mention", -1));
+    disposeRegistry.addListener(
+        card, "wave-nav-next-mention-requested", evt -> blipFocus.focusNextMatching("has-mention", 1));
+  }
+
+  /**
+   * #1268: release this view's persistent card/content listeners and cascade to
+   * the read surface. Idempotent and safe to call more than once.
+   */
+  @Override
+  public void destroy() {
+    disposeRegistry.destroy();
+    if (readSurface != null) {
+      readSurface.destroy();
+    }
   }
 
   static void configureContentList(HTMLElement contentList) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/common/J2clDisposeRegistryTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/common/J2clDisposeRegistryTest.java
@@ -1,0 +1,72 @@
+package org.waveprotocol.box.j2cl.common;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+@J2clTestInput(J2clDisposeRegistryTest.class)
+public class J2clDisposeRegistryTest {
+
+  @Test
+  public void destroyRunsTrackedDisposersInReverseOrder() {
+    J2clDisposeRegistry registry = new J2clDisposeRegistry();
+    List<String> order = new ArrayList<String>();
+    registry.track(() -> order.add("first"));
+    registry.track(() -> order.add("second"));
+
+    registry.destroy();
+
+    Assert.assertEquals(java.util.Arrays.asList("second", "first"), order);
+    Assert.assertTrue(registry.isDestroyed());
+  }
+
+  @Test
+  public void destroyIsIdempotent() {
+    J2clDisposeRegistry registry = new J2clDisposeRegistry();
+    int[] runs = {0};
+    registry.track(() -> runs[0]++);
+
+    registry.destroy();
+    registry.destroy();
+
+    Assert.assertEquals(1, runs[0]);
+  }
+
+  @Test
+  public void trackAfterDestroyRunsImmediately() {
+    J2clDisposeRegistry registry = new J2clDisposeRegistry();
+    registry.destroy();
+    int[] runs = {0};
+
+    registry.track(() -> runs[0]++);
+
+    Assert.assertEquals("late registration must be disposed immediately", 1, runs[0]);
+  }
+
+  @Test
+  public void aThrowingDisposerDoesNotAbortTeardown() {
+    J2clDisposeRegistry registry = new J2clDisposeRegistry();
+    int[] laterRan = {0};
+    // Registered first so it runs LAST (reverse order); the throwing disposer
+    // registered second runs first and must not prevent this one.
+    registry.track(() -> laterRan[0]++);
+    registry.track(
+        () -> {
+          throw new RuntimeException("boom");
+        });
+
+    registry.destroy();
+
+    Assert.assertEquals(1, laterRan[0]);
+  }
+
+  @Test
+  public void nullDisposerIsIgnored() {
+    J2clDisposeRegistry registry = new J2clDisposeRegistry();
+    registry.track(null);
+    registry.destroy(); // must not throw
+    Assert.assertTrue(registry.isDestroyed());
+  }
+}

--- a/wave/config/changelog.d/2026-07-05-j2cl-dispose-contract.json
+++ b/wave/config/changelog.d/2026-07-05-j2cl-dispose-contract.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-07-05-j2cl-dispose-contract",
+  "version": "unreleased",
+  "date": "2026-07-05",
+  "title": "New UI: event listeners are now cleaned up on teardown",
+  "summary": "The new UI's wave view and read surface now release their DOM/custom-event listeners when the page is torn down, via an explicit dispose contract. This prevents listener leaks and duplicate handlers building up over long sessions and rapid wave switching, and lays the groundwork for cleaner sidecar/shell lifecycle work.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "New UI: introduced an explicit dispose/destroy lifecycle contract; the selected-wave view and read-surface renderer now register their persistent listeners through a dispose registry and release them on page teardown (pagehide), preventing listener leaks and duplicate-handler double-fires in long sessions."
+      ]
+    }
+  ]
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -595,7 +595,10 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
                 + "J2clReadSurfaceDomRenderer.java");
     assertTrue(
         "Renderer must listen to page scroll events when selected wave content no longer owns a nested scrollbar.",
-        source.contains("DomGlobal.window.addEventListener(\"scroll\", this::onHostScroll);"));
+        // #1268: scroll listeners are now bound through the dispose registry so
+        // they are released on destroy(); still listens to window scroll.
+        source.contains(
+            "disposeRegistry.addListener(DomGlobal.window, \"scroll\", this::onHostScroll);"));
     assertTrue(
         "Viewport edge loading must use host-relative edge helpers, not hard-coded host.scrollTop in onHostScroll.",
         source.contains("if (isNearTopEdge())")


### PR DESCRIPTION
## Summary

Fixes #1268. The J2CL UI bound DOM/custom-event listeners (`wave-nav-*`, scroll, click) and never removed them, so listeners and stale callbacks accumulated across wave switches / shell re-render — leaks, duplicate handlers, and callbacks mutating detached DOM.

### What changed
- **`org.waveprotocol.box.j2cl.common.Disposable`** (new): `void destroy()` — idempotent, safe on a no-op / already-destroyed instance.
- **`org.waveprotocol.box.j2cl.common.J2clDisposeRegistry`** (new): collects teardown actions (`addListener(target, type, listener)`, `trackTimeout(handle)`, `track(Runnable)`) and releases them in reverse order on `destroy()`; registering after destroy runs the disposer immediately; a throwing disposer never aborts the rest of teardown. This makes leak-free teardown mechanical instead of hand-tracking every handler ref.
- **`J2clSelectedWaveView implements Disposable`**: its persistent card/content listeners (nav events, chrome/depth telemetry, refresh, optimistic task-toggle) now bind through the registry; `destroy()` releases them and cascades to the read surface.
- **`J2clReadSurfaceDomRenderer implements Disposable`**: the host + window `scroll` listeners bind through the registry; `destroy()` removes them.
- **`J2clRootShellController implements Disposable`**: retains the selected-wave view and registers a `pagehide` handler that calls `destroy()` (final teardown), cascading view → read surface.

Per the issue's "keep it reviewable" guidance, this lands the contract + the biggest listener owners + the teardown entry point; the compose/search/live-surface controllers adopt the same contract in follow-up slices.

## Tests
- `J2clDisposeRegistryTest` (new, 5 JVM-runnable): reverse-order teardown, idempotent destroy, late-registration-runs-immediately, throwing-disposer isolation, null-disposer ignored.
- `J2clSelectedWaveViewChromeTest` (40) + `J2clRootShellControllerTest` (7) + full `./mvnw test` → BUILD SUCCESS (behaviour unchanged).

## Local browser verification (Playwright, `?view=j2cl-root`)
Fresh user, opened the seeded wave: dispatching `wave-nav-recent-requested` focuses a blip (listener active); after firing `pagehide` → `J2clRootShellController.destroy()` → `view.destroy()`, dispatching `wave-nav-previous-requested` leaves roving focus **unchanged** — the listener was removed, so `focusAdjacent` never ran. 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more reliable UI teardown so views clean up when they are closed or the page changes.
  * Improved lifecycle handling for selected content, read surfaces, and navigation-related interactions.

* **Bug Fixes**
  * Reduced the chance of duplicate click/scroll handlers and stale callbacks after switching views.
  * Helped prevent memory leaks by ensuring listeners, timers, and other pending actions are cleared on exit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->