### PR TITLE
fix(build): self-heal zinc Java-analysis corruption; fail CI when compiled tests vanish from test discovery

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -627,6 +627,86 @@ libraryDependencies ++= Seq(
   "io.gatling"                  % "gatling-test-framework"                    % "3.10.5" % GatlingTest
 )
 
+// =============================================================================
+// Zinc Java-analysis corruption defenses
+//
+// zinc's AnalyzingJavaCompiler snapshots the class files present in the output
+// directory before javac runs and extracts APIs ONLY from class files whose
+// paths did not exist before ("newClasses = paths -- oldClasses"). When a class
+// file already exists on disk but is not tracked by the zinc analysis (e.g. an
+// interrupted build wrote class files and died before persisting the analysis),
+// the next compile overwrites it in place, extracts NO API for it, and stamps
+// the source as clean. From then on every compile reports "No changes", the
+// class is absent from Test/definedTests, and `sbt test` silently never runs
+// it — while testOnly says "No tests to run". Verified against sbt 1.10.2 /
+// zinc 1.10.2; zinc's develop branch has the same logic.
+//
+// Two defenses:
+//  1. zincAnalysisHygiene (pre-compile): if the zinc analysis file is missing
+//     but the class directory already contains class files, wipe the class
+//     directory so the rebuild re-extracts every API.
+//  2. verifyTestDiscovery (pre-test): every concrete top-level *Test class
+//     file must appear in definedTests, otherwise fail the build with a
+//     remediation hint. Wired into <config>/test, so the CI unit-test gate
+//     (`sbt --batch test`) fails instead of silently skipping tests.
+// =============================================================================
+
+lazy val zincAnalysisHygiene = taskKey[Unit]("Wipe orphaned class files when the zinc analysis file is missing")
+lazy val verifyTestDiscovery = taskKey[Unit]("Fail when compiled *Test classes are absent from definedTests")
+
+def zincDiscoveryGuardSettings(cfg: Configuration): Seq[Setting[_]] = inConfig(cfg)(Seq(
+  zincAnalysisHygiene := {
+    val log = streams.value.log
+    val analysisFile = compileAnalysisFile.value
+    val classDir = classDirectory.value
+    val classFiles = (classDir ** "*.class").get
+    if (!analysisFile.exists && classFiles.nonEmpty) {
+      log.warn(
+        s"[zincAnalysisHygiene] ${cfg.id}: analysis file ${analysisFile} is missing but " +
+          s"${classFiles.size} class files exist under ${classDir}. Deleting them so zinc " +
+          "re-extracts every API (zinc only analyzes class files created by the current javac run).")
+      IO.delete(classDir)
+    }
+  },
+  compile := compile.dependsOn(zincAnalysisHygiene).value,
+  verifyTestDiscovery := {
+    val log = streams.value.log
+    val discovered = definedTests.value.map(_.name).toSet
+    val classDir = classDirectory.value
+    val classpath = fullClasspath.value.map(_.data.toURI.toURL).toArray
+    val compiledTestClasses = (classDir ** "*.class").get.flatMap { f =>
+      IO.relativize(classDir, f).map(_.stripSuffix(".class").replace('/', '.').replace('\\', '.'))
+    }.filter(name => name.endsWith("Test") && !name.contains("$"))
+    val undiscovered = compiledTestClasses.filterNot(discovered).sorted
+    val missing =
+      if (undiscovered.isEmpty) undiscovered
+      else {
+        // Abstract classes are legitimately not test entry points; anything that
+        // fails to load stays flagged (zinc could not have discovered it either).
+        val loader = new java.net.URLClassLoader(classpath, null)
+        try undiscovered.filter { name =>
+          try !java.lang.reflect.Modifier.isAbstract(Class.forName(name, false, loader).getModifiers)
+          catch { case _: Throwable => true }
+        } finally loader.close()
+      }
+    if (missing.nonEmpty) {
+      missing.foreach(name => log.error(s"[verifyTestDiscovery] compiled but not discovered: $name"))
+      sys.error(
+        s"[verifyTestDiscovery] ${cfg.id}: ${missing.size} compiled *Test classes are absent from " +
+          "definedTests — the zinc analysis lost their APIs (typically an interrupted earlier build). " +
+          s"Fix: delete ${classDir} plus the ${cfg.id} zinc analysis (or run `sbt clean`) and rebuild.")
+    } else {
+      log.info(s"[verifyTestDiscovery] ${cfg.id}: OK — all ${compiledTestClasses.size} compiled *Test classes are discovered (definedTests=${discovered.size}).")
+    }
+  },
+  test := test.dependsOn(verifyTestDiscovery).value
+))
+
+zincDiscoveryGuardSettings(Test)
+zincDiscoveryGuardSettings(JakartaTest)
+zincDiscoveryGuardSettings(StacktraceTest)
+zincDiscoveryGuardSettings(ThumbTest)
+
 // --- Convenience aliases (Gradle task equivalents) ---
 // testMongo: run MongoDB-specific tests from default test source set
 lazy val testMongo = taskKey[Unit]("Run MongoDB persistence tests")

