### PR TITLE
fix(server): tolerate overlapping client submits to the same wavelet

### DIFF
--- a/wave/config/changelog.d/2026-07-05-overlapping-submit-fix.json
+++ b/wave/config/changelog.d/2026-07-05-overlapping-submit-fix.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-07-05-overlapping-submit-fix",
+  "version": "PR #TBD",
+  "date": "2026-07-05",
+  "title": "More reliable editing under rapid changes",
+  "summary": "Fixed a race that could reject an edit when several changes to the same wave were submitted in quick succession.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Concurrent submits to the same wave no longer fail with an internal 'overlapping submit requests' error"
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.d/2026-07-05-overlapping-submit-fix.json
+++ b/wave/config/changelog.d/2026-07-05-overlapping-submit-fix.json
@@ -1,6 +1,6 @@
 {
   "releaseId": "2026-07-05-overlapping-submit-fix",
-  "version": "PR #TBD",
+  "version": "PR #1323",
   "date": "2026-07-05",
   "title": "More reliable editing under rapid changes",
   "summary": "Fixed a race that could reject an edit when several changes to the same wave were submitted in quick succession.",

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/ClientFrontendImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/ClientFrontendImpl.java
@@ -298,7 +298,9 @@ public class ClientFrontendImpl implements ClientFrontend, WaveBus.Subscriber {
       // or initialization failure) without invoking the listener. Release the
       // outstanding-submit bookkeeping and report the failure to the client.
       if (responded.compareAndSet(false, true)) {
-        listener.onFailure(e.toString());
+        LOG.warning("Submit to " + waveletName + " failed synchronously", e);
+        // Don't leak internal exception details to the client.
+        listener.onFailure("Submit failed");
         waveletInfo.getUserManager(author).submitResponse(channelId, waveletName, null);
       } else {
         throw e;

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/ClientFrontendImpl.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/ClientFrontendImpl.java
@@ -49,6 +49,7 @@ import org.waveprotocol.wave.util.logging.Log;
 
 import java.util.Collection;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.Nullable;
@@ -267,22 +268,42 @@ public class ClientFrontendImpl implements ClientFrontend, WaveBus.Subscriber {
     }
 
     waveletInfo.getUserManager(author).submitRequest(channelId, waveletName);
-    waveletProvider.submitRequest(waveletName, delta, new SubmitRequestListener() {
-      @Override
-      public void onSuccess(int operationsApplied,
-          HashedVersion hashedVersionAfterApplication, long applicationTimestamp) {
-        listener.onSuccess(operationsApplied, hashedVersionAfterApplication,
-            applicationTimestamp);
-        waveletInfo.getUserManager(author).submitResponse(channelId, waveletName,
-            hashedVersionAfterApplication);
-      }
+    // The outstanding-submit bookkeeping above must be paired with exactly one
+    // submitResponse, otherwise the channel's updates are held back forever.
+    // Guard against both a missing response and a double response.
+    final AtomicBoolean responded = new AtomicBoolean(false);
+    try {
+      waveletProvider.submitRequest(waveletName, delta, new SubmitRequestListener() {
+        @Override
+        public void onSuccess(int operationsApplied,
+            HashedVersion hashedVersionAfterApplication, long applicationTimestamp) {
+          if (responded.compareAndSet(false, true)) {
+            listener.onSuccess(operationsApplied, hashedVersionAfterApplication,
+                applicationTimestamp);
+            waveletInfo.getUserManager(author).submitResponse(channelId, waveletName,
+                hashedVersionAfterApplication);
+          }
+        }
 
-      @Override
-      public void onFailure(String error) {
-        listener.onFailure(error);
+        @Override
+        public void onFailure(String error) {
+          if (responded.compareAndSet(false, true)) {
+            listener.onFailure(error);
+            waveletInfo.getUserManager(author).submitResponse(channelId, waveletName, null);
+          }
+        }
+      });
+    } catch (RuntimeException e) {
+      // The wavelet provider rejected the submit synchronously (e.g. a signing
+      // or initialization failure) without invoking the listener. Release the
+      // outstanding-submit bookkeeping and report the failure to the client.
+      if (responded.compareAndSet(false, true)) {
+        listener.onFailure(e.toString());
         waveletInfo.getUserManager(author).submitResponse(channelId, waveletName, null);
+      } else {
+        throw e;
       }
-    });
+    }
   }
 
   @Override

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/UserManager.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/UserManager.java
@@ -123,8 +123,9 @@ final class UserManager {
   }
 
   /**
-   * Tell the user manager that we have a submit request outstanding. While a
-   * submit request is outstanding, all wavelet updates are queued.
+   * Tell the user manager that we have a submit request outstanding. A client
+   * may have several submit requests outstanding on a wavelet at once; while any
+   * is outstanding, all wavelet updates are queued.
    *
    * @param channelId the channel identifying the specific client
    * @param waveletName the name of the wavelet

--- a/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveViewSubscription.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/frontend/WaveViewSubscription.java
@@ -64,9 +64,12 @@ final class WaveViewSubscription {
      */
     public HashedVersion lastVersion = null;
     /**
-     * Whether a submit request is awaiting a response.
+     * Number of submit requests awaiting a response. Client submit RPCs are
+     * processed concurrently on a multi-threaded executor, so a client can have
+     * more than one submit in flight on the same wavelet at once; this counter
+     * tolerates that rather than failing the overlapping submit.
      */
-    public boolean hasOutstandingSubmit = false;
+    public int outstandingSubmits = 0;
     /**
      * Outbound deltas held back while a submit is in-flight.
      */
@@ -121,17 +124,17 @@ final class WaveViewSubscription {
 
   /** This client sent a submit request */
   public synchronized void submitRequest(WaveletName waveletName) {
-    // A given client can only have one outstanding submit per wavelet.
+    // A client may have several submits in flight on the same wavelet at once,
+    // since submit RPCs are processed concurrently; hold back updates until the
+    // last of them has resolved.
     WaveletChannelState state;
     try {
       state = channels.get(waveletName.waveletId);
     } catch (ExecutionException ex) {
       throw new RuntimeException(ex);
     }
-    Preconditions.checkState(!state.hasOutstandingSubmit,
-        "Received overlapping submit requests to subscription %s", this);
+    state.outstandingSubmits++;
     LOG.info("Submit oustandinding on channel " + channelId);
-    state.hasOutstandingSubmit = true;
   }
 
   /**
@@ -146,34 +149,30 @@ final class WaveViewSubscription {
     } catch (ExecutionException ex) {
       throw new RuntimeException(ex);
     }
-    Preconditions.checkState(state.hasOutstandingSubmit);
-    state.hasOutstandingSubmit = false;
+    Preconditions.checkState(state.outstandingSubmits > 0);
+    state.outstandingSubmits--;
 
     if (version == null) {
       // Submit failed — no version to record for this submit.
       LOG.info("Submit failed (null version) on channel " + channelId);
-      List<TransformedWaveletDelta> filteredDeltas =
-          filterOwnDeltas(state.heldBackDeltas, state);
-      if (!filteredDeltas.isEmpty()) {
-        for (TransformedWaveletDelta delta : filteredDeltas) {
-          sendUpdate(waveletName, Collections.singletonList(delta), null);
-        }
-      }
-      state.heldBackDeltas.clear();
+    } else {
+      state.submittedEndVersions.add(version.getVersion());
+      LOG.info("Submit resolved on channel " + channelId);
+    }
+
+    // Only forward queued deltas once every outstanding submit has resolved, so
+    // the client still receives its own submit responses before the updates
+    // that were held back while any submit was in flight.
+    if (state.outstandingSubmits > 0) {
       return;
     }
 
-    state.submittedEndVersions.add(version.getVersion());
-    LOG.info("Submit resolved on channel " + channelId);
-
-    // Forward any queued deltas.
-    List<TransformedWaveletDelta> filteredDeltas =  filterOwnDeltas(state.heldBackDeltas, state);
-      if (!filteredDeltas.isEmpty()) {
-          for (TransformedWaveletDelta delta : filteredDeltas) {
-              List<TransformedWaveletDelta> singletonDeltaList = Collections.singletonList(delta);
-              sendUpdate(waveletName, singletonDeltaList, null);
-          }
+    List<TransformedWaveletDelta> filteredDeltas = filterOwnDeltas(state.heldBackDeltas, state);
+    if (!filteredDeltas.isEmpty()) {
+      for (TransformedWaveletDelta delta : filteredDeltas) {
+        sendUpdate(waveletName, Collections.singletonList(delta), null);
       }
+    }
     state.heldBackDeltas.clear();
   }
 
@@ -194,7 +193,7 @@ final class WaveViewSubscription {
     }
     checkUpdateVersion(waveletName, deltas, state);
     state.lastVersion = deltas.getEndVersion();
-    if (state.hasOutstandingSubmit) {
+    if (state.outstandingSubmits > 0) {
       state.heldBackDeltas.addAll(deltas);
     } else {
       List<TransformedWaveletDelta> filteredDeltas = filterOwnDeltas(deltas, state);

--- a/wave/src/test/java/org/waveprotocol/box/server/frontend/ClientFrontendImplTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/frontend/ClientFrontendImplTest.java
@@ -333,6 +333,42 @@ public class ClientFrontendImplTest extends TestCase {
     verifyZeroInteractions(submitListener);
   }
 
+  /**
+   * Tests that if the wavelet provider rejects a submit synchronously (e.g. a
+   * signing or initialization failure) without invoking the submit listener,
+   * the client is still told the submit failed and the outstanding-submit
+   * bookkeeping is released, so later updates on the channel are not stranded.
+   */
+  public void testSubmitReleasesHeldBackUpdatesWhenProviderThrowsSynchronously() throws Exception {
+    CommittedWaveletSnapshot snapshot = provideWavelet(WN1);
+    when(waveletProvider.getWaveletIds(WAVE_ID)).thenReturn(ImmutableSet.of(W1));
+    when(waveletProvider.checkAccessPermission(WN1, USER)).thenReturn(true);
+
+    OpenListener listener = openWave(IdFilters.ALL_IDS);
+    ArgumentCaptor<String> channelIdCaptor = ArgumentCaptor.forClass(String.class);
+    verify(listener).onUpdate(eq(WN1), eq(snapshot), eq(DeltaSequence.empty()),
+        eq(V0), isNullMarker(), channelIdCaptor.capture());
+    String channelId = channelIdCaptor.getValue();
+
+    Mockito.doThrow(new RuntimeException("synchronous submit failure"))
+        .when(waveletProvider).submitRequest(eq(WN1), eq(SERIALIZED_DELTA),
+            any(SubmitRequestListener.class));
+
+    SubmitRequestListener submitListener = mock(SubmitRequestListener.class);
+    clientFrontend.submitRequest(USER, WN1, SERIALIZED_DELTA, channelId, submitListener);
+
+    // The client is notified of failure rather than the exception propagating.
+    verify(submitListener).onFailure(anyString());
+
+    // The channel was released: a subsequent update is delivered, not held back.
+    TransformedWaveletDelta delta = TransformedWaveletDelta.cloneOperations(USER, V2, 1234567890L,
+        Arrays.asList(UTIL.noOp()));
+    DeltaSequence deltas = DeltaSequence.of(delta);
+    clientFrontend.waveletUpdate(snapshot.snapshot, deltas);
+    verify(listener).onUpdate(eq(WN1), isNullSnapshot(), eq(deltas),
+        isNullVersion(), isNullMarker(), anyString());
+  }
+
   public void testCannotSubmitAsDifferentUser() {
     ParticipantId otherParticipant = new ParticipantId("another@example.com");
     OpenListener openListener = openWave(IdFilters.ALL_IDS);

--- a/wave/src/test/java/org/waveprotocol/box/server/frontend/UserManagerTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/frontend/UserManagerTest.java
@@ -199,4 +199,103 @@ public class UserManagerTest extends TestCase {
     m.submitResponse("ch", W1A, V2);
     verifyZeroInteractions(listener);
   }
+
+  /**
+   * Tests that two overlapping submit requests on the same wavelet (which can
+   * happen because client submit RPCs are processed concurrently on a
+   * multi-threaded executor) do not throw. Previously the second concurrent
+   * submit tripped an {@code IllegalStateException} that failed the client's
+   * delta submission.
+   */
+  public void testOverlappingSubmitsAreTolerated() {
+    OpenListener listener = mock(OpenListener.class);
+    m.subscribe(W1, IdFilters.ALL_IDS, "ch", listener);
+
+    m.submitRequest("ch", W1A);
+    m.submitRequest("ch", W1A); // Second submit while the first is still in flight.
+
+    m.submitResponse("ch", W1A, V2);
+    m.submitResponse("ch", W1A, V3);
+    verifyZeroInteractions(listener);
+  }
+
+  /**
+   * Tests the production failure mode: while two submits overlap, the client's
+   * own echoed delta is held back and then dropped once both submits resolve.
+   */
+  public void testOwnDeltaDroppedAcrossOverlappingSubmits() {
+    OpenListener listener = mock(OpenListener.class);
+    m.subscribe(W1, IdFilters.ALL_IDS, "ch", listener);
+
+    m.submitRequest("ch", W1A);
+    m.submitRequest("ch", W1A);
+    m.onUpdate(W1A, DELTAS); // Echo of the client's own delta (end version V2).
+
+    m.submitResponse("ch", W1A, V2); // Resolves one submit at the echoed version.
+    m.submitResponse("ch", W1A, V3); // Resolves the last; flush drops the own delta.
+    verifyZeroInteractions(listener);
+  }
+
+  /**
+   * Tests that when overlapping submits resolve with mixed outcomes (one fails,
+   * one succeeds), a genuine remote delta held during the overlap is still
+   * delivered after the last submit resolves.
+   */
+  public void testHeldBackRemoteDeltaDeliveredAfterMixedOutcomeOverlap() {
+    OpenListener listener = mock(OpenListener.class);
+    m.subscribe(W1, IdFilters.ALL_IDS, "ch", listener);
+
+    m.submitRequest("ch", W1A);
+    m.submitRequest("ch", W1A);
+    m.onUpdate(W1A, DELTAS); // Remote delta (end version V2, not a submitted version).
+
+    m.submitResponse("ch", W1A, null); // First submit fails.
+    verifyZeroInteractions(listener); // Still one submit in flight.
+
+    m.submitResponse("ch", W1A, V3); // Last submit succeeds; V2 != V3 so delta is forwarded.
+    verify(listener).onUpdate(W1A, null, DELTAS, null, null, "ch");
+  }
+
+  /**
+   * Tests that more than two submits can overlap and that updates flow normally
+   * once the counter returns to zero.
+   */
+  public void testThreeOverlappingSubmits() {
+    OpenListener listener = mock(OpenListener.class);
+    m.subscribe(W1, IdFilters.ALL_IDS, "ch", listener);
+
+    m.submitRequest("ch", W1A);
+    m.submitRequest("ch", W1A);
+    m.submitRequest("ch", W1A);
+    m.submitResponse("ch", W1A, V2);
+    m.submitResponse("ch", W1A, V3);
+    m.submitResponse("ch", W1A, HashedVersion.unsigned(4));
+
+    // Counter back to zero: a later remote delta is delivered immediately.
+    TransformedWaveletDelta remote = UTIL.makeTransformedDelta(0L, HashedVersion.unsigned(5), 5);
+    DeltaSequence remoteDeltas = DeltaSequence.of(remote);
+    m.onUpdate(W1A, remoteDeltas);
+    verify(listener).onUpdate(W1A, null, remoteDeltas, null, null, "ch");
+  }
+
+  /**
+   * Tests that held-back deltas are only forwarded once every outstanding
+   * submit on the wavelet has resolved, not after the first one.
+   */
+  public void testHeldBackDeltasFlushedOnlyAfterAllSubmitsResolve() {
+    OpenListener listener = mock(OpenListener.class);
+    m.subscribe(W1, IdFilters.ALL_IDS, "ch", listener);
+
+    m.submitRequest("ch", W1A);
+    m.submitRequest("ch", W1A);
+    m.onUpdate(W1A, DELTAS);
+
+    // First response resolves; a submit is still outstanding so nothing is sent.
+    m.submitResponse("ch", W1A, V3);
+    verifyZeroInteractions(listener);
+
+    // Second response resolves the last submit; the held-back delta is now sent.
+    m.submitResponse("ch", W1A, HashedVersion.unsigned(4));
+    verify(listener).onUpdate(W1A, null, DELTAS, null, null, "ch");
+  }
 }


### PR DESCRIPTION
## Summary

The server log showed a recurring error:

```
java.lang.IllegalStateException: Received overlapping submit requests to subscription [WaveViewSubscription ...]
```

**Root cause.** Client submit RPCs are dispatched onto an unbounded cached thread pool — `ClientServerExecutor` is provided with `threadCount = -1` → `Executors.newCachedThreadPool`, and every thread in it shares the single name `"ClientServerExecutor"` (the name format has no index), which is why the logs made it look single-threaded. So two submits for the same wavelet/channel can run **concurrently**. `WaveViewSubscription` tracked in-flight submits with a boolean `hasOutstandingSubmit`; the second concurrent submit tripped `Preconditions.checkState(!hasOutstandingSubmit)` and threw. `ServerRpcProvider` then returned that as a **failed submit RPC to the client — the user's edit was rejected.** The boolean simply cannot represent more than one in-flight submit.

**Fix.**
- Replace the boolean with an `outstandingSubmits` counter in `WaveViewSubscription`. `submitRequest` increments, `submitResponse` decrements; updates are held back while the counter is `> 0` and flushed (with own-delta filtering via `submittedEndVersions`) only once it returns to `0`. All three methods are already `synchronized` on the subscription, so the counter is race-free. This also makes the "hold back updates while a submit is in flight" behavior correct for a failed submit that overlaps a still-in-flight one.
- Harden `ClientFrontendImpl.submitRequest`: wrap `waveletProvider.submitRequest` in a `try/catch` with an `AtomicBoolean` guard so exactly one `submitResponse` fires. A synchronous provider rejection (e.g. signing/init failure) now releases the counter and reports failure to the client instead of stranding the channel's held-back updates forever.

Backend-only change — no `ui/` or J2CL files touched.

## Test plan
- [x] **TDD**: added a failing test reproducing the exact `IllegalStateException` at `WaveViewSubscription.java:131`, then made it pass with the counter.
- [x] `UserManagerTest`: overlapping submits tolerated; own delta dropped across overlapping submits; held remote delta delivered after mixed fail/success overlap; three-way overlap; flush gated until the last submit resolves.
- [x] `ClientFrontendImplTest`: regression test that a synchronous provider throw still releases the channel and notifies the client.
- [x] `sbt "testOnly org.waveprotocol.box.server.frontend.*"` — all 89 tests green.
- [x] Local Grok review loop run to convergence (round 2 clean).
- [x] Local server verification: built & ran from this worktree, registered a fresh user, all routes serve (200); registration/seeding submits applied with **zero** `overlapping submit` errors and zero exceptions in `wave.log`. UI renders correctly on desktop (1440×900) and mobile (390×844).

🤖 Generated with [Claude Code](https://claude.com/claude-code)