### PR TITLE
fix(deploy): re-enable startup search warmup to stop tripping the sanity gate

### DIFF
--- a/deploy/caddy/application.conf
+++ b/deploy/caddy/application.conf
@@ -64,6 +64,11 @@ client.flags.defaults {
 core.search_type = "lucene"
 search.ot_search_enabled = true
 core.owner_address = "vega@supawave.ai"
+# Warms the shared WaveMap for the owner during startup (before the HTTP
+# listener opens), so the deploy sanity check's first inbox search doesn't
+# have to pay for the full wavelet scan inside its tighter 120s deadline.
+# readyz polling has far more headroom (up to 480s) to absorb this cost.
+search.startup_wave_view_warmup = true
 core.enable_profiling = false
 core.mail_provider = "resend"
 core.email_from_address = ${?WAVE_EMAIL_FROM}

--- a/wave/config/changelog.d/2026-07-05-enable-startup-search-warmup.json
+++ b/wave/config/changelog.d/2026-07-05-enable-startup-search-warmup.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-07-05-enable-startup-search-warmup",
+  "version": "Unreleased",
+  "date": "2026-07-05",
+  "title": "Re-enable startup search warmup on Contabo to stop tripping the deploy sanity gate",
+  "summary": "The deploy sanity check was intermittently failing with 'search returned no waves within 120 s' because the full WaveMap scan (needed to serve the first search request after a cold start) was deferred to that request instead of running at startup. Re-enabling search.startup_wave_view_warmup for the configured owner moves that one-time cost into the readyz warmup window, which has far more headroom (480s) than the sanity gate's 120s deadline.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Set search.startup_wave_view_warmup = true in deploy/caddy/application.conf so the owner's per-user view (and the underlying shared WaveMap) is warmed during server startup instead of lazily on the first real search request",
+        "This removes the race between the deploy sanity check's 120s search deadline and the growing cost of the full wavelet scan as production data accumulates"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- The Contabo deploy sanity check failed twice in a row today (runs [28748994721](https://github.com/vega113/supawave/actions/runs/28748994721/job/85244623706) and [28749795531](https://github.com/vega113/supawave/actions/runs/28749795531/job/85246795861)) with `[sanity] FAIL: search returned no waves within 120 s`, after login succeeded.
- Root cause (confirmed via SSH into the Contabo box and reading the green slot's structured logs): `initializeSearch` completes in tens of milliseconds at startup because the Lucene index is reused, but the *first real search request* for any user lazily triggers `WaveMap.loadAllWavelets()` — a full sequential scan of every wave in MongoDB (229 waves currently). That scan took 60-90+ seconds in the failing runs, blowing past the sanity check's 120s deadline, especially while the still-active blue slot was concurrently hitting the same MongoDB instance.
- This lazy path exists because PR #600 intentionally moved the eager startup warmup behind `search.startup_wave_view_warmup` (default `false`) to keep `readyz` fast — which just relocated the cost to the sanity check's much tighter window instead of eliminating it. `readyz` polling already budgets up to 480s (`SMOKE_RETRIES=240` × 2s), far more headroom than the sanity check's 120s.
- Fix: set `search.startup_wave_view_warmup = true` in `deploy/caddy/application.conf` (the file actually bundled for the Contabo deploy). Since `core.owner_address = vega@supawave.ai` is already configured, this warms the owner's per-user view — and therefore the shared `WaveMap` — synchronously during startup, before the HTTP listener opens. Subsequent search requests (including the sanity check's) land within the 30s shared-cache cooldown and skip the expensive rescan.

## Test plan
- [x] Traced the failure end-to-end via `gh run view --log-failed` and SSH into the Contabo host's structured JSON logs to confirm the root cause (full wavelet scan, not a regression from unrelated same-day J2CL frontend commits).
- [x] Confirmed the next two deploys succeeded once the transient warm-up cost happened to land under 120s, consistent with the timing-sensitive root cause rather than a code regression.
- [ ] Next deploy of `main` will exercise this change — watch for `Pre-warmed wave view for owner ... in <N> ms` in the startup logs and confirm the sanity check passes even when `N` is large.

🤖 Generated with [Claude Code](https://claude.com/claude-code)