--- a/wave/config/changelog.d/2026-07-06-zinc-test-discovery-guard.json
+++ b/wave/config/changelog.d/2026-07-06-zinc-test-discovery-guard.json
@@ -1,0 +1,16 @@
+{
+  "releaseId": "2026-07-06-zinc-test-discovery-guard",
+  "version": "unreleased",
+  "date": "2026-07-06",
+  "title": "Internal: unit-test gate can no longer silently skip compiled tests",
+  "summary": "Fixed a build-infrastructure gap where zinc (sbt's incremental compiler) could permanently lose track of compiled JUnit test classes after an interrupted build: the classes still compiled, but Test/definedTests omitted them, so `sbt test` and CI silently never ran them (at one point ~200 server test classes, including the entire box.server.rpc package). The build now self-heals the corrupted state and fails loudly if any compiled *Test class is missing from test discovery.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Build (internal): zincAnalysisHygiene wipes stale class files when the zinc analysis file is missing, so an interrupted build can no longer leave the incremental compiler blind to recompiled Java test classes (zinc only extracts APIs from class files created by the current javac run)",
+        "CI (internal): verifyTestDiscovery runs before test/jakartaTest/stacktraceTest/thumbTest and fails the build when a compiled, concrete top-level *Test class is absent from definedTests, with remediation instructions — the unit-test gate can no longer pass while silently skipping test classes"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

\`sbt --batch test\` (the CI unit-test gate) could silently skip large sets of server test classes: \`show Test/definedTests\` listed only ~206 classes instead of 413, missing the entire \`org.waveprotocol.box.server.rpc\` package (e.g. \`SelectedWaveReadStateServletTest\`), \`box.server.frontend\`, \`MarkBlipReadHelperTest\`, \`SelectedWaveReadStateHelperTest\`, and more. The classes were in \`Test/unmanagedSources\`, compiled fine into \`test-classes\` (javap-verified), and passed when run via \`Test/runMain junit.textui.TestRunner\` — but \`testOnly\` said "No tests to run".

## Root cause

zinc's \`AnalyzingJavaCompiler\` snapshots the class-file paths present in the output directory **before** javac runs and extracts APIs only from paths that did not exist before (\`newClasses = classes.paths -- oldClasses\`). When a class file already exists on disk but is untracked by the zinc analysis — typically after an **interrupted build** that wrote class files but died before persisting the analysis — the next compile overwrites the file in place, extracts **no API**, and still stamps the source clean. Every later compile then reports "No changes", so the class stays permanently absent from \`definedTests\` while its class file looks healthy. sbt 1.10.2 / zinc 1.10.2; zinc's \`develop\` branch has the same logic, so an sbt upgrade does not help.

**Deterministic reproduction** (on a healthy checkout): delete only \`target/scala-3.3.4/test-zinc/inc_compile_3.zip\`, keep \`test-classes\`, run \`sbt "show Test/definedTests"\` → compiles all 521 sources "successfully" and discovers **0** tests.

**Forensics on the affected checkout**: its analysis had stamps for 521 sources but relations/APIs for only 293 — the 228 lost sources were exactly the server-side tests recompiled in a run whose class files pre-existed; zinc's debug log for the following compile shows \`initialChanges = ... Set()\` / "No changes". Ruled out: junit-interface fingerprints (fine), final classes (tested), source filters (files present in \`unmanagedSources\`).

## Fix (two defenses in build.sbt)

1. **\`zincAnalysisHygiene\`** (runs before \`compile\` in each test config): if the zinc analysis file is missing but the class directory contains class files, wipe the class directory so the rebuild re-extracts every API. This self-heals the interrupted-build genesis case.
2. **\`verifyTestDiscovery\`** (runs before \`test\` in \`Test\`, \`JakartaTest\`, \`StacktraceTest\`, \`ThumbTest\`): fails the build when any concrete top-level \`*Test\` class file is absent from \`definedTests\` (abstract classes exempt), with remediation instructions. Because it is wired into the \`test\` task, the existing CI gate \`sbt --batch test\` in \`.github/workflows/build.yml\` enforces it with no workflow change — the gap cannot silently reopen.

## Verification (local)

- Corrupted state (analysis without APIs): \`sbt --batch Test/verifyTestDiscovery\` → **fails**, lists all 413 missing classes + fix hint ✅
- Genesis state (analysis deleted, stale classes present): hygiene wipes 1101 class files, full recompile, guard passes 413/413 ✅
- Healthy full gate: \`sbt --batch test\` → \`verifyTestDiscovery Test: OK — all 413 compiled *Test classes are discovered\`; **Passed: Total 2958, Failed 0, Errors 0** (previously-invisible \`SelectedWaveReadStateServletTest\` / \`MarkBlipReadHelperTest\` methods observed running) ✅
- Other configs: \`JakartaTest\` 36/36 (definedTests=55), \`StacktraceTest\` 1/1, \`ThumbTest\` 1/1 ✅
- \`scripts/assemble-changelog.py\` + \`scripts/validate-changelog.py\` pass ✅

Note: other local checkouts that already carry the corrupted analysis will have \`verifyTestDiscovery\` fail once with clear instructions (\`sbt clean\` or delete \`test-classes\` + the test zinc analysis); that is the guard working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)