### PR TITLE
test(j2cl-lit): measure and gate Lit UI test coverage in CI (#1275)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -963,7 +963,9 @@ ThisBuild / j2clLitTest := {
   if (!(litDir / "node_modules").exists()) {
     runCmd(log)(Seq("npm", "ci"), litDir)
   }
-  runCmd(log)(Seq("npm", "test"), litDir)
+  // #1275: run with coverage so numbers are emitted and the floor thresholds
+  // in web-test-runner.config.mjs gate regressions in CI.
+  runCmd(log)(Seq("npm", "run", "test:coverage"), litDir)
 }
 
 ThisBuild / j2clProductionBuild := {

--- a/j2cl/lit/.gitignore
+++ b/j2cl/lit/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+coverage/

--- a/j2cl/lit/README.md
+++ b/j2cl/lit/README.md
@@ -1,0 +1,49 @@
+# SupaWave Lit shell (`j2cl/lit`)
+
+Lit custom elements and shell controllers for the J2CL root UI (`/?view=j2cl-root`).
+These primitives are composed by the GWT→J2CL parity slices (#964–#971) and are the
+visual/interaction contract with the J2CL Java layer.
+
+## Layout
+
+- `src/elements/` — `wavy-*` / `shell-*` custom elements.
+- `src/` — controllers, i18n catalog, keyboard-shortcut stack, DOM-contract helpers.
+- `test/` — `@web/test-runner` + `@open-wc/testing` unit tests (one or more per element/controller).
+- `web-test-runner.config.mjs` — test-runner + coverage config.
+
+## Running tests
+
+```bash
+npm test                 # fast dev loop, no coverage
+npm run test:coverage    # runs with v8 coverage + threshold gate (what CI runs)
+```
+
+`npm run test:coverage` is what the `j2clLitTest` sbt task (and therefore CI) runs.
+It writes an lcov report to `coverage/` (gitignored) and a text summary to the
+console.
+
+## Coverage gate (#1275)
+
+Coverage is **measured and enforced**. Floor thresholds live in
+`web-test-runner.config.mjs` and are pinned a few points below the current
+baseline (statements ~95.8% / branches ~90.9% / functions ~96.6% / lines ~95.8%),
+so a meaningful regression fails CI while fractional wobbles don't churn.
+
+Raise the thresholds as coverage climbs; **never lower them without justification.**
+
+## The rule: new UI ships with tests
+
+**Every new `wavy-*` / `shell-*` element or controller — and every behavior change
+to an existing one — must include a test in the same PR** that exercises its public
+API and state transitions using the existing `@web/test-runner` + `@open-wc`
+patterns. This keeps the coverage gate green and, more importantly, protects the
+parity contract at review time.
+
+Cross-cutting concerns that must stay covered on the critical chrome surfaces:
+
+- **i18n switching** — see `test/i18n.test.js`.
+- **Keyboard shortcuts** — see `test/shortcuts/` (keybindings, dialog stack, shell-root keys).
+- **Error / loading states** — assert the visible error/empty/loading branches, not just the happy path.
+
+Snapshot + `axe-core` a11y sweeps are encouraged as follow-up once the infra cost is
+evaluated; they are not required by this slice.

--- a/j2cl/lit/package.json
+++ b/j2cl/lit/package.json
@@ -8,7 +8,8 @@
     "audit:buttons": "node scripts/audit-buttons.mjs",
     "prebuild": "node scripts/audit-buttons.mjs",
     "build": "node esbuild.config.mjs",
-    "test": "web-test-runner"
+    "test": "web-test-runner",
+    "test:coverage": "web-test-runner --coverage"
   },
   "dependencies": {
     "lit": "3.2.1"

--- a/j2cl/lit/web-test-runner.config.mjs
+++ b/j2cl/lit/web-test-runner.config.mjs
@@ -1,10 +1,31 @@
 import { playwrightLauncher } from "@web/test-runner-playwright";
 
+// #1275: coverage is measured (v8 -> istanbul) so regressions in the Lit
+// custom elements / shell controllers are visible in CI. It is turned on by
+// the `--coverage` flag (see the `test:coverage` npm script and the
+// j2clLitTest sbt task); the plain `npm test` dev loop stays fast without it.
 export default {
   files: "test/**/*.test.js",
   nodeResolve: true,
   browsers: [playwrightLauncher({ product: "chromium" })],
   testFramework: {
     config: { ui: "bdd", timeout: 5000 }
+  },
+  coverageConfig: {
+    // Only measure the shipped source; test helpers and fixtures don't count.
+    include: ["src/**/*.js"],
+    exclude: ["test/**", "node_modules/**", "**/*.test.js"],
+    reportDir: "coverage",
+    reporters: ["lcov", "text-summary"],
+    // Floor thresholds pinned a few points below the current measured baseline
+    // (statements 95.8 / branches 90.9 / functions 96.6 / lines 95.8) so a
+    // meaningful drop fails CI, without churning on every fractional wobble.
+    // Raise these as coverage climbs; never lower without justification.
+    threshold: {
+      statements: 92,
+      branches: 87,
+      functions: 92,
+      lines: 92
+    }
   }
 };

--- a/wave/config/changelog.d/2026-07-05-j2cl-lit-coverage-gate.json
+++ b/wave/config/changelog.d/2026-07-05-j2cl-lit-coverage-gate.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-07-05-j2cl-lit-coverage-gate",
+  "version": "unreleased",
+  "date": "2026-07-05",
+  "title": "Internal: measure and gate Lit UI test coverage",
+  "summary": "Developer-facing cleanup: the new UI's Lit test suite (897 tests) now reports code coverage and fails CI if it drops below a pinned baseline, so regressions in the custom elements and shell controllers are visible instead of silent. No user-visible behavior change.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "New UI (internal): enabled v8 coverage reporting in the Lit web-test-runner harness with floor thresholds pinned just below the current baseline (statements ~95.8% / branches ~90.9% / functions ~96.6% / lines ~95.8%); the j2clLitTest sbt task now runs it so CI gates regressions. Added a j2cl/lit README documenting the run commands and the rule that every new wavy-*/shell-* element or controller must ship a test in the same PR."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #1275.

The Lit shell already has a strong test surface (**897 tests** across ~130 files covering most `wavy-*`/`shell-*` elements, controllers, i18n, shortcuts, and error states). What was missing per the issue: coverage was **not measured or gated**, so a regression could land silently. This wires that up.

## Changes
- **`web-test-runner.config.mjs`** — added `coverageConfig` (v8 → `lcov` + `text-summary`), scoped to `src/**`, with floor thresholds pinned a few points below the measured baseline.
- **`package.json`** — `test:coverage` = `web-test-runner --coverage`; plain `npm test` stays fast for the dev loop.
- **`build.sbt`** — `j2clLitTest` now runs `npm run test:coverage`, so CI emits numbers and enforces the floor.
- **`j2cl/lit/README.md`** (new) — documents the run commands, the coverage gate, and the enforceable rule: *every new `wavy-*`/`shell-*` element or controller must ship a test in the same PR*. Lists the i18n / shortcuts / error-state surfaces that must stay covered.
- **`.gitignore`** — ignore the generated `coverage/` dir.

## Measured baseline
| Metric | Actual | Floor |
|---|---|---|
| Statements | 95.76% | 92 |
| Branches | 90.88% | 87 |
| Functions | 96.60% | 92 |
| Lines | 95.76% | 92 |

## Verification
- `npm run test:coverage` → **897 passed, 0 failed**, all metrics above floor, exit 0.
- Gate proven real: temporarily raising the branches floor to 95 makes the run **fail** (`Coverage for branches failed with 90.84 % compared to configured 95 %`, exit 1), then reverted.

## Acceptance criteria
- ✅ Lit test command produces coverage reports (lcov + text summary) so regressions are visible in CI.
- ✅ Enforceable "new parity slices must include tests" rule documented in the README.
- ✅ i18n switching (`test/i18n.test.js`), shortcuts (`test/shortcuts/`), and error/loading states already have explicit tests — acknowledged and pinned by the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)