### PR TITLE
feat(mentions): let prev/next-mention nav reach unloaded window regions

### DIFF
--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clBlipFocusController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clBlipFocusController.java
@@ -84,10 +84,16 @@ public final class J2clBlipFocusController {
     focusBlip(blips.get(next));
   }
 
-  public void focusNextMatching(String attributeName, int direction) {
+  /**
+   * Focuses the next rendered blip carrying {@code attributeName}. Returns
+   * false when no rendered blip matches — e.g. when the only unread blips sit
+   * in unloaded viewport-window placeholder regions — so callers can fall back
+   * to {@link #scrollToUnloadedUnread}.
+   */
+  public boolean focusNextMatching(String attributeName, int direction) {
     List<HTMLElement> blips = renderedBlips();
     if (blips.isEmpty()) {
-      return;
+      return false;
     }
     int current = focusedBlipIndex(blips);
     int start = current < 0 ? (direction > 0 ? -1 : blips.size()) : current;
@@ -96,9 +102,58 @@ public final class J2clBlipFocusController {
       HTMLElement candidate = blips.get(index);
       if (candidate.hasAttribute(attributeName)) {
         focusBlip(candidate);
-        return;
+        return true;
       }
     }
+    return false;
+  }
+
+  /**
+   * Windowed-viewport fallback for "jump to next unread": when the next unread
+   * blip is not rendered (its region is an unloaded placeholder), scroll that
+   * placeholder into view so the renderer's visible-placeholder machinery
+   * fetches its fragment. Returns the blip id whose placeholder was scrolled
+   * into view, or the empty string when no unread blip has a placeholder; the
+   * caller re-focuses the blip once it renders.
+   */
+  public String scrollToUnloadedUnread(List<String> unreadBlipIds) {
+    if (unreadBlipIds == null || unreadBlipIds.isEmpty()) {
+      return "";
+    }
+    for (String blipId : unreadBlipIds) {
+      if (blipId == null || blipId.isEmpty() || findBlipById(blipId) != null) {
+        continue;
+      }
+      HTMLElement placeholder =
+          (HTMLElement)
+              contentList.querySelector(
+                  "[data-placeholder-blip-id='" + blipId + "']");
+      if (placeholder == null) {
+        continue;
+      }
+      ScrollIntoViewOptions scrollOptions = ScrollIntoViewOptions.create();
+      scrollOptions.setBlock("center");
+      scrollOptions.setInline("nearest");
+      placeholder.scrollIntoView(scrollOptions);
+      return blipId;
+    }
+    return "";
+  }
+
+  /**
+   * Focuses (and marks read) the rendered blip with {@code blipId}. Returns
+   * false when the blip is not rendered yet.
+   */
+  public boolean focusBlipById(String blipId) {
+    if (blipId == null || blipId.isEmpty()) {
+      return false;
+    }
+    HTMLElement target = findBlipById(blipId);
+    if (target == null) {
+      return false;
+    }
+    focusBlip(target);
+    return true;
   }
 
   /**

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clBlipFocusController.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clBlipFocusController.java
@@ -86,9 +86,9 @@ public final class J2clBlipFocusController {
 
   /**
    * Focuses the next rendered blip carrying {@code attributeName}. Returns
-   * false when no rendered blip matches — e.g. when the only unread blips sit
-   * in unloaded viewport-window placeholder regions — so callers can fall back
-   * to {@link #scrollToUnloadedUnread}.
+   * false when no rendered blip matches — e.g. when the only unread or
+   * mentioned blips sit in unloaded viewport-window placeholder regions — so
+   * callers can fall back to {@link #scrollToUnloadedBlip}.
    */
   public boolean focusNextMatching(String attributeName, int direction) {
     List<HTMLElement> blips = renderedBlips();
@@ -109,18 +109,25 @@ public final class J2clBlipFocusController {
   }
 
   /**
-   * Windowed-viewport fallback for "jump to next unread": when the next unread
-   * blip is not rendered (its region is an unloaded placeholder), scroll that
-   * placeholder into view so the renderer's visible-placeholder machinery
-   * fetches its fragment. Returns the blip id whose placeholder was scrolled
-   * into view, or the empty string when no unread blip has a placeholder; the
-   * caller re-focuses the blip once it renders.
+   * Windowed-viewport fallback for nav jumps ("next unread", "next/previous
+   * mention"): when the target blip is not rendered (its region is an unloaded
+   * placeholder), scroll that placeholder into view so the renderer's
+   * visible-placeholder machinery fetches its fragment. {@code blipIds} is the
+   * server-reported candidate list in conversation order; {@code direction}
+   * picks the scan order — forward for "next" (first unloaded candidate wins),
+   * backward for "previous" (last unloaded candidate wins). Returns the blip
+   * id whose placeholder was scrolled into view, or the empty string when no
+   * candidate has a placeholder; the caller re-focuses the blip once it
+   * renders.
    */
-  public String scrollToUnloadedUnread(List<String> unreadBlipIds) {
-    if (unreadBlipIds == null || unreadBlipIds.isEmpty()) {
+  public String scrollToUnloadedBlip(List<String> blipIds, int direction) {
+    if (blipIds == null || blipIds.isEmpty()) {
       return "";
     }
-    for (String blipId : unreadBlipIds) {
+    int start = direction < 0 ? blipIds.size() - 1 : 0;
+    int step = direction < 0 ? -1 : 1;
+    for (int index = start; index >= 0 && index < blipIds.size(); index += step) {
+      String blipId = blipIds.get(index);
       if (blipId == null || blipId.isEmpty() || findBlipById(blipId) != null) {
         continue;
       }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
@@ -38,6 +38,11 @@ public final class J2clSelectedWaveModel {
   // SidecarSelectedWaveUpdate.getConversationManifest().
   private SidecarConversationManifest conversationManifest = SidecarConversationManifest.empty();
   private String lockState = SidecarSelectedWaveDocument.LOCK_STATE_UNLOCKED;
+  // Unread blip ids from the server read-state endpoint. Unlike the per-blip
+  // unread flags on readBlips (loaded blips only), this list also names unread
+  // blips whose viewport-window regions are still unloaded placeholders, so
+  // "jump to next unread" can navigate to them.
+  private List<String> unreadBlipIds = Collections.emptyList();
 
   J2clSelectedWaveModel(
       boolean hasSelection,
@@ -439,6 +444,20 @@ public final class J2clSelectedWaveModel {
     return this;
   }
 
+  /** Server-reported unread blip ids; may include blips not yet loaded into the viewport. */
+  public List<String> getUnreadBlipIds() {
+    return unreadBlipIds;
+  }
+
+  /** Package-private setter used by the projector. */
+  J2clSelectedWaveModel withUnreadBlipIds(List<String> nextUnreadBlipIds) {
+    this.unreadBlipIds =
+        nextUnreadBlipIds == null || nextUnreadBlipIds.isEmpty()
+            ? Collections.<String>emptyList()
+            : Collections.unmodifiableList(new ArrayList<String>(nextUnreadBlipIds));
+    return this;
+  }
+
   public J2clSelectedWaveViewportState getViewportState() {
     return viewportState;
   }
@@ -480,7 +499,8 @@ public final class J2clSelectedWaveModel {
         // J-UI-4 (#1082, R-3.1): preserve manifest across clones so
         // viewport-windowed renders keep nesting after fragment growth.
         .withConversationManifest(conversationManifest)
-        .withLockState(lockState);
+        .withLockState(lockState)
+        .withUnreadBlipIds(unreadBlipIds);
   }
 
   J2clSelectedWaveModel withReadBlips(List<J2clReadBlip> newReadBlips) {
@@ -506,7 +526,8 @@ public final class J2clSelectedWaveModel {
         readStateKnown,
         readStateStale)
         .withConversationManifest(conversationManifest)
-        .withLockState(lockState);
+        .withLockState(lockState)
+        .withUnreadBlipIds(unreadBlipIds);
   }
 
   J2clSelectedWaveModel withStatus(String nextStatusText, String nextDetailText) {
@@ -534,7 +555,8 @@ public final class J2clSelectedWaveModel {
         readStateKnown,
         readStateStale)
         .withConversationManifest(conversationManifest)
-        .withLockState(lockState);
+        .withLockState(lockState)
+        .withUnreadBlipIds(unreadBlipIds);
   }
 
   public int getUnreadCount() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveModel.java
@@ -43,6 +43,11 @@ public final class J2clSelectedWaveModel {
   // blips whose viewport-window regions are still unloaded placeholders, so
   // "jump to next unread" can navigate to them.
   private List<String> unreadBlipIds = Collections.emptyList();
+  // Blip ids mentioning the signed-in user, from the same read-state endpoint.
+  // Unlike the has-mention flags on readBlips (loaded blips only), this list
+  // also names mentions in unloaded placeholder regions, so the prev/next
+  // mention nav can navigate to them.
+  private List<String> mentionedBlipIds = Collections.emptyList();
 
   J2clSelectedWaveModel(
       boolean hasSelection,
@@ -458,6 +463,23 @@ public final class J2clSelectedWaveModel {
     return this;
   }
 
+  /**
+   * Server-reported blip ids mentioning the signed-in user; may include blips
+   * not yet loaded into the viewport.
+   */
+  public List<String> getMentionedBlipIds() {
+    return mentionedBlipIds;
+  }
+
+  /** Package-private setter used by the projector. */
+  J2clSelectedWaveModel withMentionedBlipIds(List<String> nextMentionedBlipIds) {
+    this.mentionedBlipIds =
+        nextMentionedBlipIds == null || nextMentionedBlipIds.isEmpty()
+            ? Collections.<String>emptyList()
+            : Collections.unmodifiableList(new ArrayList<String>(nextMentionedBlipIds));
+    return this;
+  }
+
   public J2clSelectedWaveViewportState getViewportState() {
     return viewportState;
   }
@@ -500,7 +522,8 @@ public final class J2clSelectedWaveModel {
         // viewport-windowed renders keep nesting after fragment growth.
         .withConversationManifest(conversationManifest)
         .withLockState(lockState)
-        .withUnreadBlipIds(unreadBlipIds);
+        .withUnreadBlipIds(unreadBlipIds)
+        .withMentionedBlipIds(mentionedBlipIds);
   }
 
   J2clSelectedWaveModel withReadBlips(List<J2clReadBlip> newReadBlips) {
@@ -527,7 +550,8 @@ public final class J2clSelectedWaveModel {
         readStateStale)
         .withConversationManifest(conversationManifest)
         .withLockState(lockState)
-        .withUnreadBlipIds(unreadBlipIds);
+        .withUnreadBlipIds(unreadBlipIds)
+        .withMentionedBlipIds(mentionedBlipIds);
   }
 
   J2clSelectedWaveModel withStatus(String nextStatusText, String nextDetailText) {
@@ -556,7 +580,8 @@ public final class J2clSelectedWaveModel {
         readStateStale)
         .withConversationManifest(conversationManifest)
         .withLockState(lockState)
-        .withUnreadBlipIds(unreadBlipIds);
+        .withUnreadBlipIds(unreadBlipIds)
+        .withMentionedBlipIds(mentionedBlipIds);
   }
 
   public int getUnreadCount() {

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -203,7 +203,16 @@ public final class J2clSelectedWaveProjector {
         // previous wave's manifest so the next renderWindow() does not
         // fall back to flat threading until a full snapshot resends.
         .withConversationManifest(effectiveManifest)
-        .withLockState(lockState);
+        .withLockState(lockState)
+        // Unread blip ids may name blips in unloaded placeholder regions;
+        // the view uses them so "jump to next unread" can navigate beyond
+        // the loaded viewport window.
+        .withUnreadBlipIds(
+            readStateMatchesWave
+                ? readState.getUnreadBlipIds()
+                : (previousMatchesWave && previous.isReadStateKnown()
+                    ? previous.getUnreadBlipIds()
+                    : Collections.<String>emptyList()));
   }
 
   private static String chooseLockState(
@@ -328,7 +337,11 @@ public final class J2clSelectedWaveProjector {
         // re-projections — read-state updates carry no conversation
         // document and must not flatten threading.
         .withConversationManifest(previous.getConversationManifest())
-        .withLockState(previous.getLockState());
+        .withLockState(previous.getLockState())
+        .withUnreadBlipIds(
+            readStateMatchesWave
+                ? readState.getUnreadBlipIds()
+                : previous.getUnreadBlipIds());
   }
 
   public static List<J2clReadBlip> applyReadStateToReadBlips(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java
@@ -212,6 +212,14 @@ public final class J2clSelectedWaveProjector {
                 ? readState.getUnreadBlipIds()
                 : (previousMatchesWave && previous.isReadStateKnown()
                     ? previous.getUnreadBlipIds()
+                    : Collections.<String>emptyList()))
+        // Same for mention blip ids: prev/next mention nav uses them to
+        // reach mentions beyond the loaded viewport window.
+        .withMentionedBlipIds(
+            readStateMatchesWave
+                ? readState.getMentionedBlipIds()
+                : (previousMatchesWave && previous.isReadStateKnown()
+                    ? previous.getMentionedBlipIds()
                     : Collections.<String>emptyList()));
   }
 
@@ -341,7 +349,11 @@ public final class J2clSelectedWaveProjector {
         .withUnreadBlipIds(
             readStateMatchesWave
                 ? readState.getUnreadBlipIds()
-                : previous.getUnreadBlipIds());
+                : previous.getUnreadBlipIds())
+        .withMentionedBlipIds(
+            readStateMatchesWave
+                ? readState.getMentionedBlipIds()
+                : previous.getMentionedBlipIds());
   }
 
   public static List<J2clReadBlip> applyReadStateToReadBlips(

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -103,6 +103,12 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   // Set when lastRenderedWaveId transitions to a new (non-empty) wave; cleared
   // once initial focus has been applied to a non-empty rendered surface.
   private String pendingInitialFocusWaveId = "";
+  // Windowed-viewport "jump to next unread": server-reported unread blip ids
+  // from the latest rendered model (may include blips whose regions are still
+  // unloaded placeholders), plus the blip id waiting to be focused once its
+  // placeholder fragment loads and renders.
+  private List<String> lastUnreadBlipIds = Collections.emptyList();
+  private String pendingUnreadJumpBlipId = "";
   // F-3.S3 (#1038, R-5.5): publisher installed by the root shell to
   // forward per-blip reaction snapshots to the compose controller.
   private ReactionSnapshotPublisher reactionSnapshotPublisher;
@@ -546,7 +552,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     disposeRegistry.addListener(
         card, J2clUiTokens.EVENT_NAV_RECENT, evt -> blipFocus.focusMostRecent());
     disposeRegistry.addListener(
-        card, J2clUiTokens.EVENT_NAV_NEXT_UNREAD, evt -> blipFocus.focusNextMatching("unread", 1));
+        card, J2clUiTokens.EVENT_NAV_NEXT_UNREAD, evt -> handleNextUnreadRequested());
     disposeRegistry.addListener(
         card, J2clUiTokens.EVENT_NAV_PREVIOUS, evt -> blipFocus.focusAdjacent(-1));
     disposeRegistry.addListener(
@@ -556,6 +562,31 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
         card, J2clUiTokens.EVENT_NAV_PREV_MENTION, evt -> blipFocus.focusNextMatching("has-mention", -1));
     disposeRegistry.addListener(
         card, J2clUiTokens.EVENT_NAV_NEXT_MENTION, evt -> blipFocus.focusNextMatching("has-mention", 1));
+  }
+
+  /**
+   * "Jump to next unread" with windowed-viewport fallback: prefer the next
+   * rendered blip carrying the {@code unread} attribute; when every rendered
+   * blip is read but the server still reports unread blips, scroll the first
+   * matching unloaded placeholder into view so its fragment loads, then focus
+   * it on the render pass that materializes it (GWT parity — the legacy client
+   * navigates the conversation model, not just the visible DOM).
+   */
+  private void handleNextUnreadRequested() {
+    if (blipFocus.focusNextMatching("unread", 1)) {
+      pendingUnreadJumpBlipId = "";
+      return;
+    }
+    pendingUnreadJumpBlipId = blipFocus.scrollToUnloadedUnread(lastUnreadBlipIds);
+  }
+
+  private void maybeApplyPendingUnreadJump() {
+    if (pendingUnreadJumpBlipId.isEmpty()) {
+      return;
+    }
+    if (blipFocus.focusBlipById(pendingUnreadJumpBlipId)) {
+      pendingUnreadJumpBlipId = "";
+    }
   }
 
   /**
@@ -615,10 +646,12 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     if (!renderedWaveId.equals(lastRenderedWaveId)) {
       readSurface.clearViewportScrollMemory();
       lastRenderedWaveId = renderedWaveId;
+      pendingUnreadJumpBlipId = "";
       if (!renderedWaveId.isEmpty()) {
         pendingInitialFocusWaveId = renderedWaveId;
       }
     }
+    lastUnreadBlipIds = model.getUnreadBlipIds();
     publishReactionState(model);
     // F-2 (#1037, R-3.1) — surface the wave id on the content host so the
     // <wave-blip> renderer can lift it onto each rendered card without
@@ -749,6 +782,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
 
     if (hasRenderedReadSurface) {
       maybeApplyInitialFocus(renderedWaveId, model);
+      maybeApplyPendingUnreadJump();
       blipFocus.restoreFocus();
     }
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveView.java
@@ -109,6 +109,10 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
   // placeholder fragment loads and renders.
   private List<String> lastUnreadBlipIds = Collections.emptyList();
   private String pendingUnreadJumpBlipId = "";
+  // Same pair for prev/next mention: server-reported blip ids mentioning the
+  // signed-in user, plus the pending focus target for an unloaded mention.
+  private List<String> lastMentionedBlipIds = Collections.emptyList();
+  private String pendingMentionJumpBlipId = "";
   // F-3.S3 (#1038, R-5.5): publisher installed by the root shell to
   // forward per-blip reaction snapshots to the compose controller.
   private ReactionSnapshotPublisher reactionSnapshotPublisher;
@@ -559,9 +563,9 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
         card, J2clUiTokens.EVENT_NAV_NEXT, evt -> blipFocus.focusAdjacent(1));
     disposeRegistry.addListener(card, J2clUiTokens.EVENT_NAV_END, evt -> blipFocus.focusLast());
     disposeRegistry.addListener(
-        card, J2clUiTokens.EVENT_NAV_PREV_MENTION, evt -> blipFocus.focusNextMatching("has-mention", -1));
+        card, J2clUiTokens.EVENT_NAV_PREV_MENTION, evt -> handleMentionNavRequested(-1));
     disposeRegistry.addListener(
-        card, J2clUiTokens.EVENT_NAV_NEXT_MENTION, evt -> blipFocus.focusNextMatching("has-mention", 1));
+        card, J2clUiTokens.EVENT_NAV_NEXT_MENTION, evt -> handleMentionNavRequested(1));
   }
 
   /**
@@ -577,7 +581,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       pendingUnreadJumpBlipId = "";
       return;
     }
-    pendingUnreadJumpBlipId = blipFocus.scrollToUnloadedUnread(lastUnreadBlipIds);
+    pendingUnreadJumpBlipId = blipFocus.scrollToUnloadedBlip(lastUnreadBlipIds, 1);
   }
 
   private void maybeApplyPendingUnreadJump() {
@@ -586,6 +590,31 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     }
     if (blipFocus.focusBlipById(pendingUnreadJumpBlipId)) {
       pendingUnreadJumpBlipId = "";
+    }
+  }
+
+  /**
+   * Prev/next mention with the same windowed-viewport fallback as
+   * {@link #handleNextUnreadRequested}: prefer a rendered blip carrying the
+   * {@code has-mention} attribute; when none matches but the server-reported
+   * mention list (read-state endpoint) still names blips in unloaded
+   * placeholder regions, scroll the matching placeholder into view and focus
+   * the blip on the render pass that materializes it.
+   */
+  private void handleMentionNavRequested(int direction) {
+    if (blipFocus.focusNextMatching("has-mention", direction)) {
+      pendingMentionJumpBlipId = "";
+      return;
+    }
+    pendingMentionJumpBlipId = blipFocus.scrollToUnloadedBlip(lastMentionedBlipIds, direction);
+  }
+
+  private void maybeApplyPendingMentionJump() {
+    if (pendingMentionJumpBlipId.isEmpty()) {
+      return;
+    }
+    if (blipFocus.focusBlipById(pendingMentionJumpBlipId)) {
+      pendingMentionJumpBlipId = "";
     }
   }
 
@@ -647,11 +676,13 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
       readSurface.clearViewportScrollMemory();
       lastRenderedWaveId = renderedWaveId;
       pendingUnreadJumpBlipId = "";
+      pendingMentionJumpBlipId = "";
       if (!renderedWaveId.isEmpty()) {
         pendingInitialFocusWaveId = renderedWaveId;
       }
     }
     lastUnreadBlipIds = model.getUnreadBlipIds();
+    lastMentionedBlipIds = model.getMentionedBlipIds();
     publishReactionState(model);
     // F-2 (#1037, R-3.1) — surface the wave id on the content host so the
     // <wave-blip> renderer can lift it onto each rendered card without
@@ -690,6 +721,11 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     if (waveNavRow != null) {
       int navUnread = Math.max(0, model.getUnreadCount());
       waveNavRow.setAttribute("unread-count", Integer.toString(navUnread));
+      // E.6/E.7 violet mention emphasis: derived from the server-reported
+      // mention list (read-state endpoint) rather than loaded blips, so the
+      // emphasis also reflects mentions in unloaded viewport-window regions.
+      waveNavRow.setAttribute(
+          "mention-count", Integer.toString(model.getMentionedBlipIds().size()));
       // Pin/archive state is published separately through setNavRowFolderState
       // after render sets source-wave-id, so the Lit action-bar observer does
       // not clear the state while reusing the nav row for another wave.
@@ -783,6 +819,7 @@ public final class J2clSelectedWaveView implements J2clSelectedWaveController.Vi
     if (hasRenderedReadSurface) {
       maybeApplyInitialFocus(renderedWaveId, model);
       maybeApplyPendingUnreadJump();
+      maybeApplyPendingMentionJump();
       blipFocus.restoreFocus();
     }
   }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveReadState.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarSelectedWaveReadState.java
@@ -13,6 +13,7 @@ public final class SidecarSelectedWaveReadState {
   private final int unreadCount;
   private final boolean read;
   private final List<String> unreadBlipIds;
+  private final List<String> mentionedBlipIds;
 
   public SidecarSelectedWaveReadState(String waveId, int unreadCount, boolean read) {
     this(waveId, unreadCount, read, Collections.<String>emptyList());
@@ -20,6 +21,15 @@ public final class SidecarSelectedWaveReadState {
 
   public SidecarSelectedWaveReadState(
       String waveId, int unreadCount, boolean read, List<String> unreadBlipIds) {
+    this(waveId, unreadCount, read, unreadBlipIds, Collections.<String>emptyList());
+  }
+
+  public SidecarSelectedWaveReadState(
+      String waveId,
+      int unreadCount,
+      boolean read,
+      List<String> unreadBlipIds,
+      List<String> mentionedBlipIds) {
     this.waveId = waveId;
     this.unreadCount = unreadCount;
     this.read = read;
@@ -27,6 +37,10 @@ public final class SidecarSelectedWaveReadState {
         unreadBlipIds == null
             ? Collections.<String>emptyList()
             : Collections.unmodifiableList(new ArrayList<String>(unreadBlipIds));
+    this.mentionedBlipIds =
+        mentionedBlipIds == null
+            ? Collections.<String>emptyList()
+            : Collections.unmodifiableList(new ArrayList<String>(mentionedBlipIds));
   }
 
   public String getWaveId() {
@@ -43,5 +57,13 @@ public final class SidecarSelectedWaveReadState {
 
   public List<String> getUnreadBlipIds() {
     return unreadBlipIds;
+  }
+
+  /**
+   * Blip ids carrying a mention annotation for the signed-in user; may include
+   * blips whose viewport-window regions are still unloaded placeholders.
+   */
+  public List<String> getMentionedBlipIds() {
+    return mentionedBlipIds;
   }
 }

--- a/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
+++ b/j2cl/src/main/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodec.java
@@ -323,7 +323,9 @@ public final class SidecarTransportCodec {
     int unreadCount = getInt(root, "unreadCount");
     boolean read = getBoolean(root, "isRead");
     List<String> unreadBlipIds = getStringList(root, "unreadBlipIds");
-    return new SidecarSelectedWaveReadState(waveId, unreadCount, read, unreadBlipIds);
+    List<String> mentionedBlipIds = getStringList(root, "mentionedBlipIds");
+    return new SidecarSelectedWaveReadState(
+        waveId, unreadCount, read, unreadBlipIds, mentionedBlipIds);
   }
 
   public static boolean decodeRpcFinishedFailed(Map<String, Object> envelope) {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clBlipFocusControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clBlipFocusControllerTest.java
@@ -5,6 +5,7 @@ import elemental2.dom.DomGlobal;
 import elemental2.dom.Element;
 import elemental2.dom.HTMLElement;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.After;
 import org.junit.Assert;
@@ -68,6 +69,50 @@ public class J2clBlipFocusControllerTest {
     focus.focusNextMatching("unread", 1);
 
     Assert.assertEquals("b3", activeBlipId());
+  }
+
+  @Test
+  public void focusNextMatchingReportsWhetherMatchWasFound() {
+    assumeBrowserDom();
+    J2clBlipFocusController focus = controllerWithBlips(new ArrayList<String>(), "b1:1", "b2:2");
+    blip("b2").setAttribute("unread", "");
+
+    focus.focusBlip(blip("b1"));
+    Assert.assertTrue(focus.focusNextMatching("unread", 1));
+
+    blip("b2").removeAttribute("unread");
+    Assert.assertFalse(focus.focusNextMatching("unread", 1));
+  }
+
+  @Test
+  public void scrollToUnloadedUnreadReturnsPlaceholderBlipId() {
+    assumeBrowserDom();
+    J2clBlipFocusController focus = controllerWithBlips(new ArrayList<String>(), "b1:1", "b2:2");
+    appendPlaceholder("b9");
+
+    Assert.assertEquals("b9", focus.scrollToUnloadedUnread(Arrays.asList("b9")));
+  }
+
+  @Test
+  public void scrollToUnloadedUnreadSkipsRenderedAndUnknownBlips() {
+    assumeBrowserDom();
+    J2clBlipFocusController focus = controllerWithBlips(new ArrayList<String>(), "b1:1");
+
+    // b1 is already rendered (jump handles it); b7 has no placeholder at all.
+    Assert.assertEquals("", focus.scrollToUnloadedUnread(Arrays.asList("b1", "b7")));
+  }
+
+  @Test
+  public void focusBlipByIdFocusesAndMarksRead() {
+    assumeBrowserDom();
+    List<String> read = new ArrayList<String>();
+    J2clBlipFocusController focus = controllerWithBlips(read, "b1:1", "b2:2");
+
+    Assert.assertTrue(focus.focusBlipById("b2"));
+    Assert.assertEquals("b2", activeBlipId());
+    Assert.assertEquals(Arrays.asList("b2"), read);
+
+    Assert.assertFalse(focus.focusBlipById("missing"));
   }
 
   @Test
@@ -151,6 +196,15 @@ public class J2clBlipFocusControllerTest {
 
   private HTMLElement blip(String id) {
     return (HTMLElement) contentList.querySelector("wave-blip[data-blip-id='" + id + "']");
+  }
+
+  /** Mirrors the renderer's unloaded viewport-window placeholder markup. */
+  private void appendPlaceholder(String blipId) {
+    HTMLElement placeholder = (HTMLElement) DomGlobal.document.createElement("div");
+    placeholder.className = "j2cl-read-viewport-placeholder";
+    placeholder.setAttribute("data-j2cl-viewport-placeholder", "true");
+    placeholder.setAttribute("data-placeholder-blip-id", blipId);
+    contentList.appendChild(placeholder);
   }
 
   private static String activeBlipId() {

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clBlipFocusControllerTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clBlipFocusControllerTest.java
@@ -85,21 +85,34 @@ public class J2clBlipFocusControllerTest {
   }
 
   @Test
-  public void scrollToUnloadedUnreadReturnsPlaceholderBlipId() {
+  public void scrollToUnloadedBlipReturnsPlaceholderBlipId() {
     assumeBrowserDom();
     J2clBlipFocusController focus = controllerWithBlips(new ArrayList<String>(), "b1:1", "b2:2");
     appendPlaceholder("b9");
 
-    Assert.assertEquals("b9", focus.scrollToUnloadedUnread(Arrays.asList("b9")));
+    Assert.assertEquals("b9", focus.scrollToUnloadedBlip(Arrays.asList("b9"), 1));
   }
 
   @Test
-  public void scrollToUnloadedUnreadSkipsRenderedAndUnknownBlips() {
+  public void scrollToUnloadedBlipSkipsRenderedAndUnknownBlips() {
     assumeBrowserDom();
     J2clBlipFocusController focus = controllerWithBlips(new ArrayList<String>(), "b1:1");
 
     // b1 is already rendered (jump handles it); b7 has no placeholder at all.
-    Assert.assertEquals("", focus.scrollToUnloadedUnread(Arrays.asList("b1", "b7")));
+    Assert.assertEquals("", focus.scrollToUnloadedBlip(Arrays.asList("b1", "b7"), 1));
+  }
+
+  @Test
+  public void scrollToUnloadedBlipScansBackwardForPreviousDirection() {
+    assumeBrowserDom();
+    J2clBlipFocusController focus = controllerWithBlips(new ArrayList<String>(), "b1:1");
+    appendPlaceholder("b8");
+    appendPlaceholder("b9");
+
+    // "next" (direction > 0) picks the first unloaded id in list order;
+    // "previous" (direction < 0) picks the last.
+    Assert.assertEquals("b8", focus.scrollToUnloadedBlip(Arrays.asList("b8", "b9"), 1));
+    Assert.assertEquals("b9", focus.scrollToUnloadedBlip(Arrays.asList("b8", "b9"), -1));
   }
 
   @Test

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorReadStateTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorReadStateTest.java
@@ -138,6 +138,69 @@ public class J2clSelectedWaveProjectorReadStateTest extends J2clSelectedWaveProj
   }
 
   @Test
+  public void projectExposesServerUnreadBlipIdsOnModel() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            fragmentUpdate("b+root", "Root text", "b+reply", "Reply text"),
+            null,
+            0,
+            new SidecarSelectedWaveReadState(
+                WAVE_ID, 1, false, Arrays.asList("b+unloaded")),
+            false);
+
+    Assert.assertEquals(Arrays.asList("b+unloaded"), projected.getUnreadBlipIds());
+  }
+
+  @Test
+  public void projectCarriesForwardPreviousUnreadBlipIdsAcrossUpdates() {
+    J2clSelectedWaveModel first =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            sampleUpdate(),
+            null,
+            0,
+            new SidecarSelectedWaveReadState(
+                WAVE_ID, 1, false, Arrays.asList("b+unloaded")),
+            false);
+
+    J2clSelectedWaveModel second =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            sampleUpdate(),
+            first,
+            0);
+
+    Assert.assertEquals(Arrays.asList("b+unloaded"), second.getUnreadBlipIds());
+  }
+
+  @Test
+  public void reprojectReadStateReplacesUnreadBlipIds() {
+    J2clSelectedWaveModel first =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            sampleUpdate(),
+            null,
+            0,
+            new SidecarSelectedWaveReadState(
+                WAVE_ID, 2, false, Arrays.asList("b+one", "b+two")),
+            false);
+
+    J2clSelectedWaveModel reprojected =
+        J2clSelectedWaveProjector.reprojectReadState(
+            first,
+            digest("Wave A", "snippet", 1),
+            new SidecarSelectedWaveReadState(WAVE_ID, 1, false, Arrays.asList("b+two")),
+            false);
+
+    Assert.assertEquals(Arrays.asList("b+two"), reprojected.getUnreadBlipIds());
+  }
+
+  @Test
   public void applyReadStatePreservesExistingBlipMarkersWhenUnreadIdsAreAbsent() {
     java.util.List<J2clReadBlip> blips =
         Arrays.asList(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorReadStateTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjectorReadStateTest.java
@@ -201,6 +201,73 @@ public class J2clSelectedWaveProjectorReadStateTest extends J2clSelectedWaveProj
   }
 
   @Test
+  public void projectExposesServerMentionedBlipIdsOnModel() {
+    J2clSelectedWaveModel projected =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            fragmentUpdate("b+root", "Root text", "b+reply", "Reply text"),
+            null,
+            0,
+            new SidecarSelectedWaveReadState(
+                WAVE_ID, 1, false, Arrays.asList("b+unloaded"),
+                Arrays.asList("b+mentioned")),
+            false);
+
+    Assert.assertEquals(Arrays.asList("b+mentioned"), projected.getMentionedBlipIds());
+  }
+
+  @Test
+  public void projectCarriesForwardPreviousMentionedBlipIdsAcrossUpdates() {
+    J2clSelectedWaveModel first =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            sampleUpdate(),
+            null,
+            0,
+            new SidecarSelectedWaveReadState(
+                WAVE_ID, 1, false, Arrays.asList("b+unloaded"),
+                Arrays.asList("b+mentioned")),
+            false);
+
+    J2clSelectedWaveModel second =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            sampleUpdate(),
+            first,
+            0);
+
+    Assert.assertEquals(Arrays.asList("b+mentioned"), second.getMentionedBlipIds());
+  }
+
+  @Test
+  public void reprojectReadStateReplacesMentionedBlipIds() {
+    J2clSelectedWaveModel first =
+        J2clSelectedWaveProjector.project(
+            WAVE_ID,
+            digest("Wave A", "snippet", 0),
+            sampleUpdate(),
+            null,
+            0,
+            new SidecarSelectedWaveReadState(
+                WAVE_ID, 2, false, Arrays.asList("b+one"),
+                Arrays.asList("b+m1", "b+m2")),
+            false);
+
+    J2clSelectedWaveModel reprojected =
+        J2clSelectedWaveProjector.reprojectReadState(
+            first,
+            digest("Wave A", "snippet", 1),
+            new SidecarSelectedWaveReadState(
+                WAVE_ID, 1, false, Arrays.asList("b+one"), Arrays.asList("b+m2")),
+            false);
+
+    Assert.assertEquals(Arrays.asList("b+m2"), reprojected.getMentionedBlipIds());
+  }
+
+  @Test
   public void applyReadStatePreservesExistingBlipMarkersWhenUnreadIdsAreAbsent() {
     java.util.List<J2clReadBlip> blips =
         Arrays.asList(

--- a/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
+++ b/j2cl/src/test/java/org/waveprotocol/box/j2cl/transport/SidecarTransportCodecTest.java
@@ -34,6 +34,18 @@ public class SidecarTransportCodecTest {
     Assert.assertEquals(0, state.getUnreadCount());
     Assert.assertFalse(state.isRead());
     Assert.assertTrue(state.getUnreadBlipIds().isEmpty());
+    Assert.assertTrue(state.getMentionedBlipIds().isEmpty());
+  }
+
+  @Test
+  public void decodeSelectedWaveReadStateReadsMentionedBlipIds() {
+    String json =
+        "{\"waveId\":\"example.com/w+abc\",\"unreadCount\":1,\"isRead\":false,"
+            + "\"unreadBlipIds\":[\"b+2\"],\"mentionedBlipIds\":[\"b+5\",\"b+9\"]}";
+
+    SidecarSelectedWaveReadState state = SidecarTransportCodec.decodeSelectedWaveReadState(json);
+
+    Assert.assertEquals(Arrays.asList("b+5", "b+9"), state.getMentionedBlipIds());
   }
 
   @Test

--- a/wave/config/changelog.d/2026-07-05-unread-count-tombstone-and-window-jump.json
+++ b/wave/config/changelog.d/2026-07-05-unread-count-tombstone-and-window-jump.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-07-05-unread-count-tombstone-and-window-jump",
+  "version": "unreleased",
+  "date": "2026-07-05",
+  "title": "Fix phantom unread counts and \"jump to next unread\" in the new UI",
+  "summary": "Waves could show an unread badge (for example \"1 unread\") even though every visible message was read, and the \"jump to next unread\" toolbar button silently did nothing. Two causes were fixed: deleted messages no longer count as unread, and the jump action can now reach unread messages that sit in a not-yet-loaded part of a long wave.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Unread counts: messages deleted in the new UI leave a hidden tombstone in the conversation, and the server kept counting those tombstones as unread even though no client renders them — producing a permanent phantom unread badge that could never be cleared. The search digest unread count and the read-state endpoint's unread blip list now skip tombstoned blips.",
+        "New UI: \"jump to next unread\" only scanned the blips already rendered in the viewport window, so in long waves it did nothing when the next unread blip lived in a not-yet-loaded placeholder region. The jump now falls back to scrolling that placeholder into view, loads its content, and focuses (and marks read) the blip once it renders — matching the legacy client's model-based navigation."
+      ]
+    }
+  ]
+}

--- a/wave/config/changelog.d/2026-07-06-mention-nav-window-jump.json
+++ b/wave/config/changelog.d/2026-07-06-mention-nav-window-jump.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-07-06-mention-nav-window-jump",
+  "version": "unreleased",
+  "date": "2026-07-06",
+  "title": "Make prev/next-mention navigation reach unloaded parts of long waves in the new UI",
+  "summary": "In long waves, the \"previous mention\" and \"next mention\" toolbar buttons only scanned the messages already loaded on screen, so mentions further down (or up) in a not-yet-loaded part of the wave were unreachable, and the mention highlight on the toolbar only reflected loaded content. The server now reports which messages mention you, and the jump buttons use that list to scroll unloaded regions into view and land on the mention once it renders.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "New UI: \"previous/next mention\" only scanned the blips already rendered in the viewport window, so in long waves the buttons silently did nothing when the nearest mention lived in a not-yet-loaded placeholder region. The read-state endpoint now also returns the blip ids carrying a mention of the signed-in user (skipping deleted tombstones, case-insensitive address match like the mentions: search filter), and the mention nav buttons fall back to scrolling the matching placeholder into view, loading its content, and focusing the mention once it renders — the same windowed-viewport fallback \"jump to next unread\" uses.",
+        "New UI: the mention emphasis on the wave toolbar is now driven by the server-reported mention list instead of never lighting up — it highlights whenever the wave mentions you, including mentions in unloaded regions."
+      ]
+    }
+  ]
+}

--- a/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServlet.java
+++ b/wave/src/jakarta-overrides/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServlet.java
@@ -102,7 +102,13 @@ public final class SelectedWaveReadStateServlet extends HttpServlet {
       return;
     }
 
-    writeJson(resp, rawWaveId, result.getUnreadCount(), result.isRead(), result.getUnreadBlipIds());
+    writeJson(
+        resp,
+        rawWaveId,
+        result.getUnreadCount(),
+        result.isRead(),
+        result.getUnreadBlipIds(),
+        result.getMentionedBlipIds());
   }
 
   private static void writeJson(
@@ -110,32 +116,41 @@ public final class SelectedWaveReadStateServlet extends HttpServlet {
       String waveId,
       int unreadCount,
       boolean isRead,
-      List<String> unreadBlipIds)
+      List<String> unreadBlipIds,
+      List<String> mentionedBlipIds)
       throws IOException {
     resp.setStatus(HttpServletResponse.SC_OK);
     resp.setContentType("application/json; charset=utf-8");
     StringBuilder body = new StringBuilder(64);
     body.append("{\"waveId\":\"").append(escapeJson(waveId)).append("\",\"unreadCount\":")
         .append(unreadCount).append(",\"isRead\":").append(isRead)
-        .append(",\"unreadBlipIds\":[");
-    if (unreadBlipIds != null) {
+        .append(",\"unreadBlipIds\":");
+    appendJsonStringArray(body, unreadBlipIds);
+    body.append(",\"mentionedBlipIds\":");
+    appendJsonStringArray(body, mentionedBlipIds);
+    body.append('}');
+    try (var w = resp.getWriter()) {
+      w.append(body.toString());
+      w.flush();
+    }
+  }
+
+  private static void appendJsonStringArray(StringBuilder body, List<String> values) {
+    body.append('[');
+    if (values != null) {
       boolean first = true;
-      for (String blipId : unreadBlipIds) {
-        if (blipId == null) {
+      for (String value : values) {
+        if (value == null) {
           continue;
         }
         if (!first) {
           body.append(',');
         }
-        body.append('"').append(escapeJson(blipId)).append('"');
+        body.append('"').append(escapeJson(value)).append('"');
         first = false;
       }
     }
-    body.append("]}");
-    try (var w = resp.getWriter()) {
-      w.append(body.toString());
-      w.flush();
-    }
+    body.append(']');
   }
 
   private static String escapeJson(String value) {

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelper.java
@@ -66,13 +66,15 @@ public class SelectedWaveReadStateHelper {
     private final int unreadCount;
     private final boolean read;
     private final List<String> unreadBlipIds;
+    private final List<String> mentionedBlipIds;
 
     private Result(
         boolean exists,
         boolean accessAllowed,
         int unreadCount,
         boolean read,
-        List<String> unreadBlipIds) {
+        List<String> unreadBlipIds,
+        List<String> mentionedBlipIds) {
       this.exists = exists;
       this.accessAllowed = accessAllowed;
       this.unreadCount = unreadCount;
@@ -81,6 +83,10 @@ public class SelectedWaveReadStateHelper {
           unreadBlipIds == null
               ? Collections.<String>emptyList()
               : Collections.unmodifiableList(new ArrayList<String>(unreadBlipIds));
+      this.mentionedBlipIds =
+          mentionedBlipIds == null
+              ? Collections.<String>emptyList()
+              : Collections.unmodifiableList(new ArrayList<String>(mentionedBlipIds));
     }
 
     public boolean exists() { return exists; }
@@ -89,8 +95,16 @@ public class SelectedWaveReadStateHelper {
     public boolean isRead() { return read; }
     public List<String> getUnreadBlipIds() { return unreadBlipIds; }
 
+    /**
+     * Conversation blip ids carrying a mention annotation for the signed-in
+     * user, in digest traversal order; independent of read state.
+     */
+    public List<String> getMentionedBlipIds() { return mentionedBlipIds; }
+
     public static Result notFound() {
-      return new Result(false, false, 0, true, Collections.<String>emptyList());
+      return new Result(
+          false, false, 0, true,
+          Collections.<String>emptyList(), Collections.<String>emptyList());
     }
 
     public static Result found(int unreadCount) {
@@ -98,7 +112,13 @@ public class SelectedWaveReadStateHelper {
     }
 
     public static Result found(int unreadCount, List<String> unreadBlipIds) {
-      return new Result(true, true, unreadCount, unreadCount <= 0, unreadBlipIds);
+      return found(unreadCount, unreadBlipIds, Collections.<String>emptyList());
+    }
+
+    public static Result found(
+        int unreadCount, List<String> unreadBlipIds, List<String> mentionedBlipIds) {
+      return new Result(
+          true, true, unreadCount, unreadCount <= 0, unreadBlipIds, mentionedBlipIds);
     }
   }
 
@@ -163,7 +183,8 @@ public class SelectedWaveReadStateHelper {
       WaveDigester.UnreadBlipState readState = digester.getUnreadBlipState(user, view);
       return Result.found(
           Math.max(0, readState.getUnreadCount()),
-          readState.getUnreadBlipIds());
+          readState.getUnreadBlipIds(),
+          readState.getMentionedBlipIds());
     } catch (RuntimeException e) {
       LOG.warning("read-state: unread state build failed for " + waveId, e);
       throw e;

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveDigester.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveDigester.java
@@ -28,6 +28,7 @@ import com.google.wave.api.SearchResult.Digest;
 import org.waveprotocol.box.common.Snippets;
 import org.waveprotocol.box.server.robots.util.ConversationUtil;
 import org.waveprotocol.box.server.waveserver.SimpleSearchProviderImpl.WaveSupplementContext;
+import org.waveprotocol.wave.model.conversation.AnnotationConstants;
 import org.waveprotocol.wave.model.conversation.BlipIterators;
 import org.waveprotocol.wave.model.conversation.ConversationBlip;
 import org.waveprotocol.wave.model.conversation.ObservableConversation;
@@ -61,6 +62,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -79,13 +81,22 @@ public class WaveDigester {
   public static final class UnreadBlipState {
     private final int unreadCount;
     private final List<String> unreadBlipIds;
+    private final List<String> mentionedBlipIds;
 
     public UnreadBlipState(List<String> unreadBlipIds) {
+      this(unreadBlipIds, Collections.<String>emptyList());
+    }
+
+    public UnreadBlipState(List<String> unreadBlipIds, List<String> mentionedBlipIds) {
       this.unreadBlipIds =
           unreadBlipIds == null
               ? Collections.<String>emptyList()
               : Collections.unmodifiableList(new ArrayList<String>(unreadBlipIds));
       this.unreadCount = this.unreadBlipIds.size();
+      this.mentionedBlipIds =
+          mentionedBlipIds == null
+              ? Collections.<String>emptyList()
+              : Collections.unmodifiableList(new ArrayList<String>(mentionedBlipIds));
     }
 
     public int getUnreadCount() {
@@ -94,6 +105,16 @@ public class WaveDigester {
 
     public List<String> getUnreadBlipIds() {
       return unreadBlipIds;
+    }
+
+    /**
+     * Conversation blip ids whose body carries a {@code mention/}-prefixed
+     * annotation naming the viewer. Independent of read state — the J2CL
+     * mention nav buttons use these ids to reach mentions in unloaded
+     * viewport-window regions.
+     */
+    public List<String> getMentionedBlipIds() {
+      return mentionedBlipIds;
     }
   }
 
@@ -279,6 +300,12 @@ public class WaveDigester {
             context.conversationalWavelets,
             context.supplement,
             context.conversations,
+            context.waveletAdapters),
+        collectMentionedBlipIds(
+            participant,
+            context.convWavelet,
+            context.conversationalWavelets,
+            context.conversations,
             context.waveletAdapters));
   }
 
@@ -369,6 +396,73 @@ public class WaveDigester {
       }
     }
     return unreadBlipIds;
+  }
+
+  /**
+   * Collects the ids of conversation blips whose body carries a
+   * {@code mention/}-prefixed annotation naming {@code participant}
+   * (case-insensitive address match, mirroring the {@code mentions:} search
+   * filter). Traverses the same conversation structure as
+   * {@link #collectUnreadBlipIds} so ordering matches the digest/read-state
+   * view, and skips tombstoned blips for the same reason unread state does:
+   * clients never render them.
+   */
+  private List<String> collectMentionedBlipIds(
+      ParticipantId participant,
+      WaveletData convWavelet,
+      Iterable<? extends ObservableWaveletData> conversationalWavelets,
+      ObservableConversationView conversations,
+      Map<ObservableWaveletData, OpBasedWavelet> waveletAdapters) {
+    if (participant == null || convWavelet == null || conversations == null) {
+      return Collections.emptyList();
+    }
+    String viewerAddress = participant.getAddress().toLowerCase(Locale.ROOT);
+    List<String> mentionedBlipIds = new ArrayList<String>();
+    ObservableConversation rootConversation = chooseDigestConversation(conversations);
+    for (ObservableWaveletData conversationalWavelet : conversationalWavelets) {
+      ObservableConversation conversation;
+      if (conversationalWavelet == convWavelet) {
+        conversation = rootConversation;
+      } else {
+        OpBasedWavelet wavelet = getOrCreateReadOnlyWavelet(conversationalWavelet, waveletAdapters);
+        if (!WaveletBasedConversation.waveletHasConversation(wavelet)) {
+          continue;
+        }
+        conversation = chooseDigestConversation(conversationUtil.buildConversation(wavelet));
+      }
+      if (conversation == null) {
+        continue;
+      }
+      for (ConversationBlip blip : BlipIterators.breadthFirst(conversation)) {
+        if (!isTombstoned(blip) && blipMentions(blip, viewerAddress)) {
+          mentionedBlipIds.add(blip.getId());
+        }
+      }
+    }
+    return mentionedBlipIds;
+  }
+
+  /**
+   * True when the blip body carries a mention annotation whose value is the
+   * given lower-cased participant address.
+   */
+  @VisibleForTesting
+  static boolean blipMentions(ConversationBlip blip, String lowerCaseAddress) {
+    Document content = blip.getContent();
+    if (content == null || content.size() == 0) {
+      return false;
+    }
+    for (RangedAnnotation<String> annotation :
+        content.rangedAnnotations(0, content.size(), null)) {
+      if (annotation == null || annotation.value() == null) {
+        continue;
+      }
+      if (AnnotationConstants.isMentionKey(annotation.key())
+          && lowerCaseAddress.equals(annotation.value().toLowerCase(Locale.ROOT))) {
+        return true;
+      }
+    }
+    return false;
   }
 
   static ObservableWaveletData findViewerUserDataWavelet(

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveDigester.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveDigester.java
@@ -36,6 +36,7 @@ import org.waveprotocol.wave.model.conversation.ObservableConversationView;
 import org.waveprotocol.wave.model.conversation.TitleHelper;
 import org.waveprotocol.wave.model.conversation.WaveletBasedConversation;
 import org.waveprotocol.wave.model.document.Document;
+import org.waveprotocol.wave.model.document.RangedAnnotation;
 import org.waveprotocol.wave.model.id.IdUtil;
 import org.waveprotocol.wave.model.id.ModernIdSerialiser;
 import org.waveprotocol.wave.model.id.WaveId;
@@ -73,6 +74,7 @@ public class WaveDigester {
   private static final int DIGEST_SNIPPET_LENGTH = 140;
   private static final int PARTICIPANTS_SNIPPET_LENGTH = 5;
   private static final String EMPTY_WAVELET_TITLE = "";
+  private static final String TOMBSTONE_DELETED_ANNOTATION = "tombstone/deleted";
 
   public static final class UnreadBlipState {
     private final int unreadCount;
@@ -361,7 +363,7 @@ public class WaveDigester {
         continue;
       }
       for (ConversationBlip blip : BlipIterators.breadthFirst(conversation)) {
-        if (supplement.isUnread(blip)) {
+        if (supplement.isUnread(blip) && !isTombstoned(blip)) {
           unreadBlipIds.add(blip.getId());
         }
       }
@@ -490,12 +492,35 @@ public class WaveDigester {
         continue;
       }
       for (ConversationBlip blip : BlipIterators.breadthFirst(conversation)) {
-        if (supplement.isUnread(blip)) {
+        if (supplement.isUnread(blip) && !isTombstoned(blip)) {
           unreadCount++;
         }
       }
     }
     return unreadCount;
+  }
+
+  /**
+   * True when the blip carries the J2CL F.6 deletion tombstone
+   * ({@code tombstone/deleted=true} annotation across the blip body). Such
+   * blips remain in the conversation manifest but are never rendered by
+   * clients, so they must not contribute to unread state — a tombstoned
+   * unread blip could otherwise never be marked read.
+   */
+  @VisibleForTesting
+  static boolean isTombstoned(ConversationBlip blip) {
+    Document content = blip.getContent();
+    if (content == null || content.size() == 0) {
+      return false;
+    }
+    for (RangedAnnotation<String> annotation :
+        content.rangedAnnotations(0, content.size(),
+            CollectionUtils.newStringSet(TOMBSTONE_DELETED_ANNOTATION))) {
+      if ("true".equals(annotation.value())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private ObservableConversation chooseDigestConversation(ObservableConversationView conversations) {

--- a/wave/src/test/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServletTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/rpc/SelectedWaveReadStateServletTest.java
@@ -152,6 +152,59 @@ public final class SelectedWaveReadStateServletTest extends TestCase {
     assertTrue("body missing waveId: " + json, json.contains("\"waveId\":\"" + VALID_WAVE_ID + "\""));
   }
 
+  /**
+   * The success body must carry the server-computed mentioned blip ids so the
+   * J2CL mention nav buttons can reach mentions in unloaded viewport-window
+   * regions.
+   */
+  public void testReturnsJsonWithMentionedBlipIdsOnSuccess() throws Exception {
+    SessionManager sessionManager = mock(SessionManager.class);
+    when(sessionManager.getLoggedInUser(any())).thenReturn(USER);
+    SelectedWaveReadStateHelper helper = mock(SelectedWaveReadStateHelper.class);
+    when(helper.computeReadState(any(ParticipantId.class), any(WaveId.class)))
+        .thenReturn(SelectedWaveReadStateHelper.Result.found(1,
+            java.util.Arrays.asList("b+2"),
+            java.util.Arrays.asList("b+5", "b+8")));
+
+    SelectedWaveReadStateServlet servlet =
+        new SelectedWaveReadStateServlet(sessionManager, helper);
+    HttpServletRequest request = requestWith(VALID_WAVE_ID);
+    StringWriter body = new StringWriter();
+    HttpServletResponse response = responseWithWriter(body);
+
+    servlet.doGet(request, response);
+
+    String json = body.toString();
+    assertTrue("body missing unreadBlipIds: " + json,
+        json.contains("\"unreadBlipIds\":[\"b+2\"]"));
+    assertTrue("body missing mentionedBlipIds: " + json,
+        json.contains("\"mentionedBlipIds\":[\"b+5\",\"b+8\"]"));
+  }
+
+  /**
+   * Results built without mention data (the two-arg found overload) must still
+   * emit an empty mentionedBlipIds array so clients can parse one shape.
+   */
+  public void testReturnsEmptyMentionedBlipIdsWhenAbsent() throws Exception {
+    SessionManager sessionManager = mock(SessionManager.class);
+    when(sessionManager.getLoggedInUser(any())).thenReturn(USER);
+    SelectedWaveReadStateHelper helper = mock(SelectedWaveReadStateHelper.class);
+    when(helper.computeReadState(any(ParticipantId.class), any(WaveId.class)))
+        .thenReturn(SelectedWaveReadStateHelper.Result.found(0));
+
+    SelectedWaveReadStateServlet servlet =
+        new SelectedWaveReadStateServlet(sessionManager, helper);
+    HttpServletRequest request = requestWith(VALID_WAVE_ID);
+    StringWriter body = new StringWriter();
+    HttpServletResponse response = responseWithWriter(body);
+
+    servlet.doGet(request, response);
+
+    String json = body.toString();
+    assertTrue("body missing empty mentionedBlipIds: " + json,
+        json.contains("\"mentionedBlipIds\":[]"));
+  }
+
   public void testReturnsReadTrueWhenUnreadCountZero() throws Exception {
     SessionManager sessionManager = mock(SessionManager.class);
     when(sessionManager.getLoggedInUser(any())).thenReturn(USER);

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelperTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/SelectedWaveReadStateHelperTest.java
@@ -189,6 +189,32 @@ public final class SelectedWaveReadStateHelperTest extends TestCase {
     assertNotNull(digestedView.getWavelet(USER_UDW));
   }
 
+  /**
+   * The digester's mentioned blip ids must flow through to the read-state
+   * result untouched: the J2CL mention nav buttons rely on them to reach
+   * mentions in unloaded viewport-window regions.
+   */
+  public void testComputeReadStatePropagatesMentionedBlipIds() throws Exception {
+    WaveMap waveMap = mock(WaveMap.class);
+    WaveDigester digester = mock(WaveDigester.class);
+    SelectedWaveReadStateHelper helper =
+        new SelectedWaveReadStateHelper(DOMAIN, waveMap, digester);
+
+    when(waveMap.lookupWavelets(WAVE_ID)).thenReturn(ImmutableSet.of(ACCESSIBLE_CONV));
+    stubWaveletContainer(waveMap, ACCESSIBLE_CONV, wavelet(ACCESSIBLE_CONV, USER));
+
+    when(digester.getUnreadBlipState(eq(USER), any(WaveViewData.class)))
+        .thenReturn(
+            new WaveDigester.UnreadBlipState(
+                Arrays.asList("b+1"), Arrays.asList("b+3", "b+9")));
+
+    SelectedWaveReadStateHelper.Result result = helper.computeReadState(USER, WAVE_ID);
+
+    assertTrue(result.exists());
+    assertEquals(Arrays.asList("b+1"), result.getUnreadBlipIds());
+    assertEquals(Arrays.asList("b+3", "b+9"), result.getMentionedBlipIds());
+  }
+
   private static ObservableWaveletData wavelet(WaveletId waveletId, ParticipantId participant) {
     ObservableWaveletData wavelet = mock(ObservableWaveletData.class);
     when(wavelet.getWaveletId()).thenReturn(waveletId);

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveDigesterTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveDigesterTest.java
@@ -22,7 +22,9 @@ package org.waveprotocol.box.server.waveserver;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.waveprotocol.box.server.util.testing.TestingConstants.OTHER_USER;
 import static org.waveprotocol.box.server.util.testing.TestingConstants.PARTICIPANT;
+import static org.waveprotocol.box.server.util.testing.TestingConstants.USER;
 import static org.waveprotocol.box.server.util.testing.TestingConstants.WAVE_ID;
 
 import com.google.wave.api.SearchResult.Digest;
@@ -49,6 +51,7 @@ import org.waveprotocol.wave.model.wave.opbased.OpBasedWavelet;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -330,6 +333,67 @@ public class WaveDigesterTest extends TestCase {
     assertEquals(Collections.singletonList(liveBlip.getId()),
         unreadState.getUnreadBlipIds());
     assertEquals(1, unreadState.getUnreadCount());
+  }
+
+  /**
+   * The read-state endpoint's mentioned blip ids must list exactly the blips
+   * whose body carries a {@code mention/}-prefixed annotation naming the
+   * viewer, so "jump to next/previous mention" can reach mentions in unloaded
+   * viewport-window regions. Address matching is case-insensitive, mirroring
+   * the {@code mentions:} search filter.
+   */
+  public void testMentionedBlipIdsListBlipsMentioningTheViewer() {
+    TestingWaveletData data =
+        new TestingWaveletData(WAVE_ID, CONVERSATION_WAVELET_ID, PARTICIPANT, true);
+    ConversationBlip mentioned = data.appendBlipWithTextAndReturn("hey @" + USER);
+    Document mentionedContent = mentioned.getContent();
+    mentionedContent.setAnnotation(
+        0, mentionedContent.size(), "mention/user", USER.toUpperCase(Locale.ROOT));
+    ConversationBlip otherMention = data.appendBlipWithTextAndReturn("hey @" + OTHER_USER);
+    Document otherContent = otherMention.getContent();
+    otherContent.setAnnotation(0, otherContent.size(), "mention/user", OTHER_USER);
+    data.appendBlipWithText("no mention here");
+
+    WaveDigester.UnreadBlipState state =
+        digester.getUnreadBlipState(PARTICIPANT, data.copyViewData());
+
+    assertEquals(Collections.singletonList(mentioned.getId()), state.getMentionedBlipIds());
+  }
+
+  /**
+   * Tombstoned blips are never rendered, so a mention inside one must not be
+   * navigable — same rationale as excluding tombstones from unread state.
+   */
+  public void testTombstonedBlipIsExcludedFromMentionedBlipIds() {
+    TestingWaveletData data =
+        new TestingWaveletData(WAVE_ID, CONVERSATION_WAVELET_ID, PARTICIPANT, true);
+    ConversationBlip liveMention = data.appendBlipWithTextAndReturn("live @" + USER);
+    Document liveContent = liveMention.getContent();
+    liveContent.setAnnotation(0, liveContent.size(), "mention/user", USER);
+    ConversationBlip deletedMention = data.appendBlipWithTextAndReturn("deleted @" + USER);
+    Document deletedContent = deletedMention.getContent();
+    deletedContent.setAnnotation(0, deletedContent.size(), "mention/user", USER);
+    deletedContent.setAnnotation(
+        0, deletedContent.size(), "tombstone/deleted", "true");
+
+    WaveDigester.UnreadBlipState state =
+        digester.getUnreadBlipState(PARTICIPANT, data.copyViewData());
+
+    assertEquals(Collections.singletonList(liveMention.getId()), state.getMentionedBlipIds());
+  }
+
+  /** Without a viewer there is no "me" to match mentions against. */
+  public void testMentionedBlipIdsEmptyForNullParticipant() {
+    TestingWaveletData data =
+        new TestingWaveletData(WAVE_ID, CONVERSATION_WAVELET_ID, PARTICIPANT, true);
+    ConversationBlip mentioned = data.appendBlipWithTextAndReturn("hey @" + USER);
+    Document mentionedContent = mentioned.getContent();
+    mentionedContent.setAnnotation(0, mentionedContent.size(), "mention/user", USER);
+
+    WaveDigester.UnreadBlipState state =
+        digester.getUnreadBlipState(null, data.copyViewData());
+
+    assertTrue(state.getMentionedBlipIds().isEmpty());
   }
 
   /**

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveDigesterTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveDigesterTest.java
@@ -35,6 +35,7 @@ import org.waveprotocol.box.server.robots.operations.TestingWaveletData;
 import org.waveprotocol.box.server.robots.util.ConversationUtil;
 import org.waveprotocol.wave.model.conversation.ConversationBlip;
 import org.waveprotocol.wave.model.conversation.ObservableConversationView;
+import org.waveprotocol.wave.model.document.Document;
 import org.waveprotocol.wave.model.document.util.EmptyDocument;
 import org.waveprotocol.wave.model.id.IdGenerator;
 import org.waveprotocol.wave.model.id.WaveletId;
@@ -276,6 +277,59 @@ public class WaveDigesterTest extends TestCase {
     Map<ObservableWaveletData, OpBasedWavelet> waveletAdapters = new IdentityHashMap<>();
     int unreadCount = digester.countUnread(CROSS_DOMAIN_VIEWER, context, waveletAdapters);
     assertEquals(0, unreadCount);
+  }
+
+  /**
+   * J2CL blip deletion (F.6) writes a {@code tombstone/deleted=true}
+   * annotation across the blip body and leaves the blip in the conversation
+   * manifest. Clients never render tombstoned blips, so counting them as
+   * unread produces a phantom unread badge that can never be cleared.
+   */
+  public void testTombstonedBlipIsExcludedFromUnreadCount() {
+    TestingWaveletData data =
+        new TestingWaveletData(WAVE_ID, CONVERSATION_WAVELET_ID, PARTICIPANT, true);
+    data.appendBlipWithText("blip number 1");
+    ConversationBlip deletedBlip = data.appendBlipWithTextAndReturn("deleted blip");
+    Document deletedContent = deletedBlip.getContent();
+    deletedContent.setAnnotation(
+        0, deletedContent.size(), "tombstone/deleted", "true");
+    ObservableWaveletData observableWaveletData = data.copyWaveletData().get(0);
+    ObservableWavelet wavelet = OpBasedWavelet.createReadOnly(observableWaveletData);
+    ObservableConversationView conversation = conversationUtil.buildConversation(wavelet);
+
+    SupplementedWave supplement = mock(SupplementedWave.class);
+    when(supplement.isUnread(any(ConversationBlip.class))).thenReturn(true);
+
+    Digest digest =
+        digester.generateDigest(
+            conversation,
+            supplement,
+            observableWaveletData,
+            Collections.singletonList(observableWaveletData));
+
+    assertEquals(1, digest.getUnreadCount());
+  }
+
+  /**
+   * The read-state endpoint's unread blip ids must skip tombstoned blips for
+   * the same reason as the digest unread count: the J2CL read surface never
+   * renders them, so "jump to next unread" could never reach them.
+   */
+  public void testTombstonedBlipIsExcludedFromUnreadBlipIds() {
+    TestingWaveletData data =
+        new TestingWaveletData(WAVE_ID, CONVERSATION_WAVELET_ID, PARTICIPANT, true);
+    ConversationBlip liveBlip = data.appendBlipWithTextAndReturn("live blip");
+    ConversationBlip deletedBlip = data.appendBlipWithTextAndReturn("deleted blip");
+    Document deletedContent = deletedBlip.getContent();
+    deletedContent.setAnnotation(
+        0, deletedContent.size(), "tombstone/deleted", "true");
+
+    WaveDigester.UnreadBlipState unreadState =
+        digester.getUnreadBlipState(PARTICIPANT, data.copyViewData());
+
+    assertEquals(Collections.singletonList(liveBlip.getId()),
+        unreadState.getUnreadBlipIds());
+    assertEquals(1, unreadState.getUnreadCount());
   }
 
   /**


### PR DESCRIPTION
## Summary

In long waves, the J2CL/Lit prev/next-mention toolbar actions (`J2clSelectedWaveView.bindNavigationEvents` → `blipFocus.focusNextMatching("has-mention", ±1)`) only scanned blips already rendered in the viewport window, so mentions in unloaded placeholder regions were unreachable — and the mention emphasis on `<wavy-wave-nav-row>` never lit up because `mention-count` was never published. This is the mention analogue of the next-unread window-jump fix.

**Server**
- `WaveDigester.getUnreadBlipState` now also collects `mentionedBlipIds`: conversation blips whose body carries a `mention/`-prefixed annotation naming the signed-in user (case-insensitive address match, mirroring the `mentions:` search filter), skipping F.6 tombstoned blips.
- `SelectedWaveReadStateHelper.Result` and the `/read-state` servlet JSON expose the new list (`"mentionedBlipIds":[...]`, always present so clients parse one shape).

**Client**
- `SidecarTransportCodec`/`SidecarSelectedWaveReadState` parse the new field; `J2clSelectedWaveProjector` plumbs it through `J2clSelectedWaveModel` with the same carry-forward semantics as `unreadBlipIds` (both `project` and `reprojectReadState` paths).
- `J2clBlipFocusController.scrollToUnloadedUnread` is generalized to `scrollToUnloadedBlip(blipIds, direction)` — forward scan for "next", backward for "previous" — and the mention nav handlers fall back to it when no rendered blip matches, focusing the blip on the render pass that materializes its fragment (`pendingMentionJumpBlipId`, mirroring the unread jump).
- The view publishes `mention-count` to `<wavy-wave-nav-row>` from the server list, so the E.6/E.7 violet emphasis reflects mentions in unloaded regions too.

⚠️ **Depends on the unread window-jump fix**: this branch includes commit `fix(unread): exclude tombstoned blips from unread state; let next-unread jump reach unloaded window regions` (cherry-picked from `claude/magical-noyce-60434a`, which has no PR yet) because the mention fallback builds on its primitives (`boolean focusNextMatching`, placeholder scroll, pending-focus hook, model unreadBlipIds plumbing). If that branch lands first, this PR rebases to just the mention commit.

## Tests (TDD — each new behavior red first)

- `WaveDigesterTest`: viewer mention match incl. case-insensitivity + non-viewer exclusion, tombstone exclusion, null-participant guard (14 pass)
- `SelectedWaveReadStateHelperTest`: mentionedBlipIds propagation (6 pass)
- `SelectedWaveReadStateServletTest`: JSON contains `mentionedBlipIds`, and empty-list shape when absent (9 pass)
- `SidecarTransportCodecTest`: parses `mentionedBlipIds`, empty default (58 pass)
- `J2clSelectedWaveProjectorReadStateTest`: project/carry-forward/reproject plumbing (16 pass)
- `J2clBlipFocusControllerTest`: scrollToUnloadedBlip forward/backward scan (compile-checked; DOM cases skip on JVM like the existing unread ones)
- Full suites: `sbt --batch test` → 1504 passed; `j2cl/mvnw -P search-sidecar test` → 1200 passed

Note: `SelectedWaveReadStateHelperTest`/`SelectedWaveReadStateServletTest` were verified via `Test/runMain junit.textui.TestRunner ...` because sbt/zinc test discovery misses these classes at HEAD (pre-existing repo-wide issue — the whole `box.server.rpc` test package is invisible to `sbt test`; flagged as a separate task).

## Local verification

Staged server (`scripts/worktree-boot.sh --shared-file-store --port 9899`), registered fresh user `mentionlane848a11`, signed in:
- `GET /read-state?waveId=<welcome wave>` → 200 `{...,"unreadBlipIds":[...6 ids...],"mentionedBlipIds":[]}` (new field present; welcome wave has no mentions)
- unknown wave → 404, unauthenticated → 403 (unchanged)

Full record: `journal/local-verification/2026-07-06-branch-claude-serene-perlman-848a11.md` (worktree-local).

## Changelog

`wave/config/changelog.d/2026-07-06-mention-nav-window-jump.json` (validated + assembles: 410 entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)