### PR TITLE
fix(unread): exclude empty (non-renderable) blips from unread state

### DIFF
--- a/wave/config/changelog.d/2026-07-06-empty-blip-phantom-unread.json
+++ b/wave/config/changelog.d/2026-07-06-empty-blip-phantom-unread.json
@@ -1,0 +1,15 @@
+{
+  "releaseId": "2026-07-06-empty-blip-phantom-unread",
+  "version": "unreleased",
+  "date": "2026-07-06",
+  "title": "Fix a stuck \"1 unread\" badge caused by empty messages",
+  "summary": "A wave could keep showing an unread badge (for example \"1 unread\") even though every message in it was already read and none looked unread. The cause was an empty message (one with no text — an empty draft, or a body that only holds an image/attachment with no caption): the server counted it as unread, but the new UI never draws empty messages, so there was nothing to open or scroll to and the badge could never be cleared. Empty messages no longer count toward unread state.",
+  "sections": [
+    {
+      "type": "fix",
+      "items": [
+        "Unread counts: the search digest unread badge and the read-state endpoint's unread-message list now skip messages with no text characters. The new UI's read surface only renders a message when it has text content (an image/attachment- or draft-only body projects to empty text and is dropped), so counting such a message as unread produced a phantom badge that could never be cleared and \"jump to next unread\" had nothing to focus — the same failure mode previously fixed for deleted (tombstoned) messages."
+      ]
+    }
+  ]
+}

--- a/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveDigester.java
+++ b/wave/src/main/java/org/waveprotocol/box/server/waveserver/WaveDigester.java
@@ -37,6 +37,7 @@ import org.waveprotocol.wave.model.conversation.TitleHelper;
 import org.waveprotocol.wave.model.conversation.WaveletBasedConversation;
 import org.waveprotocol.wave.model.document.Document;
 import org.waveprotocol.wave.model.document.RangedAnnotation;
+import org.waveprotocol.wave.model.document.util.DocHelper;
 import org.waveprotocol.wave.model.id.IdUtil;
 import org.waveprotocol.wave.model.id.ModernIdSerialiser;
 import org.waveprotocol.wave.model.id.WaveId;
@@ -194,6 +195,15 @@ public class WaveDigester {
     return 0;
   }
 
