### PR TITLE
refactor(j2cl): centralize DOM contract strings in J2clUiTokens (#1269)

### DIFF
--- a/docs/j2cl-parity-architecture.md
+++ b/docs/j2cl-parity-architecture.md
@@ -472,6 +472,31 @@ wired to `J2clClientTelemetry` + the notification service.
 | `J2clReadSurfaceDomRenderer` `ensureFocusFrame` querySelector paths | missing DOM node | `queryOptionalElement` / `requireElement` |
 | `J2clRootShellController` event-detail reads | missing CustomEvent detail | `safeGetString/Boolean` |
 
+## 13b. J2CL ↔ Host/Lit DOM Contract Tokens (#1269)
+
+`org.waveprotocol.box.j2cl.common.J2clUiTokens` is the **single source of truth
+for the DOM contract** between the J2CL Java surfaces and the host page / Lit
+layer: custom-event names (`EVENT_NAV_*`, `EVENT_DEPTH_*`, the shell/compose
+body events, `EVENT_BLIP_TASK_TOGGLED`), the `data-j2cl-*` host attributes, and
+custom-element tags. Previously these literals were scattered across the Java
+sources and duplicated on the Lit side, so a typo only failed at runtime in the
+compiled JS and a rename meant hunting every call site.
+
+Rules:
+- Java call sites reference the constants (e.g. `J2clUiTokens.EVENT_NAV_RECENT`);
+  the nav family can be iterated via `J2clUiTokens.EVENTS_NAV`.
+- The Lit vocabulary in `j2cl/lit/src/` (nav-row events, `data-j2cl-*` attrs)
+  must stay in sync with these values; `J2clUiTokensTest` pins each value to its
+  exact wire string so a drift is caught at build time.
+- Adding/renaming a nav event or data attribute touches `J2clUiTokens` + the call
+  sites only.
+
+Migrated first: the selected-wave view and root-shell controller (nav, depth,
+shell/compose body events, and the `data-j2cl-inline-rich-composer` /
+`data-j2cl-read-surface-preview` helpers). Remaining files (renderer, search
+panel, compose views) adopt the constants incrementally; standard DOM events
+(`scroll`) intentionally stay literal.
+
 ## 14. Bottom Line
 
 The repo should not choose between:

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/common/J2clUiTokens.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/common/J2clUiTokens.java
@@ -1,5 +1,9 @@
 package org.waveprotocol.box.j2cl.common;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * #1269: the single source of truth for the DOM contract between the J2CL Java
  * surfaces and the host page / Lit layer — custom-event names and the
@@ -30,19 +34,20 @@ public final class J2clUiTokens {
   public static final String EVENT_NAV_PIN_TOGGLE = "wave-nav-pin-toggle-requested";
   public static final String EVENT_NAV_VERSION_HISTORY = "wave-nav-version-history-requested";
 
-  /** All nav-row event names, in nav-row order. Useful for bulk binding / audit. */
-  public static final String[] EVENTS_NAV = {
-    EVENT_NAV_RECENT,
-    EVENT_NAV_NEXT_UNREAD,
-    EVENT_NAV_PREVIOUS,
-    EVENT_NAV_NEXT,
-    EVENT_NAV_END,
-    EVENT_NAV_PREV_MENTION,
-    EVENT_NAV_NEXT_MENTION,
-    EVENT_NAV_ARCHIVE_TOGGLE,
-    EVENT_NAV_PIN_TOGGLE,
-    EVENT_NAV_VERSION_HISTORY
-  };
+  /** All nav-row event names, in nav-row order (immutable). For bulk binding / audit. */
+  public static final List<String> EVENTS_NAV =
+      Collections.unmodifiableList(
+          Arrays.asList(
+              EVENT_NAV_RECENT,
+              EVENT_NAV_NEXT_UNREAD,
+              EVENT_NAV_PREVIOUS,
+              EVENT_NAV_NEXT,
+              EVENT_NAV_END,
+              EVENT_NAV_PREV_MENTION,
+              EVENT_NAV_NEXT_MENTION,
+              EVENT_NAV_ARCHIVE_TOGGLE,
+              EVENT_NAV_PIN_TOGGLE,
+              EVENT_NAV_VERSION_HISTORY));
 
   // ---- Depth navigation events (from <wavy-depth-nav-bar>) ----
   public static final String EVENT_DEPTH_DRILL_IN = "wavy-depth-drill-in";
@@ -50,10 +55,10 @@ public final class J2clUiTokens {
   public static final String EVENT_DEPTH_ROOT = "wavy-depth-root";
   public static final String EVENT_DEPTH_JUMP_TO_CRUMB = "wavy-depth-jump-to-crumb";
 
-  /** Depth-nav telemetry event set (the up/root/jump-to-crumb chrome clicks). */
-  public static final String[] EVENTS_DEPTH_CHROME = {
-    EVENT_DEPTH_UP, EVENT_DEPTH_ROOT, EVENT_DEPTH_JUMP_TO_CRUMB
-  };
+  /** Depth-nav telemetry event set (the up/root/jump-to-crumb chrome clicks; immutable). */
+  public static final List<String> EVENTS_DEPTH_CHROME =
+      Collections.unmodifiableList(
+          Arrays.asList(EVENT_DEPTH_UP, EVENT_DEPTH_ROOT, EVENT_DEPTH_JUMP_TO_CRUMB));
 
   // ---- Shell / compose body-level events ----
   public static final String EVENT_NEW_WAVE_REQUESTED = "wavy-new-wave-requested";
@@ -80,4 +85,13 @@ public final class J2clUiTokens {
   public static final String DATA_ATTR_ROOT_RETURN_TARGET = "data-j2cl-root-return-target";
   public static final String DATA_ATTR_ROOT_SIGNIN = "data-j2cl-root-signin";
   public static final String DATA_ATTR_ROOT_SIGNOUT = "data-j2cl-root-signout";
+
+  // ---- Root-shell host classes (created by the shell controller) ----
+  public static final String CSS_CLASS_ROOT_CREATE_HOST = "j2cl-root-create-host";
+  public static final String CSS_CLASS_ROOT_TOOLBAR_HOST = "j2cl-root-toolbar-host";
+  public static final String CSS_CLASS_ROOT_REPLY_HOST = "j2cl-root-reply-host";
+
+  // ---- Root-shell element ids ----
+  public static final String HOST_ID_LIVE_STATUS = "j2cl-root-live-status-text";
+  public static final String HOST_ID_LIVE_STATUS_SEPARATOR = "j2cl-root-live-status-separator";
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/common/J2clUiTokens.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/common/J2clUiTokens.java
@@ -1,0 +1,83 @@
+package org.waveprotocol.box.j2cl.common;
+
+/**
+ * #1269: the single source of truth for the DOM contract between the J2CL Java
+ * surfaces and the host page / Lit layer — custom-event names and the
+ * {@code data-j2cl-*} attributes.
+ *
+ * <p>Previously these literals were scattered (and duplicated on the Lit side),
+ * so a typo only failed at runtime in the compiled JS and a rename meant hunting
+ * every call site. Adding or renaming a nav event / data attribute now touches
+ * this file plus the call sites; the Lit vocabulary in {@code j2cl/lit/src/}
+ * must stay in sync with the values here.
+ *
+ * <p>Values are the exact wire strings; do not change them without updating the
+ * Lit side and any test that dispatches the literal.
+ */
+public final class J2clUiTokens {
+
+  private J2clUiTokens() {}
+
+  // ---- Wave navigation-row events (bubbles + composed from <wavy-wave-nav-row>) ----
+  public static final String EVENT_NAV_RECENT = "wave-nav-recent-requested";
+  public static final String EVENT_NAV_NEXT_UNREAD = "wave-nav-next-unread-requested";
+  public static final String EVENT_NAV_PREVIOUS = "wave-nav-previous-requested";
+  public static final String EVENT_NAV_NEXT = "wave-nav-next-requested";
+  public static final String EVENT_NAV_END = "wave-nav-end-requested";
+  public static final String EVENT_NAV_PREV_MENTION = "wave-nav-prev-mention-requested";
+  public static final String EVENT_NAV_NEXT_MENTION = "wave-nav-next-mention-requested";
+  public static final String EVENT_NAV_ARCHIVE_TOGGLE = "wave-nav-archive-toggle-requested";
+  public static final String EVENT_NAV_PIN_TOGGLE = "wave-nav-pin-toggle-requested";
+  public static final String EVENT_NAV_VERSION_HISTORY = "wave-nav-version-history-requested";
+
+  /** All nav-row event names, in nav-row order. Useful for bulk binding / audit. */
+  public static final String[] EVENTS_NAV = {
+    EVENT_NAV_RECENT,
+    EVENT_NAV_NEXT_UNREAD,
+    EVENT_NAV_PREVIOUS,
+    EVENT_NAV_NEXT,
+    EVENT_NAV_END,
+    EVENT_NAV_PREV_MENTION,
+    EVENT_NAV_NEXT_MENTION,
+    EVENT_NAV_ARCHIVE_TOGGLE,
+    EVENT_NAV_PIN_TOGGLE,
+    EVENT_NAV_VERSION_HISTORY
+  };
+
+  // ---- Depth navigation events (from <wavy-depth-nav-bar>) ----
+  public static final String EVENT_DEPTH_DRILL_IN = "wavy-depth-drill-in";
+  public static final String EVENT_DEPTH_UP = "wavy-depth-up";
+  public static final String EVENT_DEPTH_ROOT = "wavy-depth-root";
+  public static final String EVENT_DEPTH_JUMP_TO_CRUMB = "wavy-depth-jump-to-crumb";
+
+  /** Depth-nav telemetry event set (the up/root/jump-to-crumb chrome clicks). */
+  public static final String[] EVENTS_DEPTH_CHROME = {
+    EVENT_DEPTH_UP, EVENT_DEPTH_ROOT, EVENT_DEPTH_JUMP_TO_CRUMB
+  };
+
+  // ---- Shell / compose body-level events ----
+  public static final String EVENT_NEW_WAVE_REQUESTED = "wavy-new-wave-requested";
+  public static final String EVENT_NEW_WITH_PARTICIPANTS = "wave-new-with-participants-requested";
+  public static final String EVENT_ADD_PARTICIPANT = "wave-add-participant-requested";
+  public static final String EVENT_PUBLICITY_TOGGLE = "wave-publicity-toggle-requested";
+  public static final String EVENT_ROOT_LOCK_TOGGLE = "wave-root-lock-toggle-requested";
+  public static final String EVENT_BACK_TO_INBOX_CLICKED = "wavy-back-to-inbox-clicked";
+  public static final String EVENT_SELECTED_WAVE_REFRESH = "wavy-selected-wave-refresh-requested";
+
+  // ---- Blip / read-surface events ----
+  public static final String EVENT_BLIP_TASK_TOGGLED = "wave-blip-task-toggled";
+
+  // ---- Lifecycle / page events ----
+  public static final String EVENT_PAGE_HIDE = "pagehide";
+  public static final String EVENT_SCROLL = "scroll";
+
+  // ---- Custom element tags ----
+  public static final String CUSTOM_ELEMENT_DEPTH_NAV_BAR = "wavy-depth-nav-bar";
+
+  // ---- data-j2cl-* host attributes ----
+  public static final String DATA_ATTR_INLINE_RICH_COMPOSER = "data-j2cl-inline-rich-composer";
+  public static final String DATA_ATTR_READ_SURFACE_PREVIEW = "data-j2cl-read-surface-preview";
+  public static final String DATA_ATTR_ROOT_RETURN_TARGET = "data-j2cl-root-return-target";
+  public static final String DATA_ATTR_ROOT_SIGNIN = "data-j2cl-root-signin";
+  public static final String DATA_ATTR_ROOT_SIGNOUT = "data-j2cl-root-signout";
+}

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -13,6 +13,7 @@ import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceController;
 import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceController.CreateSuccessHandler;
 import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceController.ReplySuccessHandler;
 import org.waveprotocol.box.j2cl.compose.J2clComposeSurfaceView;
+import org.waveprotocol.box.j2cl.common.J2clUiTokens;
 import org.waveprotocol.box.j2cl.notify.J2clDomNotificationService;
 import org.waveprotocol.box.j2cl.notify.J2clNotificationService;
 import org.waveprotocol.box.j2cl.search.J2clSearchGateway;
@@ -200,23 +201,23 @@ public final class J2clRootShellController implements org.waveprotocol.box.j2cl.
     // form's title input. Listening on document.body so the event bubbles
     // up regardless of where the rail is currently mounted.
     disposeRegistry.addListener(elemental2.dom.DomGlobal.document.body, 
-        "wavy-new-wave-requested",
+        J2clUiTokens.EVENT_NEW_WAVE_REQUESTED,
         evt -> composeController.focusCreateSurface(newWaveTriggerFromEvent(evt)));
     disposeRegistry.addListener(elemental2.dom.DomGlobal.document.body, 
-        "wave-new-with-participants-requested",
+        J2clUiTokens.EVENT_NEW_WITH_PARTICIPANTS,
         evt -> composeController.onCreateRequestedWithParticipants(participantsFromEvent(evt)));
     disposeRegistry.addListener(elemental2.dom.DomGlobal.document.body, 
-        "wave-add-participant-requested",
+        J2clUiTokens.EVENT_ADD_PARTICIPANT,
         evt ->
             composeController.onAddParticipantsRequested(
                 sourceWaveIdFromEvent(evt), addParticipantAddressesFromEvent(evt)));
     disposeRegistry.addListener(elemental2.dom.DomGlobal.document.body, 
-        "wave-publicity-toggle-requested",
+        J2clUiTokens.EVENT_PUBLICITY_TOGGLE,
         evt ->
             composeController.onPublicityToggleRequested(
                 sourceWaveIdFromEvent(evt), nextPublicFromEvent(evt)));
     disposeRegistry.addListener(elemental2.dom.DomGlobal.document.body, 
-        "wave-root-lock-toggle-requested",
+        J2clUiTokens.EVENT_ROOT_LOCK_TOGGLE,
         evt ->
             composeController.onLockStateToggleRequested(
                 sourceWaveIdFromEvent(evt),
@@ -271,7 +272,7 @@ public final class J2clRootShellController implements org.waveprotocol.box.j2cl.
     // returning to the inbox is an instant in-shell transition (the anchor
     // href stays functional for middle-click / no-JS fallbacks).
     disposeRegistry.addListener(DomGlobal.document.body, 
-        "wavy-back-to-inbox-clicked",
+        J2clUiTokens.EVENT_BACK_TO_INBOX_CLICKED,
         event -> {
           event.preventDefault();
           // #1271: a wave switch should not carry stale error toasts across.
@@ -280,7 +281,7 @@ public final class J2clRootShellController implements org.waveprotocol.box.j2cl.
         });
     // #1268: final teardown on navigation away releases the selected-wave view's
     // listeners (which cascade to the read surface) so they do not leak.
-    disposeRegistry.addListener(DomGlobal.window, "pagehide", event -> destroy());
+    disposeRegistry.addListener(DomGlobal.window, J2clUiTokens.EVENT_PAGE_HIDE, event -> destroy());
     liveSurfaceController.start();
   }
 
@@ -324,7 +325,7 @@ public final class J2clRootShellController implements org.waveprotocol.box.j2cl.
     // #j2cl-root-shell-workflow section where the controller is mounted.
     elemental2.dom.Element shellRoot = host.closest("shell-root");
     elemental2.dom.Element target = shellRoot != null ? shellRoot : host;
-    return "true".equals(target.getAttribute("data-j2cl-inline-rich-composer"));
+    return "true".equals(target.getAttribute(J2clUiTokens.DATA_ATTR_INLINE_RICH_COMPOSER));
   }
 
   static boolean isReadSurfacePreviewHost(boolean hostMarked, boolean bodyMarked) {
@@ -334,10 +335,10 @@ public final class J2clRootShellController implements org.waveprotocol.box.j2cl.
   private boolean isReadSurfacePreviewHost(HTMLElement candidate) {
     boolean hostMarked =
         candidate != null
-            && "true".equals(candidate.getAttribute("data-j2cl-read-surface-preview"));
+            && "true".equals(candidate.getAttribute(J2clUiTokens.DATA_ATTR_READ_SURFACE_PREVIEW));
     HTMLElement body = (HTMLElement) elemental2.dom.DomGlobal.document.body;
     boolean bodyMarked =
-        body != null && "true".equals(body.getAttribute("data-j2cl-read-surface-preview"));
+        body != null && "true".equals(body.getAttribute(J2clUiTokens.DATA_ATTR_READ_SURFACE_PREVIEW));
     return isReadSurfacePreviewHost(hostMarked, bodyMarked);
   }
 
@@ -451,7 +452,7 @@ public final class J2clRootShellController implements org.waveprotocol.box.j2cl.
     }
     disposeRegistry.addListener(
         card,
-        "wavy-depth-drill-in",
+        J2clUiTokens.EVENT_DEPTH_DRILL_IN,
         evt -> {
           Object detail = Js.asPropertyMap(evt).get("detail");
           if (detail == null) {
@@ -469,7 +470,7 @@ public final class J2clRootShellController implements org.waveprotocol.box.j2cl.
         });
     disposeRegistry.addListener(
         card,
-        "wavy-depth-up",
+        J2clUiTokens.EVENT_DEPTH_UP,
         evt -> {
           Object detail = Js.asPropertyMap(evt).get("detail");
           String parentId = "";
@@ -486,14 +487,14 @@ public final class J2clRootShellController implements org.waveprotocol.box.j2cl.
         });
     disposeRegistry.addListener(
         card,
-        "wavy-depth-root",
+        J2clUiTokens.EVENT_DEPTH_ROOT,
         (Event evt) -> {
           routeController.onDepthChanged(null);
           view.setDepthFocus("", "", "");
         });
     disposeRegistry.addListener(
         card,
-        "wavy-depth-jump-to-crumb",
+        J2clUiTokens.EVENT_DEPTH_JUMP_TO_CRUMB,
         evt -> {
           Object detail = Js.asPropertyMap(evt).get("detail");
           String blipId = "";

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/root/J2clRootShellController.java
@@ -82,11 +82,11 @@ public final class J2clRootShellController implements org.waveprotocol.box.j2cl.
     this.selectedWaveView = selectedWaveView;
     HTMLElement selectedWaveComposeHost = selectedWaveView.getComposeHost();
     HTMLElement selectedCreateHost =
-        createSiblingHostBefore(selectedWaveComposeHost, "j2cl-root-create-host");
+        createSiblingHostBefore(selectedWaveComposeHost, J2clUiTokens.CSS_CLASS_ROOT_CREATE_HOST);
     HTMLElement selectedToolbarHost =
-        createChildHost(selectedWaveComposeHost, "j2cl-root-toolbar-host");
+        createChildHost(selectedWaveComposeHost, J2clUiTokens.CSS_CLASS_ROOT_TOOLBAR_HOST);
     HTMLElement selectedReplyHost =
-        createChildHost(selectedWaveComposeHost, "j2cl-root-reply-host");
+        createChildHost(selectedWaveComposeHost, J2clUiTokens.CSS_CLASS_ROOT_REPLY_HOST);
     boolean inlineRichComposerEnabled = isInlineRichComposerEnabled(host);
     String rootShellSessionSeed = buildRootShellSessionSeed();
     final J2clSearchPanelController[] searchControllerRef = new J2clSearchPanelController[1];

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -506,7 +506,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
    * controller wiring on top.
    */
   private void bindChromeEvents(HTMLElement card, J2clClientTelemetry.Sink sink) {
-    String[] navEvents = J2clUiTokens.EVENTS_NAV;
+    List<String> navEvents = J2clUiTokens.EVENTS_NAV;
     for (final String navEvent : navEvents) {
       disposeRegistry.addListener(
           card,
@@ -522,7 +522,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
             }
           });
     }
-    String[] depthEvents = J2clUiTokens.EVENTS_DEPTH_CHROME;
+    List<String> depthEvents = J2clUiTokens.EVENTS_DEPTH_CHROME;
     for (final String depthEvent : depthEvents) {
       disposeRegistry.addListener(
           card,

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -23,6 +23,7 @@ import jsinterop.base.JsPropertyMap;
 import org.waveprotocol.box.j2cl.common.Disposable;
 import org.waveprotocol.box.j2cl.common.J2clDisposeRegistry;
 import org.waveprotocol.box.j2cl.common.J2clJsInteropUtils;
+import org.waveprotocol.box.j2cl.common.J2clUiTokens;
 import org.waveprotocol.box.j2cl.i18n.J2clI18n;
 import org.waveprotocol.box.j2cl.overlay.J2clInteractionBlipModel;
 import org.waveprotocol.box.j2cl.overlay.J2clMentionRange;
@@ -173,7 +174,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
 
     // F-2 slice 2 (#1046, R-3.7-chrome): depth-nav bar (G.2 + G.3).
     // Hidden by default until S5 writes a current depth.
-    depthNavBar = (HTMLElement) DomGlobal.document.createElement("wavy-depth-nav-bar");
+    depthNavBar = (HTMLElement) DomGlobal.document.createElement(J2clUiTokens.CUSTOM_ELEMENT_DEPTH_NAV_BAR);
     depthNavBar.setAttribute("hidden", "");
     coldCard.appendChild(depthNavBar);
 
@@ -263,12 +264,12 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
    */
   private static HTMLElement ensureDepthNavBar(HTMLElement card) {
     removeSelectedWaveEyebrow(card);
-    HTMLElement existing = (HTMLElement) card.querySelector("wavy-depth-nav-bar");
+    HTMLElement existing = (HTMLElement) card.querySelector(J2clUiTokens.CUSTOM_ELEMENT_DEPTH_NAV_BAR);
     if (existing != null) {
       return existing;
     }
     HTMLElement bar =
-        (HTMLElement) DomGlobal.document.createElement("wavy-depth-nav-bar");
+        (HTMLElement) DomGlobal.document.createElement(J2clUiTokens.CUSTOM_ELEMENT_DEPTH_NAV_BAR);
     bar.setAttribute("hidden", "");
     card.insertBefore(bar, card.firstChild);
     return bar;
@@ -382,7 +383,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     }
     disposeRegistry.addListener(
         contentList,
-        "wave-blip-task-toggled",
+        J2clUiTokens.EVENT_BLIP_TASK_TOGGLED,
         evt -> {
           Object detail = jsinterop.base.Js.asPropertyMap(evt).get("detail");
           if (detail == null) {
@@ -481,7 +482,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     }
     disposeRegistry.addListener(
         card,
-        "wavy-selected-wave-refresh-requested",
+        J2clUiTokens.EVENT_SELECTED_WAVE_REFRESH,
         evt -> {
           if (selectedWaveRefreshHandler == null) {
             return;
@@ -505,18 +506,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
    * controller wiring on top.
    */
   private void bindChromeEvents(HTMLElement card, J2clClientTelemetry.Sink sink) {
-    String[] navEvents = {
-      "wave-nav-recent-requested",
-      "wave-nav-next-unread-requested",
-      "wave-nav-previous-requested",
-      "wave-nav-next-requested",
-      "wave-nav-end-requested",
-      "wave-nav-prev-mention-requested",
-      "wave-nav-next-mention-requested",
-      "wave-nav-archive-toggle-requested",
-      "wave-nav-pin-toggle-requested",
-      "wave-nav-version-history-requested"
-    };
+    String[] navEvents = J2clUiTokens.EVENTS_NAV;
     for (final String navEvent : navEvents) {
       disposeRegistry.addListener(
           card,
@@ -532,7 +522,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
             }
           });
     }
-    String[] depthEvents = {"wavy-depth-up", "wavy-depth-root", "wavy-depth-jump-to-crumb"};
+    String[] depthEvents = J2clUiTokens.EVENTS_DEPTH_CHROME;
     for (final String depthEvent : depthEvents) {
       disposeRegistry.addListener(
           card,
@@ -554,17 +544,18 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     // #1273: the nav-row events are thin callers into the single focus owner.
     // #1268: bound through the dispose registry so they are removed on destroy().
     disposeRegistry.addListener(
-        card, "wave-nav-recent-requested", evt -> blipFocus.focusMostRecent());
+        card, J2clUiTokens.EVENT_NAV_RECENT, evt -> blipFocus.focusMostRecent());
     disposeRegistry.addListener(
-        card, "wave-nav-next-unread-requested", evt -> blipFocus.focusNextMatching("unread", 1));
+        card, J2clUiTokens.EVENT_NAV_NEXT_UNREAD, evt -> blipFocus.focusNextMatching("unread", 1));
     disposeRegistry.addListener(
-        card, "wave-nav-previous-requested", evt -> blipFocus.focusAdjacent(-1));
-    disposeRegistry.addListener(card, "wave-nav-next-requested", evt -> blipFocus.focusAdjacent(1));
-    disposeRegistry.addListener(card, "wave-nav-end-requested", evt -> blipFocus.focusLast());
+        card, J2clUiTokens.EVENT_NAV_PREVIOUS, evt -> blipFocus.focusAdjacent(-1));
     disposeRegistry.addListener(
-        card, "wave-nav-prev-mention-requested", evt -> blipFocus.focusNextMatching("has-mention", -1));
+        card, J2clUiTokens.EVENT_NAV_NEXT, evt -> blipFocus.focusAdjacent(1));
+    disposeRegistry.addListener(card, J2clUiTokens.EVENT_NAV_END, evt -> blipFocus.focusLast());
     disposeRegistry.addListener(
-        card, "wave-nav-next-mention-requested", evt -> blipFocus.focusNextMatching("has-mention", 1));
+        card, J2clUiTokens.EVENT_NAV_PREV_MENTION, evt -> blipFocus.focusNextMatching("has-mention", -1));
+    disposeRegistry.addListener(
+        card, J2clUiTokens.EVENT_NAV_NEXT_MENTION, evt -> blipFocus.focusNextMatching("has-mention", 1));
   }
 
   /**

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/common/J2clUiTokensTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/common/J2clUiTokensTest.java
@@ -1,0 +1,68 @@
+package org.waveprotocol.box.j2cl.common;
+
+import com.google.j2cl.junit.apt.J2clTestInput;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * #1269: pins the {@link J2clUiTokens} values to their exact wire strings. These
+ * are the DOM contract with the host page / Lit layer — a change here without a
+ * matching Lit-side change silently breaks the runtime, so lock them down.
+ */
+@J2clTestInput(J2clUiTokensTest.class)
+public class J2clUiTokensTest {
+
+  @Test
+  public void navEventValuesAreStable() {
+    Assert.assertEquals("wave-nav-recent-requested", J2clUiTokens.EVENT_NAV_RECENT);
+    Assert.assertEquals("wave-nav-next-unread-requested", J2clUiTokens.EVENT_NAV_NEXT_UNREAD);
+    Assert.assertEquals("wave-nav-previous-requested", J2clUiTokens.EVENT_NAV_PREVIOUS);
+    Assert.assertEquals("wave-nav-next-requested", J2clUiTokens.EVENT_NAV_NEXT);
+    Assert.assertEquals("wave-nav-end-requested", J2clUiTokens.EVENT_NAV_END);
+    Assert.assertEquals("wave-nav-prev-mention-requested", J2clUiTokens.EVENT_NAV_PREV_MENTION);
+    Assert.assertEquals("wave-nav-next-mention-requested", J2clUiTokens.EVENT_NAV_NEXT_MENTION);
+    Assert.assertEquals("wave-nav-archive-toggle-requested", J2clUiTokens.EVENT_NAV_ARCHIVE_TOGGLE);
+    Assert.assertEquals("wave-nav-pin-toggle-requested", J2clUiTokens.EVENT_NAV_PIN_TOGGLE);
+    Assert.assertEquals(
+        "wave-nav-version-history-requested", J2clUiTokens.EVENT_NAV_VERSION_HISTORY);
+  }
+
+  @Test
+  public void depthAndShellEventValuesAreStable() {
+    Assert.assertEquals("wavy-depth-drill-in", J2clUiTokens.EVENT_DEPTH_DRILL_IN);
+    Assert.assertEquals("wavy-depth-up", J2clUiTokens.EVENT_DEPTH_UP);
+    Assert.assertEquals("wavy-depth-root", J2clUiTokens.EVENT_DEPTH_ROOT);
+    Assert.assertEquals("wavy-depth-jump-to-crumb", J2clUiTokens.EVENT_DEPTH_JUMP_TO_CRUMB);
+    Assert.assertEquals("wavy-new-wave-requested", J2clUiTokens.EVENT_NEW_WAVE_REQUESTED);
+    Assert.assertEquals("wave-new-with-participants-requested", J2clUiTokens.EVENT_NEW_WITH_PARTICIPANTS);
+    Assert.assertEquals("wave-add-participant-requested", J2clUiTokens.EVENT_ADD_PARTICIPANT);
+    Assert.assertEquals("wave-publicity-toggle-requested", J2clUiTokens.EVENT_PUBLICITY_TOGGLE);
+    Assert.assertEquals("wave-root-lock-toggle-requested", J2clUiTokens.EVENT_ROOT_LOCK_TOGGLE);
+    Assert.assertEquals("wavy-back-to-inbox-clicked", J2clUiTokens.EVENT_BACK_TO_INBOX_CLICKED);
+    Assert.assertEquals(
+        "wavy-selected-wave-refresh-requested", J2clUiTokens.EVENT_SELECTED_WAVE_REFRESH);
+    Assert.assertEquals("wave-blip-task-toggled", J2clUiTokens.EVENT_BLIP_TASK_TOGGLED);
+  }
+
+  @Test
+  public void dataAttrAndElementValuesAreStable() {
+    Assert.assertEquals("data-j2cl-inline-rich-composer", J2clUiTokens.DATA_ATTR_INLINE_RICH_COMPOSER);
+    Assert.assertEquals("data-j2cl-read-surface-preview", J2clUiTokens.DATA_ATTR_READ_SURFACE_PREVIEW);
+    Assert.assertEquals("wavy-depth-nav-bar", J2clUiTokens.CUSTOM_ELEMENT_DEPTH_NAV_BAR);
+  }
+
+  @Test
+  public void navEventArrayIsCompleteAndUnique() {
+    Assert.assertEquals(10, J2clUiTokens.EVENTS_NAV.length);
+    Set<String> unique = new HashSet<String>();
+    for (String event : J2clUiTokens.EVENTS_NAV) {
+      Assert.assertTrue("duplicate nav event: " + event, unique.add(event));
+    }
+    Assert.assertTrue(unique.contains(J2clUiTokens.EVENT_NAV_RECENT));
+    Assert.assertTrue(unique.contains(J2clUiTokens.EVENT_NAV_VERSION_HISTORY));
+    // The depth-chrome subset is the up/root/jump-to-crumb clicks.
+    Assert.assertEquals(3, J2clUiTokens.EVENTS_DEPTH_CHROME.length);
+  }
+}

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/common/J2clUiTokensTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/common/J2clUiTokensTest.java
@@ -47,22 +47,43 @@ public class J2clUiTokensTest {
   }
 
   @Test
-  public void dataAttrAndElementValuesAreStable() {
-    Assert.assertEquals("data-j2cl-inline-rich-composer", J2clUiTokens.DATA_ATTR_INLINE_RICH_COMPOSER);
-    Assert.assertEquals("data-j2cl-read-surface-preview", J2clUiTokens.DATA_ATTR_READ_SURFACE_PREVIEW);
-    Assert.assertEquals("wavy-depth-nav-bar", J2clUiTokens.CUSTOM_ELEMENT_DEPTH_NAV_BAR);
+  public void lifecycleEventValuesAreStable() {
+    Assert.assertEquals("pagehide", J2clUiTokens.EVENT_PAGE_HIDE);
+    Assert.assertEquals("scroll", J2clUiTokens.EVENT_SCROLL);
   }
 
   @Test
-  public void navEventArrayIsCompleteAndUnique() {
-    Assert.assertEquals(10, J2clUiTokens.EVENTS_NAV.length);
+  public void dataAttrElementAndHostValuesAreStable() {
+    Assert.assertEquals("data-j2cl-inline-rich-composer", J2clUiTokens.DATA_ATTR_INLINE_RICH_COMPOSER);
+    Assert.assertEquals("data-j2cl-read-surface-preview", J2clUiTokens.DATA_ATTR_READ_SURFACE_PREVIEW);
+    Assert.assertEquals("data-j2cl-root-return-target", J2clUiTokens.DATA_ATTR_ROOT_RETURN_TARGET);
+    Assert.assertEquals("data-j2cl-root-signin", J2clUiTokens.DATA_ATTR_ROOT_SIGNIN);
+    Assert.assertEquals("data-j2cl-root-signout", J2clUiTokens.DATA_ATTR_ROOT_SIGNOUT);
+    Assert.assertEquals("wavy-depth-nav-bar", J2clUiTokens.CUSTOM_ELEMENT_DEPTH_NAV_BAR);
+    Assert.assertEquals("j2cl-root-create-host", J2clUiTokens.CSS_CLASS_ROOT_CREATE_HOST);
+    Assert.assertEquals("j2cl-root-toolbar-host", J2clUiTokens.CSS_CLASS_ROOT_TOOLBAR_HOST);
+    Assert.assertEquals("j2cl-root-reply-host", J2clUiTokens.CSS_CLASS_ROOT_REPLY_HOST);
+    Assert.assertEquals("j2cl-root-live-status-text", J2clUiTokens.HOST_ID_LIVE_STATUS);
+    Assert.assertEquals(
+        "j2cl-root-live-status-separator", J2clUiTokens.HOST_ID_LIVE_STATUS_SEPARATOR);
+  }
+
+  @Test
+  public void navEventListIsCompleteUniqueAndImmutable() {
+    Assert.assertEquals(10, J2clUiTokens.EVENTS_NAV.size());
     Set<String> unique = new HashSet<String>();
     for (String event : J2clUiTokens.EVENTS_NAV) {
       Assert.assertTrue("duplicate nav event: " + event, unique.add(event));
     }
     Assert.assertTrue(unique.contains(J2clUiTokens.EVENT_NAV_RECENT));
     Assert.assertTrue(unique.contains(J2clUiTokens.EVENT_NAV_VERSION_HISTORY));
-    // The depth-chrome subset is the up/root/jump-to-crumb clicks.
-    Assert.assertEquals(3, J2clUiTokens.EVENTS_DEPTH_CHROME.length);
+    Assert.assertEquals(3, J2clUiTokens.EVENTS_DEPTH_CHROME.size());
+    // The published arrays are immutable so a caller can't corrupt the contract.
+    try {
+      J2clUiTokens.EVENTS_NAV.set(0, "hacked");
+      Assert.fail("EVENTS_NAV must be immutable");
+    } catch (UnsupportedOperationException expected) {
+      // good
+    }
   }
 }

--- a/wave/config/changelog.d/2026-07-05-j2cl-ui-tokens.json
+++ b/wave/config/changelog.d/2026-07-05-j2cl-ui-tokens.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-07-05-j2cl-ui-tokens",
+  "version": "unreleased",
+  "date": "2026-07-05",
+  "title": "Internal: centralize the new UI's DOM event/attribute contract",
+  "summary": "Developer-facing cleanup: the custom event names and data-attributes that form the contract between the new UI's Java layer and the host page/Lit layer are now defined once in a single constants file, instead of being copy-pasted string literals scattered across the code. This removes a class of typo bugs that only failed at runtime and makes renames a one-file change. No user-visible behavior change.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "New UI (internal): introduced J2clUiTokens as the single source of truth for the J2CL↔host/Lit DOM contract (nav/depth/shell custom event names, data-j2cl-* attributes, custom-element tags), and migrated the selected-wave view and root-shell controller off hard-coded literals. A test pins each token to its wire value so the Lit side can't silently drift."
+      ]
+    }
+  ]
+}

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/HtmlRendererJ2clRootShellIntegrationTest.java
@@ -270,12 +270,14 @@ public final class HtmlRendererJ2clRootShellIntegrationTest extends TestCase {
         "Root-shell New Wave must use a dedicated visible create child host so "
             + "J2clComposeSurfaceView does not clear the reply/toolbar hosts.",
         source.contains(
-            "createSiblingHostBefore(selectedWaveComposeHost, \"j2cl-root-create-host\")"));
+            "createSiblingHostBefore(selectedWaveComposeHost, "
+                + "J2clUiTokens.CSS_CLASS_ROOT_CREATE_HOST)"));
     assertFalse(
         "Root-shell New Wave must not create the dedicated create host inside "
             + "sidecar-selected-compose because that breaks the :empty collapse sentinel.",
         source.contains(
-            "createChildHost(selectedWaveComposeHost, \"j2cl-root-create-host\")"));
+            "createChildHost(selectedWaveComposeHost, "
+                + "J2clUiTokens.CSS_CLASS_ROOT_CREATE_HOST)"));
     assertFalse(
         "Root-shell New Wave must not bind createHost to searchView.getComposeHost(), "
             + "because the root shell hides the legacy search card.",


### PR DESCRIPTION
## Summary

Fixes #1269. Custom-event names, `data-j2cl-*` attributes, and custom-element tags were scattered string literals across the Java sources (and duplicated on the Lit side) — a typo only failed at runtime in the compiled JS, and a rename meant hunting every call site.

### What changed
- **`org.waveprotocol.box.j2cl.common.J2clUiTokens`** (new): the single source of truth for the J2CL ↔ host/Lit DOM contract:
  - `EVENT_NAV_*` (10) + the `EVENTS_NAV` array; `EVENT_DEPTH_*` + `EVENTS_DEPTH_CHROME`
  - shell/compose body events (`EVENT_NEW_WAVE_REQUESTED`, `EVENT_ADD_PARTICIPANT`, `EVENT_PUBLICITY_TOGGLE`, `EVENT_ROOT_LOCK_TOGGLE`, `EVENT_BACK_TO_INBOX_CLICKED`, `EVENT_SELECTED_WAVE_REFRESH`), `EVENT_BLIP_TASK_TOGGLED`
  - `data-j2cl-*` attrs + `CUSTOM_ELEMENT_DEPTH_NAV_BAR`
- Migrated the two primary contract owners — `J2clSelectedWaveView` and `J2clRootShellController` — off the literals (nav/depth/shell body events, refresh, task-toggle, and the `data-j2cl-inline-rich-composer` / `data-j2cl-read-surface-preview` helpers).
- Doc: `docs/j2cl-parity-architecture.md` §13b names `J2clUiTokens` the DOM contract source of truth + the Lit sync rule.

Standard DOM events (`scroll`) intentionally stay literal (not a J2CL-specific magic string, and pinned by an existing SSR guardrail). Remaining files (renderer, search panel, compose views) adopt the constants incrementally.

## Tests
- `J2clUiTokensTest` (new): pins every token to its exact wire string (a rename can't silently drift from the Lit side) + asserts `EVENTS_NAV` is complete (10) and unique.
- `J2clSelectedWaveViewChromeTest` (40) + `J2clRootShellControllerTest` (7) pass unchanged — the constants equal the literals the tests dispatch, so behaviour is identical. Full `./mvnw test` → BUILD SUCCESS.

## Local browser verification (Playwright, `?view=j2cl-root`)
Fresh user, opened the seeded wave: clicking the nav-row "recent" button (now wired via `J2clUiTokens.EVENT_NAV_RECENT`) focuses a blip, **0 console errors** — confirming the value-preserving migration works in the transpiled output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
