### PR TITLE
fix(unread): exclude tombstoned blips from unread state; let next-unread reach unloaded window regions

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clBlipFocusController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clBlipFocusController.java
@@ -124,10 +124,7 @@ public final class J2clBlipFocusController {
       if (blipId == null || blipId.isEmpty() || findBlipById(blipId) != null) {
         continue;
       }
-      HTMLElement placeholder =
-          (HTMLElement)
-              contentList.querySelector(
-                  "[data-placeholder-blip-id='" + blipId + "']");
+      HTMLElement placeholder = findPlaceholderByBlipId(blipId);
       if (placeholder == null) {
         continue;
       }
@@ -329,6 +326,24 @@ public final class J2clBlipFocusController {
     for (HTMLElement blip : renderedBlips()) {
       if (blipId.equals(blipIdOf(blip))) {
         return blip;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Attribute-value comparison instead of selector interpolation: blip ids are
+   * not guaranteed CSS-selector-safe, and an id containing a quote/backslash
+   * would make an interpolated querySelector throw or silently miss.
+   */
+  private HTMLElement findPlaceholderByBlipId(String blipId) {
+    NodeList<Element> placeholders =
+        contentList.querySelectorAll("[data-placeholder-blip-id]");
+    for (int index = 0; index < placeholders.length; index++) {
+      HTMLElement placeholder = (HTMLElement) placeholders.item(index);
+      if (placeholder != null
+          && blipId.equals(placeholder.getAttribute("data-placeholder-blip-id"))) {
+        return placeholder;
       }
     }
     return null;

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clBlipFocusController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clBlipFocusController.java
@@ -84,10 +84,16 @@ public final class J2clBlipFocusController {
     focusBlip(blips.get(next));
   }
 
-  public void focusNextMatching(String attributeName, int direction) {
+  /**
+   * Focuses the next rendered blip carrying {@code attributeName}. Returns
+   * false when no rendered blip matches — e.g. when the only unread blips sit
+   * in unloaded viewport-window placeholder regions — so callers can fall back
+   * to {@link #scrollToUnloadedUnread}.
+   */
+  public boolean focusNextMatching(String attributeName, int direction) {
     List<HTMLElement> blips = renderedBlips();
     if (blips.isEmpty()) {
-      return;
+      return false;
     }
     int current = focusedBlipIndex(blips);
     int start = current < 0 ? (direction > 0 ? -1 : blips.size()) : current;
@@ -96,9 +102,58 @@ public final class J2clBlipFocusController {
       HTMLElement candidate = blips.get(index);
       if (candidate.hasAttribute(attributeName)) {
         focusBlip(candidate);
-        return;
+        return true;
       }
     }
+    return false;
+  }
+
+  /**
+   * Windowed-viewport fallback for "jump to next unread": when the next unread
+   * blip is not rendered (its region is an unloaded placeholder), scroll that
+   * placeholder into view so the renderer's visible-placeholder machinery
+   * fetches its fragment. Returns the blip id whose placeholder was scrolled
+   * into view, or the empty string when no unread blip has a placeholder; the
+   * caller re-focuses the blip once it renders.
+   */
+  public String scrollToUnloadedUnread(List<String> unreadBlipIds) {
+    if (unreadBlipIds == null || unreadBlipIds.isEmpty()) {
+      return "";
+    }
+    for (String blipId : unreadBlipIds) {
+      if (blipId == null || blipId.isEmpty() || findBlipById(blipId) != null) {
+        continue;
+      }
+      HTMLElement placeholder =
+          (HTMLElement)
+              contentList.querySelector(
+                  "[data-placeholder-blip-id='" + blipId + "']");
+      if (placeholder == null) {
+        continue;
+      }
+      ScrollIntoViewOptions scrollOptions = ScrollIntoViewOptions.create();
+      scrollOptions.setBlock("center");
+      scrollOptions.setInline("nearest");
+      placeholder.scrollIntoView(scrollOptions);
+      return blipId;
+    }
+    return "";
+  }
+
+  /**
+   * Focuses (and marks read) the rendered blip with {@code blipId}. Returns
+   * false when the blip is not rendered yet.
+   */
+  public boolean focusBlipById(String blipId) {
+    if (blipId == null || blipId.isEmpty()) {
+      return false;
+    }
+    HTMLElement target = findBlipById(blipId);
+    if (target == null) {
+      return false;
+    }
+    focusBlip(target);
+    return true;
   }
 
   /**

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
@@ -38,6 +38,11 @@ public final class J2clSelectedWaveModel {
   // SidecarSelectedWaveUpdate.getConversationManifest().
   private SidecarConversationManifest conversationManifest = SidecarConversationManifest.empty();
   private String lockState = SidecarSelectedWaveDocument.LOCK_STATE_UNLOCKED;
+  // Unread blip ids from the server read-state endpoint. Unlike the per-blip
+  // unread flags on readBlips (loaded blips only), this list also names unread
+  // blips whose viewport-window regions are still unloaded placeholders, so
+  // "jump to next unread" can navigate to them.
+  private List<String> unreadBlipIds = Collections.emptyList();
 
   J2clSelectedWaveModel(
       boolean hasSelection,
@@ -439,6 +444,20 @@ public final class J2clSelectedWaveModel {
     return this;
   }
 
+  /** Server-reported unread blip ids; may include blips not yet loaded into the viewport. */
+  public List<String> getUnreadBlipIds() {
+    return unreadBlipIds;
+  }
+
+  /** Package-private setter used by the projector. */
+  J2clSelectedWaveModel withUnreadBlipIds(List<String> nextUnreadBlipIds) {
+    this.unreadBlipIds =
+        nextUnreadBlipIds == null || nextUnreadBlipIds.isEmpty()
+            ? Collections.<String>emptyList()
+            : Collections.unmodifiableList(new ArrayList<String>(nextUnreadBlipIds));
+    return this;
+  }
+
   public J2clSelectedWaveViewportState getViewportState() {
     return viewportState;
   }
@@ -480,7 +499,8 @@ public final class J2clSelectedWaveModel {
         // J-UI-4 (#1082, R-3.1): preserve manifest across clones so
         // viewport-windowed renders keep nesting after fragment growth.
         .withConversationManifest(conversationManifest)
-        .withLockState(lockState);
+        .withLockState(lockState)
+        .withUnreadBlipIds(unreadBlipIds);
   }
 
   J2clSelectedWaveModel withReadBlips(List<J2clReadBlip> newReadBlips) {
@@ -506,7 +526,8 @@ public final class J2clSelectedWaveModel {
         readStateKnown,
         readStateStale)
         .withConversationManifest(conversationManifest)
-        .withLockState(lockState);
+        .withLockState(lockState)
+        .withUnreadBlipIds(unreadBlipIds);
   }
 
   J2clSelectedWaveModel withStatus(String nextStatusText, String nextDetailText) {
@@ -534,7 +555,8 @@ public final class J2clSelectedWaveModel {
         readStateKnown,
         readStateStale)
         .withConversationManifest(conversationManifest)
-        .withLockState(lockState);
+        .withLockState(lockState)
+        .withUnreadBlipIds(unreadBlipIds);
   }
 
   public int getUnreadCount() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -203,7 +203,16 @@ public final class J2clSelectedWaveProjector {
         // previous wave's manifest so the next renderWindow() does not
         // fall back to flat threading until a full snapshot resends.
         .withConversationManifest(effectiveManifest)
-        .withLockState(lockState);
+        .withLockState(lockState)
+        // Unread blip ids may name blips in unloaded placeholder regions;
+        // the view uses them so "jump to next unread" can navigate beyond
+        // the loaded viewport window.
+        .withUnreadBlipIds(
+            readStateMatchesWave
+                ? readState.getUnreadBlipIds()
+                : (previousMatchesWave && previous.isReadStateKnown()
+                    ? previous.getUnreadBlipIds()
+                    : Collections.<String>emptyList()));
   }
 
   private static String chooseLockState(
@@ -328,7 +337,11 @@ public final class J2clSelectedWaveProjector {
         // re-projections — read-state updates carry no conversation
         // document and must not flatten threading.
         .withConversationManifest(previous.getConversationManifest())
-        .withLockState(previous.getLockState());
+        .withLockState(previous.getLockState())
+        .withUnreadBlipIds(
+            readStateMatchesWave
+                ? readState.getUnreadBlipIds()
+                : previous.getUnreadBlipIds());
   }
 
   public static List<J2clReadBlip> applyReadStateToReadBlips(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -103,6 +103,12 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   // Set when lastRenderedWaveId transitions to a new (non-empty) wave; cleared
   // once initial focus has been applied to a non-empty rendered surface.
   private String pendingInitialFocusWaveId = "";
+  // Windowed-viewport "jump to next unread": server-reported unread blip ids
+  // from the latest rendered model (may include blips whose regions are still
+  // unloaded placeholders), plus the blip id waiting to be focused once its
+  // placeholder fragment loads and renders.
+  private List<String> lastUnreadBlipIds = Collections.emptyList();
+  private String pendingUnreadJumpBlipId = "";
   // F-3.S3 (#1038, R-5.5): publisher installed by the root shell to
   // forward per-blip reaction snapshots to the compose controller.
   private ReactionSnapshotPublisher reactionSnapshotPublisher;
@@ -546,7 +552,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     disposeRegistry.addListener(
         card, J2clUiTokens.EVENT_NAV_RECENT, evt -> blipFocus.focusMostRecent());
     disposeRegistry.addListener(
-        card, J2clUiTokens.EVENT_NAV_NEXT_UNREAD, evt -> blipFocus.focusNextMatching("unread", 1));
+        card, J2clUiTokens.EVENT_NAV_NEXT_UNREAD, evt -> handleNextUnreadRequested());
     disposeRegistry.addListener(
         card, J2clUiTokens.EVENT_NAV_PREVIOUS, evt -> blipFocus.focusAdjacent(-1));
     disposeRegistry.addListener(
@@ -556,6 +562,31 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
         card, J2clUiTokens.EVENT_NAV_PREV_MENTION, evt -> blipFocus.focusNextMatching("has-mention", -1));
     disposeRegistry.addListener(
         card, J2clUiTokens.EVENT_NAV_NEXT_MENTION, evt -> blipFocus.focusNextMatching("has-mention", 1));
+  }
+
+  /**
+   * "Jump to next unread" with windowed-viewport fallback: prefer the next
+   * rendered blip carrying the {@code unread} attribute; when every rendered
+   * blip is read but the server still reports unread blips, scroll the first
+   * matching unloaded placeholder into view so its fragment loads, then focus
+   * it on the render pass that materializes it (GWT parity — the legacy client
+   * navigates the conversation model, not just the visible DOM).
+   */
+  private void handleNextUnreadRequested() {
+    if (blipFocus.focusNextMatching("unread", 1)) {
+      pendingUnreadJumpBlipId = "";
+      return;
+    }
+    pendingUnreadJumpBlipId = blipFocus.scrollToUnloadedUnread(lastUnreadBlipIds);
+  }
+
+  private void maybeApplyPendingUnreadJump() {
+    if (pendingUnreadJumpBlipId.isEmpty()) {
+      return;
+    }
+    if (blipFocus.focusBlipById(pendingUnreadJumpBlipId)) {
+      pendingUnreadJumpBlipId = "";
+    }
   }
 
   /**
@@ -615,10 +646,12 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     if (!renderedWaveId.equals(lastRenderedWaveId)) {
       readSurface.clearViewportScrollMemory();
       lastRenderedWaveId = renderedWaveId;
+      pendingUnreadJumpBlipId = "";
       if (!renderedWaveId.isEmpty()) {
         pendingInitialFocusWaveId = renderedWaveId;
       }
     }
+    lastUnreadBlipIds = model.getUnreadBlipIds();
     publishReactionState(model);
     // F-2 (#1037, R-3.1) — surface the wave id on the content host so the
     // <wave-blip> renderer can lift it onto each rendered card without
@@ -749,6 +782,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
 
     if (hasRenderedReadSurface) {
       maybeApplyInitialFocus(renderedWaveId, model);
+      maybeApplyPendingUnreadJump();
       blipFocus.restoreFocus();
     }
   }

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clBlipFocusControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clBlipFocusControllerTest.java
@@ -94,6 +94,16 @@ public class J2clBlipFocusControllerTest {
   }
 
   @Test
+  public void scrollToUnloadedUnreadHandlesSelectorUnsafeBlipIds() {
+    assumeBrowserDom();
+    J2clBlipFocusController focus = controllerWithBlips(new ArrayList<String>(), "b1:1");
+    String hostileId = "b+we'ird\\id";
+    appendPlaceholder(hostileId);
+
+    Assert.assertEquals(hostileId, focus.scrollToUnloadedUnread(Arrays.asList(hostileId)));
+  }
+
+  @Test
   public void scrollToUnloadedUnreadSkipsRenderedAndUnknownBlips() {
     assumeBrowserDom();
     J2clBlipFocusController focus = controllerWithBlips(new ArrayList<String>(), "b1:1");

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clBlipFocusControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clBlipFocusControllerTest.java
@@ -5,6 +5,7 @@ import elemental2.dom.DomGlobal;
 import elemental2.dom.Element;
 import elemental2.dom.HTMLElement;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.After;
 import org.junit.Assert;
@@ -68,6 +69,50 @@ public class J2clBlipFocusControllerTest {
     focus.focusNextMatching("unread", 1);
 
     Assert.assertEquals("b3", activeBlipId());
+  }
+
+  @Test
+  public void focusNextMatchingReportsWhetherMatchWasFound() {
+    assumeBrowserDom();
+    J2clBlipFocusController focus = controllerWithBlips(new ArrayList<String>(), "b1:1", "b2:2");
+    blip("b2").setAttribute("unread", "");
+
+    focus.focusBlip(blip("b1"));
+    Assert.assertTrue(focus.focusNextMatching("unread", 1));
+
+    blip("b2").removeAttribute("unread");
+    Assert.assertFalse(focus.focusNextMatching("unread", 1));
+  }
+
+  @Test
+  public void scrollToUnloadedUnreadReturnsPlaceholderBlipId() {
+    assumeBrowserDom();
+    J2clBlipFocusController focus = controllerWithBlips(new ArrayList<String>(), "b1:1", "b2:2");
+    appendPlaceholder("b9");
+
+    Assert.assertEquals("b9", focus.scrollToUnloadedUnread(Arrays.asList("b9")));
+  }
+
+  @Test
+  public void scrollToUnloadedUnreadSkipsRenderedAndUnknownBlips() {
+    assumeBrowserDom();
+    J2clBlipFocusController focus = controllerWithBlips(new ArrayList<String>(), "b1:1");
+
+    // b1 is already rendered (jump handles it); b7 has no placeholder at all.
+    Assert.assertEquals("", focus.scrollToUnloadedUnread(Arrays.asList("b1", "b7")));
+  }
+
+  @Test
+  public void focusBlipByIdFocusesAndMarksRead() {
+    assumeBrowserDom();
+    List<String> read = new ArrayList<String>();
+    J2clBlipFocusController focus = controllerWithBlips(read, "b1:1", "b2:2");
+
+    Assert.assertTrue(focus.focusBlipById("b2"));
+    Assert.assertEquals("b2", activeBlipId());
+    Assert.assertEquals(Arrays.asList("b2"), read);
+
+    Assert.assertFalse(focus.focusBlipById("missing"));
   }
 
   @Test
@@ -151,6 +196,15 @@ public class J2clBlipFocusControllerTest {
 
   private HTMLElement blip(String id) {
     return (HTMLElement) contentList.querySelector("wave-blip[data-blip-id='" + id + "']");
+  }
+
+  /** Mirrors the renderer's unloaded viewport-window placeholder markup. */
+  private void appendPlaceholder(String blipId) {
+    HTMLElement placeholder = (HTMLElement) DomGlobal.document.createElement("div");
+    placeholder.className = "j2cl-read-viewport-placeholder";
+    placeholder.setAttribute("data-j2cl-viewport-placeholder", "true");
+    placeholder.setAttribute("data-placeholder-blip-id", blipId);
+    contentList.appendChild(placeholder);
   }
 
   private static String activeBlipId() {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorReadStateTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorReadStateTest.java
@@ -138,6 +138,69 @@ public class J2clSelectedWaveProjectorReadStateTest extends J2clSelectedWaveProj
   }
 
   @Test
+  public void projectExposesServerUnreadBlipIdsOnModel() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            fragmentUpdate("b+root", "Root text", "b+reply", "Reply text"),
+            null,
+            0,
+            new SidecarSelectedWaveReadState(
+                WAVE_ID, 1, false, Arrays.asList("b+unloaded")),
+            false);
+
+    Assert.assertEquals(Arrays.asList("b+unloaded"), projected.getUnreadBlipIds());
+  }
+
+  @Test
+  public void projectCarriesForwardPreviousUnreadBlipIdsAcrossUpdates() {
+    J2clSelectedWaveModel first =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            sampleUpdate(),
+            null,
+            0,
+            new SidecarSelectedWaveReadState(
+                WAVE_ID, 1, false, Arrays.asList("b+unloaded")),
+            false);
+
+    J2clSelectedWaveModel second =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            sampleUpdate(),
+            first,
+            0);
+
+    Assert.assertEquals(Arrays.asList("b+unloaded"), second.getUnreadBlipIds());
+  }
+
+  @Test
+  public void reprojectReadStateReplacesUnreadBlipIds() {
+    J2clSelectedWaveModel first =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            sampleUpdate(),
+            null,
+            0,
+            new SidecarSelectedWaveReadState(
+                WAVE_ID, 2, false, Arrays.asList("b+one", "b+two")),
+            false);
+
+    J2clSelectedWaveModel reprojected =
+        J2clSelectedWaveProjector.reprojectReadState(
+            first,
+            digest("Wave A", "snippet", 1),
+            new SidecarSelectedWaveReadState(WAVE_ID, 1, false, Arrays.asList("b+two")),
+            false);
+
+    Assert.assertEquals(Arrays.asList("b+two"), reprojected.getUnreadBlipIds());
+  }
+
+  @Test
   public void applyReadStatePreservesExistingBlipMarkersWhenUnreadIdsAreAbsent() {
     java.util.List<J2clReadBlip> blips =
         Arrays.asList(

--- a/wave/config/changelog.d/2026-07-05-unread-count-tombstone-and-window-jump.json
+++ b/wave/config/changelog.d/2026-07-05-unread-count-tombstone-and-window-jump.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-07-05-unread-count-tombstone-and-window-jump",
+  "version": "unreleased",
+  "date": "2026-07-05",
+  "title": "Fix phantom unread counts and \"jump to next unread\" in the new UI",
+  "summary": "Waves could show an unread badge (for example \"1 unread\") even though every visible message was read, and the \"jump to next unread\" toolbar button silently did nothing. Two causes were fixed: deleted messages no longer count as unread, and the jump action can now reach unread messages that sit in a not-yet-loaded part of a long wave.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Unread counts: messages deleted in the new UI leave a hidden tombstone in the conversation, and the server kept counting those tombstones as unread even though no client renders them — producing a permanent phantom unread badge that could never be cleared. The search digest unread count and the read-state endpoint's unread blip list now skip tombstoned blips.",
+        "New UI: \"jump to next unread\" only scanned the blips already rendered in the viewport window, so in long waves it did nothing when the next unread blip lived in a not-yet-loaded placeholder region. The jump now falls back to scrolling that placeholder into view, loads its content, and focuses (and marks read) the blip once it renders — matching the legacy client's model-based navigation."
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveDigester.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveDigester.java
@@ -36,6 +36,7 @@ import org.waveprotocol.wave.model.conversation.ObservableConversationView;
 import org.waveprotocol.wave.model.conversation.TitleHelper;
 import org.waveprotocol.wave.model.conversation.WaveletBasedConversation;
 import org.waveprotocol.wave.model.document.Document;
+import org.waveprotocol.wave.model.document.RangedAnnotation;
 import org.waveprotocol.wave.model.id.IdUtil;
 import org.waveprotocol.wave.model.id.ModernIdSerialiser;
 import org.waveprotocol.wave.model.id.WaveId;
@@ -73,6 +74,7 @@ public class WaveDigester {
   private static final int DIGEST_SNIPPET_LENGTH = 140;
   private static final int PARTICIPANTS_SNIPPET_LENGTH = 5;
   private static final String EMPTY_WAVELET_TITLE = "";
+  private static final String TOMBSTONE_DELETED_ANNOTATION = "tombstone/deleted";
 
   public static final class UnreadBlipState {
     private final int unreadCount;
@@ -361,7 +363,7 @@ public class WaveDigester {
         continue;
       }
       for (ConversationBlip blip : BlipIterators.breadthFirst(conversation)) {
-        if (supplement.isUnread(blip)) {
+        if (supplement.isUnread(blip) && !isTombstoned(blip)) {
           unreadBlipIds.add(blip.getId());
         }
       }
@@ -490,12 +492,35 @@ public class WaveDigester {
         continue;
       }
       for (ConversationBlip blip : BlipIterators.breadthFirst(conversation)) {
-        if (supplement.isUnread(blip)) {
+        if (supplement.isUnread(blip) && !isTombstoned(blip)) {
           unreadCount++;
         }
       }
     }
     return unreadCount;
+  }
+
+  /**
+   * True when the blip carries the J2CL F.6 deletion tombstone
+   * ({@code tombstone/deleted=true} annotation across the blip body). Such
+   * blips remain in the conversation manifest but are never rendered by
+   * clients, so they must not contribute to unread state — a tombstoned
+   * unread blip could otherwise never be marked read.
+   */
+  @VisibleForTesting
+  static boolean isTombstoned(ConversationBlip blip) {
+    Document content = blip.getContent();
+    if (content == null || content.size() == 0) {
+      return false;
+    }
+    for (RangedAnnotation<String> annotation :
+        content.rangedAnnotations(0, content.size(),
+            CollectionUtils.newStringSet(TOMBSTONE_DELETED_ANNOTATION))) {
+      if ("true".equals(annotation.value())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private ObservableConversation chooseDigestConversation(ObservableConversationView conversations) {

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveDigester.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveDigester.java
@@ -48,6 +48,7 @@ import org.waveprotocol.wave.model.supplement.SupplementedWaveImpl;
 import org.waveprotocol.wave.model.supplement.SupplementedWaveImpl.DefaultFollow;
 import org.waveprotocol.wave.model.supplement.WaveletBasedSupplement;
 import org.waveprotocol.wave.model.util.CollectionUtils;
+import org.waveprotocol.wave.model.util.ReadableStringSet;
 import org.waveprotocol.wave.model.wave.ParticipantId;
 import org.waveprotocol.wave.model.wave.ParticipantIdUtil;
 import org.waveprotocol.wave.model.wave.data.ReadableBlipData;
@@ -75,6 +76,10 @@ public class WaveDigester {
   private static final int PARTICIPANTS_SNIPPET_LENGTH = 5;
   private static final String EMPTY_WAVELET_TITLE = "";
   private static final String TOMBSTONE_DELETED_ANNOTATION = "tombstone/deleted";
+  // Hoisted out of isTombstoned: it runs once per blip inside the unread
+  // traversal loops, so the key set must not be reallocated per call.
+  private static final ReadableStringSet TOMBSTONE_ANNOTATION_KEYS =
+      CollectionUtils.newStringSet(TOMBSTONE_DELETED_ANNOTATION);
 
   public static final class UnreadBlipState {
     private final int unreadCount;
@@ -514,8 +519,7 @@ public class WaveDigester {
       return false;
     }
     for (RangedAnnotation<String> annotation :
-        content.rangedAnnotations(0, content.size(),
-            CollectionUtils.newStringSet(TOMBSTONE_DELETED_ANNOTATION))) {
+        content.rangedAnnotations(0, content.size(), TOMBSTONE_ANNOTATION_KEYS)) {
       if ("true".equals(annotation.value())) {
         return true;
       }

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveDigesterTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveDigesterTest.java
@@ -35,6 +35,7 @@ import org.waveprotocol.box.server.robots.operations.TestingWaveletData;
 import org.waveprotocol.box.server.robots.util.ConversationUtil;
 import org.waveprotocol.wave.model.conversation.ConversationBlip;
 import org.waveprotocol.wave.model.conversation.ObservableConversationView;
+import org.waveprotocol.wave.model.document.Document;
 import org.waveprotocol.wave.model.document.util.EmptyDocument;
 import org.waveprotocol.wave.model.id.IdGenerator;
 import org.waveprotocol.wave.model.id.WaveletId;
@@ -276,6 +277,59 @@ public class WaveDigesterTest extends TestCase {
     Map<ObservableWaveletData, OpBasedWavelet> waveletAdapters = new IdentityHashMap<>();
     int unreadCount = digester.countUnread(CROSS_DOMAIN_VIEWER, context, waveletAdapters);
     assertEquals(0, unreadCount);
+  }
+
+  /**
+   * J2CL blip deletion (F.6) writes a {@code tombstone/deleted=true}
+   * annotation across the blip body and leaves the blip in the conversation
+   * manifest. Clients never render tombstoned blips, so counting them as
+   * unread produces a phantom unread badge that can never be cleared.
+   */
+  public void testTombstonedBlipIsExcludedFromUnreadCount() {
+    TestingWaveletData data =
+        new TestingWaveletData(WAVE_ID, CONVERSATION_WAVELET_ID, PARTICIPANT, true);
+    data.appendBlipWithText("blip number 1");
+    ConversationBlip deletedBlip = data.appendBlipWithTextAndReturn("deleted blip");
+    Document deletedContent = deletedBlip.getContent();
+    deletedContent.setAnnotation(
+        0, deletedContent.size(), "tombstone/deleted", "true");
+    ObservableWaveletData observableWaveletData = data.copyWaveletData().get(0);
+    ObservableWavelet wavelet = OpBasedWavelet.createReadOnly(observableWaveletData);
+    ObservableConversationView conversation = conversationUtil.buildConversation(wavelet);
+
+    SupplementedWave supplement = mock(SupplementedWave.class);
+    when(supplement.isUnread(any(ConversationBlip.class))).thenReturn(true);
+
+    Digest digest =
+        digester.generateDigest(
+            conversation,
+            supplement,
+            observableWaveletData,
+            Collections.singletonList(observableWaveletData));
+
+    assertEquals(1, digest.getUnreadCount());
+  }
+
+  /**
+   * The read-state endpoint's unread blip ids must skip tombstoned blips for
+   * the same reason as the digest unread count: the J2CL read surface never
+   * renders them, so "jump to next unread" could never reach them.
+   */
+  public void testTombstonedBlipIsExcludedFromUnreadBlipIds() {
+    TestingWaveletData data =
+        new TestingWaveletData(WAVE_ID, CONVERSATION_WAVELET_ID, PARTICIPANT, true);
+    ConversationBlip liveBlip = data.appendBlipWithTextAndReturn("live blip");
+    ConversationBlip deletedBlip = data.appendBlipWithTextAndReturn("deleted blip");
+    Document deletedContent = deletedBlip.getContent();
+    deletedContent.setAnnotation(
+        0, deletedContent.size(), "tombstone/deleted", "true");
+
+    WaveDigester.UnreadBlipState unreadState =
+        digester.getUnreadBlipState(PARTICIPANT, data.copyViewData());
+
+    assertEquals(Collections.singletonList(liveBlip.getId()),
+        unreadState.getUnreadBlipIds());
+    assertEquals(1, unreadState.getUnreadCount());
   }
 
   /**


### PR DESCRIPTION
## Problem

Waves in the Lit/J2CL UI could show an unread badge (e.g. **1 unread** on wave `supawave.ai/w+S7EXc3lMwcI`) while every visible blip was read, and the **jump to next unread** toolbar action silently did nothing.

## Root causes

1. **Server counts deleted (tombstoned) blips as unread — permanent phantom badge.**
   J2CL blip deletion (F.6) writes a `tombstone/deleted=true` annotation across the blip body and leaves the blip in the conversation manifest. The delete op bumps the blip's last-modified version past every participant's read marks, so `WaveDigester.countUnread` / `collectUnreadBlipIds` counted the tombstone as unread — but no client renders tombstoned blips (`J2clReadSurfaceDomRenderer.normalizeBlips` drops them), so the badge showed a count that could never be cleared and the jump action had nothing to focus.

2. **Client jump only scans the rendered viewport window.**
   `J2clBlipFocusController.focusNextMatching` walked rendered DOM only, so in long waves an unread blip inside an unloaded placeholder region was unreachable even when the badge was correct.

## Fix

- **Server:** `WaveDigester` now skips blips carrying the tombstone annotation in both the digest unread count and the read-state endpoint's unread blip ids (shared `isTombstoned` helper; both paths already shared the same walk). Existing poisoned supplements self-heal since unread state is derived, not stored.
- **Client:** the read-state endpoint's `unreadBlipIds` are plumbed through `J2clSelectedWaveModel` (same late-field pattern as `conversationManifest`). `focusNextMatching` now reports whether it focused anything; when it doesn't but the server still reports unread blips, the view scrolls the first matching unloaded placeholder into view (which triggers the existing visible-placeholder fragment fetch) and focuses/marks the blip read on the render pass that materializes it — GWT parity with model-based navigation.

## Tests

- `WaveDigesterTest`: 2 new tests (tombstoned blip excluded from unread count and from unread blip ids) — watched fail before the fix, green after; full waveserver + supplement suites green (395).
- `J2clSelectedWaveProjectorReadStateTest`: 3 new tests for `unreadBlipIds` plumbing (project / carry-forward / reproject).
- `J2clBlipFocusControllerTest`: 4 new browser-DOM cases (`focusNextMatching` boolean, placeholder scroll fallback, `focusBlipById`).
- `MarkBlipReadServletTest`, `SelectedWaveReadStateServletTest`, jakarta `J2clStageOneReadSurfaceParityTest` green.

## Local verification (staged server, port 9899, fresh QA user, real UI)

Playwright flow: register → sign in → open welcome wave → mark all 6 blips read → **delete a blip via the wave-blip toolbar** → poll `/read-state` and `/search/`:

- `PASS: tombstoned blip not counted unread in /read-state` (`unreadCount: 0`, `unreadBlipIds: []`) — before the fix this became a permanent phantom `1 unread`.
- `PASS: search digest unread badge agrees with read-state and excludes the tombstone`.
- `PASS: no sidecar page errors during flow` (jump click included; known pre-existing GWT `webclient.nocache.js` bootstrap flake filtered).

## Follow-up (task chip spawned)

Mention prev/next navigation has the same windowing gap but needs server-side mention-location support; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unread counts now ignore deleted/tombstoned messages, keeping badges and unread lists accurate.
  * “Jump to next unread” now works across long conversations, including unread items that haven’t loaded yet.
  * Navigation to unread content is more reliable and now clearly reports when no match is found.

* **New Features**
  * Improved unread navigation can scroll unloaded items into view and focus them once available.
  * Read-state handling now preserves and updates unread item tracking more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->