+  // Fallback counting path, used only when no conversation-backed supplement is
+  // available (context.supplement == null — malformed or non-conversational
+  // waves). Unlike the supplement-based countUnread/collectUnreadBlipIds, this
+  // raw document-id scan does NOT exclude tombstoned or empty (non-renderable)
+  // blips, so it can still over-count phantom unread state. That is
+  // intentionally deferred: the J2CL inbox badge, read-state endpoint, and
+  // jump-to-next-unread all flow through the supplement-based path, and only
+  // conversation-less waves reach here. See contributesToUnread /
+  // hasRenderableText for the rationale.
   private int countUnreadFromReadState(PrimitiveSupplement readState,
       Iterable<? extends ObservableWaveletData> conversationalWavelets) {
     int unreadCount = 0;
@@ -368,7 +378,7 @@ public class WaveDigester {
         continue;
       }
       for (ConversationBlip blip : BlipIterators.breadthFirst(conversation)) {
-        if (supplement.isUnread(blip) && !isTombstoned(blip)) {
+        if (contributesToUnread(supplement, blip)) {
           unreadBlipIds.add(blip.getId());
         }
       }
@@ -497,12 +507,52 @@ public class WaveDigester {
         continue;
       }
       for (ConversationBlip blip : BlipIterators.breadthFirst(conversation)) {
-        if (supplement.isUnread(blip) && !isTombstoned(blip)) {
+        if (contributesToUnread(supplement, blip)) {
           unreadCount++;
         }
       }
     }
     return unreadCount;
+  }
+
+  /**
+   * A blip contributes to unread state only when it is genuinely unread for
+   * the viewer AND a client would actually render it — otherwise the viewer
+   * can never mark it read and the unread badge is stuck forever. Two kinds of
+   * blip are counted by the raw supplement but never rendered:
+   * <ul>
+   *   <li>tombstoned (F.6-deleted) blips — see {@link #isTombstoned}; and</li>
+   *   <li>blips with no text characters (an empty body of just
+   *       {@code <body><line/></body>}, or an element-only body such as an
+   *       image/attachment placeholder). The J2CL read surface derives each
+   *       renderable blip from its extracted {@code textContent} and skips any
+   *       blip whose {@code textContent} is empty
+   *       ({@code J2clSelectedWaveProjector.extractDocumentReadBlips}), so
+   *       such a blip is never shown and never marked read.</li>
+   * </ul>
+   */
+  private static boolean contributesToUnread(SupplementedWave supplement, ConversationBlip blip) {
+    return supplement.isUnread(blip) && !isTombstoned(blip) && hasRenderableText(blip);
+  }
+
+  /**
+   * True when the blip body contains at least one text character. This mirrors
+   * the J2CL client's renderability test: its sidecar projection builds a
+   * blip's {@code textContent} from character items only (element starts, e.g.
+   * {@code <line/>} or {@code <img/>}, contribute no text), and
+   * {@code J2clSelectedWaveProjector.extractDocumentReadBlips} drops any
+   * blip whose {@code textContent} is empty. Counting such a blip as unread
+   * produces a phantom unread badge that can never be cleared. Whitespace is
+   * intentionally preserved (not trimmed) so this predicate matches the
+   * client's condition exactly and does not under-count a rendered blip.
+   */
+  @VisibleForTesting
+  static boolean hasRenderableText(ConversationBlip blip) {
+    Document content = blip.getContent();
+    if (content == null || content.size() == 0) {
+      return false;
+    }
+    return !DocHelper.getText(content, 0, content.size()).isEmpty();
   }
 
   /**

--- a/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveDigesterTest.java
+++ b/wave/src/test/java/org/waveprotocol/box/server/waveserver/WaveDigesterTest.java
@@ -333,6 +333,110 @@ public class WaveDigesterTest extends TestCase {
   }
 
   /**
+   * A blip with an empty body (no text characters — just the implicit
+   * {@code <body><line/></body>}) produces empty {@code textContent} in the
+   * J2CL sidecar projection, so
+   * {@code J2clSelectedWaveProjector.extractDocumentReadBlips} skips it and
+   * the read surface never renders it. Counting such a blip as unread yields a
+   * phantom unread badge that can never be cleared — the same failure mode as
+   * a tombstoned blip. The digest unread count must exclude empty blips.
+   */
+  public void testEmptyBlipIsExcludedFromUnreadCount() {
+    TestingWaveletData data =
+        new TestingWaveletData(WAVE_ID, CONVERSATION_WAVELET_ID, PARTICIPANT, true);
+    data.appendBlipWithText("blip number 1");
+    // Empty blip: appended with no text, so its body is just <body><line/></body>.
+    data.appendBlipWithText("");
+    ObservableWaveletData observableWaveletData = data.copyWaveletData().get(0);
+    ObservableWavelet wavelet = OpBasedWavelet.createReadOnly(observableWaveletData);
+    ObservableConversationView conversation = conversationUtil.buildConversation(wavelet);
+
+    SupplementedWave supplement = mock(SupplementedWave.class);
+    when(supplement.isUnread(any(ConversationBlip.class))).thenReturn(true);
+
+    Digest digest =
+        digester.generateDigest(
+            conversation,
+            supplement,
+            observableWaveletData,
+            Collections.singletonList(observableWaveletData));
+
+    assertEquals(1, digest.getUnreadCount());
+  }
+
+  /**
+   * The read-state endpoint's unread blip ids must skip empty blips for the
+   * same reason as the digest unread count: the J2CL read surface never
+   * renders an empty-body blip, so "jump to next unread" could never reach it
+   * and the badge could never be cleared.
+   */
+  public void testEmptyBlipIsExcludedFromUnreadBlipIds() {
+    TestingWaveletData data =
+        new TestingWaveletData(WAVE_ID, CONVERSATION_WAVELET_ID, PARTICIPANT, true);
+    ConversationBlip liveBlip = data.appendBlipWithTextAndReturn("live blip");
+    // Empty blip: no text characters, so its body is just <body><line/></body>.
+    data.appendBlipWithText("");
+
+    WaveDigester.UnreadBlipState unreadState =
+        digester.getUnreadBlipState(PARTICIPANT, data.copyViewData());
+
+    assertEquals(Collections.singletonList(liveBlip.getId()),
+        unreadState.getUnreadBlipIds());
+    assertEquals(1, unreadState.getUnreadCount());
+  }
+
+  /**
+   * A blip whose body holds only an element (e.g. an image/attachment) with no
+   * caption text also projects to empty {@code textContent} on the J2CL read
+   * surface — element starts contribute no characters — so it is never
+   * rendered and must not count as unread.
+   */
+  public void testImageOnlyBlipWithoutCaptionIsExcludedFromUnreadCount() {
+    TestingWaveletData data =
+        new TestingWaveletData(WAVE_ID, CONVERSATION_WAVELET_ID, PARTICIPANT, true);
+    data.appendBlipWithText("caption blip");
+    // Element-only body: an attachment with no caption text -> empty textContent.
+    data.appendBlipWithXml("<image attachment=\"att+1\"/>");
+    ObservableWaveletData observableWaveletData = data.copyWaveletData().get(0);
+    ObservableWavelet wavelet = OpBasedWavelet.createReadOnly(observableWaveletData);
+    ObservableConversationView conversation = conversationUtil.buildConversation(wavelet);
+
+    SupplementedWave supplement = mock(SupplementedWave.class);
+    when(supplement.isUnread(any(ConversationBlip.class))).thenReturn(true);
+
+    Digest digest =
+        digester.generateDigest(
+            conversation,
+            supplement,
+            observableWaveletData,
+            Collections.singletonList(observableWaveletData));
+
+    assertEquals(1, digest.getUnreadCount());
+  }
+
+  /**
+   * Direct coverage of {@link WaveDigester#hasRenderableText} — in particular
+   * the whitespace case. A blip whose only text is whitespace still projects to
+   * a non-empty {@code textContent} on the client and IS rendered, so it must
+   * count as unread. This guards against a future refactor adding a
+   * {@code trim()} that would silently under-count such blips.
+   */
+  public void testHasRenderableTextMirrorsClientRenderability() {
+    TestingWaveletData data =
+        new TestingWaveletData(WAVE_ID, CONVERSATION_WAVELET_ID, PARTICIPANT, true);
+    ConversationBlip textBlip = data.appendBlipWithTextAndReturn("hello");
+    ConversationBlip emptyBlip = data.appendBlipWithTextAndReturn("");
+    ConversationBlip whitespaceBlip = data.appendBlipWithTextAndReturn("   ");
+
+    assertTrue("text blip has renderable content",
+        WaveDigester.hasRenderableText(textBlip));
+    assertFalse("empty-body blip has no renderable content",
+        WaveDigester.hasRenderableText(emptyBlip));
+    assertTrue("whitespace-only blip is rendered by the client, so it must count",
+        WaveDigester.hasRenderableText(whitespaceBlip));
+  }
+
+  /**
    * Non-blip documents must not contribute to unread counts.
    */
   public void testCountUnreadViaContextPathIgnoresNonBlipDocuments() {


### PR DESCRIPTION
## Problem

A wave could show a permanent **"1 unread"** badge in the inbox even though every visible message was read and none appeared unread — and the badge could never be cleared. (Reported on `supawave.ai/w+S7EXc3lMwcI`.)

## Root cause

The inbox badge comes from the server's `WaveDigester`, which counts a blip as unread when `supplement.isUnread(blip) && !isTombstoned(blip)`. But the J2CL read surface ([`J2clSelectedWaveProjector.extractDocumentReadBlips`](../blob/main/j2cl/src/main/java/org/waveprotocol/box/j2cl/search/J2clSelectedWaveProjector.java)) **skips any blip whose extracted `textContent` is empty**:

- an empty-body blip (`<body><line/></body>`, e.g. an empty draft), or
- an element-only body such as an image/attachment with no caption.

`SidecarTransportCodec.extractDocument` builds `textContent` from character items only (element starts like `<line/>`/`<img/>` add none; the leading `<line/>` is swallowed). So such a blip is never rendered → never markable → the unread count is stuck forever.

This is the **same failure mode PR #1322 fixed for tombstoned blips** — empty blips are a second, previously-unhandled case.

## Fix

Both server counting paths — `countUnread` (digest badge) and `collectUnreadBlipIds` (read-state endpoint / "jump to next unread") — now go through a shared `contributesToUnread()` predicate that additionally requires `hasRenderableText(blip)`: the blip has ≥1 text character (via `DocHelper.getText`, **whitespace preserved** so it matches the client's `textContent.isEmpty()` condition exactly and never under-counts a rendered blip).

## Tests

Added to `WaveDigesterTest` (all **15** pass):
- `testEmptyBlipIsExcludedFromUnreadCount` / `...FromUnreadBlipIds` — empty-body blip excluded from the digest count and the read-state blip-id list.
- `testImageOnlyBlipWithoutCaptionIsExcludedFromUnreadCount` — element-only (attachment, no caption) body excluded.
- `testHasRenderableTextMirrorsClientRenderability` — direct predicate coverage, incl. whitespace-only ⇒ counted (guards against a future `trim()`).

## Scope / notes

- Server-only change; mirrors the `isTombstoned` pattern. No client changes.
- `countUnreadFromReadState` (the supplement-null fallback for conversation-less waves) is intentionally left as-is and now carries a comment explaining why — same deferral as the tombstone fix.
- Reviewed via two **Grok Build** rounds (approved: "Good to merge").

🤖 Generated with [Claude Code](https://claude.com/claude-code)